### PR TITLE
feat(auth): 포트원 KG이니시스 본인인증 도입

### DIFF
--- a/functions/.env.example
+++ b/functions/.env.example
@@ -11,6 +11,8 @@ WEB_API_KEY=your_firebase_api_key_here
 # ============================================================================
 # Optional feature-specific secrets
 # ============================================================================
+# PORTONE_API_SECRET=your_portone_api_secret_here
+
 # APPLE_PRIVATE_KEY=your_apple_private_key_here
 # APPLE_KEY_ID=your_apple_key_id_here
 # APPLE_TEAM_ID=your_apple_team_id_here

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "functions",
       "dependencies": {
+        "@portone/server-sdk": "^0.19.0",
         "@sentry/integrations": "^7.114.0",
         "@sentry/node": "^10.26.0",
         "cors": "^2.8.5",
@@ -2857,6 +2858,12 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@portone/server-sdk": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@portone/server-sdk/-/server-sdk-0.19.0.tgz",
+      "integrity": "sha512-JIbD9HEEqaYuuW0zKU/sapqH1HQBf/Len+8ZPnMRb7E7tHnqRGrKPLS+fom34xUTiF3ZVKTrDjHeQHQ2YZc2og==",
+      "license": "(Apache-2.0 OR MIT)"
     },
     "node_modules/@prisma/instrumentation": {
       "version": "7.2.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,6 +17,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
+    "@portone/server-sdk": "^0.19.0",
     "@sentry/integrations": "^7.114.0",
     "@sentry/node": "^10.26.0",
     "cors": "^2.8.5",

--- a/functions/src/api/auth.ts
+++ b/functions/src/api/auth.ts
@@ -2,4 +2,6 @@ export { checkEmailExists } from "../auth/checkEmailExists";
 export { checkNicknameExists } from "../auth/checkNicknameExists";
 export { checkPhoneExists } from "../auth/checkPhoneExists";
 export { revokeAppleToken } from "../auth/revokeAppleToken";
+export { verifyPortOneIdentity } from "../auth/verifyPortOneIdentity";
+export { verifyAndSavePortOneProfile } from "../auth/verifyAndSavePortOneProfile";
 export { verifyAndSaveProfile } from "../auth/verifyAndSaveProfile";

--- a/functions/src/auth/verifyAndSavePortOneProfile.ts
+++ b/functions/src/auth/verifyAndSavePortOneProfile.ts
@@ -1,0 +1,474 @@
+import { createHmac } from 'node:crypto';
+import { PortOneClient } from '@portone/server-sdk';
+import { onCall } from 'firebase-functions/v2/https';
+import { logger } from 'firebase-functions';
+import * as admin from 'firebase-admin';
+import { ValidationError, ERROR_CODES } from '../errors/AppError';
+import { handleFunctionError } from '../errors/errorHandler';
+import { requireAuth, requireMaxLength, requireString } from '../errors/validators';
+import { withCallableGuard } from '../middleware/callableGuard';
+import { isValidKoreanPhone, maskPhone, toE164 } from '../utils/phone';
+import { hasXSSPattern, isValidEmail } from '../utils/security';
+
+const TERMS_VERSION = '1.0.0';
+const MIN_SIGNUP_AGE = 14;
+
+interface VerifyAndSavePortOneProfileData {
+  identityVerificationId: string;
+  nickname?: string;
+  region?: string;
+  experienceYears?: number;
+  career?: string;
+  note?: string;
+  termsAgreed: boolean;
+  privacyAgreed: boolean;
+  marketingAgreed: boolean;
+  email?: string;
+  mode: 'signup' | 'social';
+}
+
+function validateString(
+  value: unknown,
+  field: string,
+  opts: { min?: number; max?: number; pattern?: RegExp }
+): string {
+  const { min = 1, max = 500, pattern } = opts;
+
+  if (value === undefined || value === null || value === '') {
+    throw new ValidationError(ERROR_CODES.VALIDATION_REQUIRED, {
+      userMessage: `${field}을(를) 입력해주세요.`,
+    });
+  }
+
+  if (typeof value !== 'string') {
+    throw new ValidationError(ERROR_CODES.VALIDATION_FORMAT, {
+      userMessage: `${field} 형식이 올바르지 않습니다.`,
+    });
+  }
+
+  const trimmed = value.trim();
+
+  if (trimmed.length < min) {
+    throw new ValidationError(ERROR_CODES.VALIDATION_MIN_LENGTH, {
+      userMessage: `${field}은(는) 최소 ${min}자 이상이어야 합니다.`,
+    });
+  }
+
+  if (trimmed.length > max) {
+    throw new ValidationError(ERROR_CODES.VALIDATION_MAX_LENGTH, {
+      userMessage: `${field}은(는) ${max}자를 초과할 수 없습니다.`,
+    });
+  }
+
+  if (hasXSSPattern(trimmed)) {
+    throw new ValidationError(ERROR_CODES.VALIDATION_FORMAT, {
+      userMessage: '사용할 수 없는 문자가 포함되어 있습니다.',
+    });
+  }
+
+  if (pattern && !pattern.test(trimmed)) {
+    throw new ValidationError(ERROR_CODES.VALIDATION_FORMAT, {
+      userMessage: `${field} 형식이 올바르지 않습니다.`,
+    });
+  }
+
+  return trimmed;
+}
+
+function validateOptionalString(
+  value: unknown,
+  field: string,
+  opts: { max?: number }
+): string | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  return validateString(value, field, { min: 1, ...opts });
+}
+
+function normalizeBirthDate(value?: string): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.replace(/-/g, '');
+  return /^\d{8}$/.test(normalized) ? normalized : null;
+}
+
+function normalizeGender(value?: string): 'male' | 'female' | undefined {
+  switch (value) {
+    case 'MALE':
+      return 'male';
+    case 'FEMALE':
+      return 'female';
+    default:
+      return undefined;
+  }
+}
+
+function createDeterministicHash(value: string, secret: string): string {
+  return createHmac('sha256', secret).update(value).digest('hex');
+}
+
+function getPortOneSecret(): string {
+  const secret = process.env.PORTONE_API_SECRET?.trim();
+
+  if (!secret) {
+    logger.error('verifyAndSavePortOneProfile: PORTONE_API_SECRET missing');
+    throw new Error('PORTONE_API_SECRET is not configured');
+  }
+
+  return secret;
+}
+
+function validateAge(birthDate: string): void {
+  const year = parseInt(birthDate.substring(0, 4), 10);
+  const month = parseInt(birthDate.substring(4, 6), 10);
+  const day = parseInt(birthDate.substring(6, 8), 10);
+  const today = new Date();
+  let age = today.getFullYear() - year;
+  const monthDiff = today.getMonth() + 1 - month;
+
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < day)) {
+    age--;
+  }
+
+  if (age < MIN_SIGNUP_AGE) {
+    throw new ValidationError(ERROR_CODES.VALIDATION_FORMAT, {
+      userMessage: `만 ${MIN_SIGNUP_AGE}세 이상만 가입할 수 있습니다.`,
+    });
+  }
+}
+
+export const verifyAndSavePortOneProfile = onCall(
+  { region: 'asia-northeast3' },
+  (request) =>
+    withCallableGuard(
+      request,
+      {
+        operation: 'verifyAndSavePortOneProfile',
+        rateLimit: {
+          maxRequests: 3,
+          authenticatedMaxRequests: 5,
+          keyPrefix: 'ratelimit:verify-portone-profile',
+        },
+        requireRecaptcha: false,
+      },
+      async (request) => {
+        let authPhoneSet = false;
+
+        try {
+          const uid = requireAuth(request);
+          const data = request.data as VerifyAndSavePortOneProfileData;
+          const identityVerificationId = requireString(
+            data.identityVerificationId,
+            '본인인증 ID'
+          );
+          requireMaxLength(identityVerificationId, 200, '본인인증 ID');
+
+          if (data.mode !== 'signup' && data.mode !== 'social') {
+            throw new ValidationError(ERROR_CODES.VALIDATION_FORMAT, {
+              userMessage: '잘못된 요청입니다.',
+            });
+          }
+
+          if (!data.termsAgreed || !data.privacyAgreed) {
+            throw new ValidationError(ERROR_CODES.VALIDATION_SCHEMA, {
+              userMessage: '필수 약관에 동의해야 합니다.',
+            });
+          }
+
+          const nickname = data.nickname
+            ? validateString(data.nickname, '닉네임', { min: 2, max: 15 })
+            : undefined;
+          const region = validateOptionalString(data.region, '지역', { max: 50 });
+          const career = validateOptionalString(data.career, '경력', { max: 500 });
+          const note = validateOptionalString(data.note, '기타사항', { max: 300 });
+          const email = validateOptionalString(data.email, '이메일', { max: 100 });
+          const hasNickname = Boolean(nickname);
+
+          if (email && !isValidEmail(email)) {
+            throw new ValidationError(ERROR_CODES.VALIDATION_FORMAT, {
+              userMessage: '올바른 이메일 형식이 아닙니다.',
+            });
+          }
+
+          let experienceYears: number | undefined;
+          if (data.experienceYears != null) {
+            if (
+              typeof data.experienceYears !== 'number' ||
+              data.experienceYears < 0 ||
+              data.experienceYears > 50 ||
+              !Number.isInteger(data.experienceYears)
+            ) {
+              throw new ValidationError(ERROR_CODES.VALIDATION_FORMAT, {
+                userMessage: '경력은 0~50 사이의 정수여야 합니다.',
+              });
+            }
+
+            experienceYears = data.experienceYears;
+          }
+
+          const portOneSecret = getPortOneSecret();
+          const client = PortOneClient({ secret: portOneSecret });
+          const identityVerification =
+            await client.identityVerification.getIdentityVerification({
+              identityVerificationId,
+            });
+
+          if (identityVerification.status !== 'VERIFIED') {
+            throw new ValidationError(ERROR_CODES.VALIDATION_FORMAT, {
+              userMessage: '포트원 본인인증이 아직 완료되지 않았습니다.',
+            });
+          }
+
+          const verifiedCustomer = identityVerification.verifiedCustomer;
+          const name = validateString(verifiedCustomer.name, '이름', {
+            min: 2,
+            max: 20,
+            pattern: /^[가-힣a-zA-Z\s]+$/,
+          });
+          const birthDate = normalizeBirthDate(verifiedCustomer.birthDate);
+          if (!birthDate) {
+            throw new ValidationError(ERROR_CODES.VALIDATION_FORMAT, {
+              userMessage: '본인인증 생년월일 정보를 확인할 수 없습니다.',
+            });
+          }
+          validateAge(birthDate);
+
+          const gender = normalizeGender(verifiedCustomer.gender);
+          if (!gender) {
+            throw new ValidationError(ERROR_CODES.VALIDATION_FORMAT, {
+              userMessage: '본인인증 성별 정보를 확인할 수 없습니다.',
+            });
+          }
+
+          const normalizedPhoneNumber =
+            typeof verifiedCustomer.phoneNumber === 'string' &&
+            isValidKoreanPhone(verifiedCustomer.phoneNumber)
+              ? toE164(verifiedCustomer.phoneNumber)
+              : undefined;
+
+          if (!normalizedPhoneNumber) {
+            throw new ValidationError(ERROR_CODES.VALIDATION_FORMAT, {
+              userMessage:
+                '본인인증 결과에 휴대폰 번호가 없습니다. 이니시스 연동 옵션을 확인해주세요.',
+            });
+          }
+
+          const ciHash =
+            typeof verifiedCustomer.ci === 'string' && verifiedCustomer.ci.length > 0
+              ? createDeterministicHash(verifiedCustomer.ci, portOneSecret)
+              : undefined;
+
+          try {
+            await admin.auth().updateUser(uid, {
+              phoneNumber: normalizedPhoneNumber,
+            });
+            authPhoneSet = true;
+          } catch (updateError) {
+            const errorCode = (updateError as { code?: string })?.code;
+            if (errorCode === 'auth/phone-number-already-exists') {
+              throw new ValidationError(ERROR_CODES.VALIDATION_FORMAT, {
+                userMessage: '이미 다른 계정에 등록된 휴대폰 번호입니다.',
+              });
+            }
+            throw updateError;
+          }
+
+          const db = admin.firestore();
+          const userDocRef = db.collection('users').doc(uid);
+          const consentRef = userDocRef.collection('consents').doc('current');
+          const consentHistoryRef = userDocRef.collection('consents').doc();
+          const now = admin.firestore.FieldValue.serverTimestamp();
+          const role = 'staff' as const;
+
+          const identityData: Record<string, unknown> = {
+            provider: 'portone',
+            channel: 'inicis_unified',
+            identityVerificationId,
+            verifiedAt: identityVerification.verifiedAt,
+            name,
+            birthDate,
+            gender,
+            phoneNumber: normalizedPhoneNumber,
+            isForeigner: verifiedCustomer.isForeigner ?? false,
+          };
+
+          if (ciHash) {
+            identityData.ciHash = ciHash;
+          }
+
+          const profileData: Record<string, unknown> = {
+            uid,
+            name,
+            birthDate,
+            gender,
+            phone: normalizedPhoneNumber,
+            role,
+            status: 'active' as const,
+            phoneVerified: true,
+            identityVerified: true,
+            identityProvider: 'portone_inicis',
+            identity: identityData,
+            isActive: true,
+            profileCompleted: hasNickname,
+            updatedAt: now,
+          };
+
+          if (nickname) profileData.nickname = nickname;
+          if (email) profileData.email = email;
+          if (region) profileData.region = region;
+          if (experienceYears !== undefined) profileData.experienceYears = experienceYears;
+          if (career) profileData.career = career;
+          if (note) profileData.note = note;
+
+          const consentData: Record<string, unknown> = {
+            version: TERMS_VERSION,
+            userId: uid,
+            termsOfService: {
+              agreed: true,
+              version: TERMS_VERSION,
+              agreedAt: now,
+            },
+            privacyPolicy: {
+              agreed: true,
+              version: TERMS_VERSION,
+              agreedAt: now,
+            },
+            marketing: data.marketingAgreed
+              ? { agreed: true, agreedAt: now }
+              : { agreed: false, declinedAt: now },
+            updatedAt: now,
+          };
+
+          try {
+            await db.runTransaction(async (transaction) => {
+              const readPromises: [
+                Promise<FirebaseFirestore.DocumentSnapshot>,
+                Promise<FirebaseFirestore.QuerySnapshot>,
+                ...Promise<FirebaseFirestore.QuerySnapshot>[],
+              ] = [
+                transaction.get(userDocRef),
+                transaction.get(
+                  db.collection('users').where('phone', '==', normalizedPhoneNumber).limit(1)
+                ),
+              ];
+
+              if (hasNickname && nickname) {
+                readPromises.push(
+                  transaction.get(db.collection('users').where('nickname', '==', nickname).limit(1))
+                );
+              }
+
+              if (ciHash) {
+                readPromises.push(
+                  transaction.get(db.collection('users').where('identity.ciHash', '==', ciHash).limit(1))
+                );
+              }
+
+              const [freshDoc, phoneSnap, ...rest] = await Promise.all(readPromises);
+              const nicknameSnap = hasNickname ? rest.shift() ?? null : null;
+              const ciSnap = ciHash ? rest.shift() ?? null : null;
+
+              if (!phoneSnap.empty) {
+                const existingUser = phoneSnap.docs[0];
+                if (existingUser.id !== uid) {
+                  throw new ValidationError(ERROR_CODES.VALIDATION_FORMAT, {
+                    userMessage: '이미 등록된 휴대폰 번호입니다.',
+                  });
+                }
+              }
+
+              if (nicknameSnap && !nicknameSnap.empty) {
+                const nicknameOwner = nicknameSnap.docs[0];
+                if (nicknameOwner.id !== uid) {
+                  throw new ValidationError(ERROR_CODES.VALIDATION_FORMAT, {
+                    userMessage: '이미 사용 중인 닉네임입니다. 다른 닉네임을 입력해주세요.',
+                  });
+                }
+              }
+
+              if (ciSnap && !ciSnap.empty) {
+                const identityOwner = ciSnap.docs[0];
+                if (identityOwner.id !== uid) {
+                  throw new ValidationError(ERROR_CODES.VALIDATION_FORMAT, {
+                    userMessage: '이미 가입된 본인인증 정보입니다.',
+                  });
+                }
+              }
+
+              if (!freshDoc.exists) {
+                profileData.createdAt = now;
+              }
+
+              transaction.set(userDocRef, profileData, { merge: true });
+              transaction.set(consentRef, consentData, { merge: true });
+              transaction.set(consentHistoryRef, {
+                ...consentData,
+                createdAt: now,
+              });
+            });
+          } catch (transactionError) {
+            if (authPhoneSet) {
+              try {
+                await admin.auth().updateUser(uid, { phoneNumber: null });
+              } catch (rollbackError) {
+                logger.error(
+                  'verifyAndSavePortOneProfile: failed to rollback auth phone after transaction error',
+                  {
+                    uid,
+                    phone: maskPhone(normalizedPhoneNumber),
+                    error: rollbackError,
+                  }
+                );
+              }
+            }
+
+            throw transactionError;
+          }
+
+          try {
+            await admin.auth().updateUser(uid, { displayName: name });
+          } catch (displayNameError) {
+            logger.warn('verifyAndSavePortOneProfile: displayName update failed', {
+              uid,
+              error: displayNameError,
+            });
+          }
+
+          try {
+            await admin.auth().setCustomUserClaims(uid, { role });
+          } catch (claimsError) {
+            logger.warn('verifyAndSavePortOneProfile: claims update failed', {
+              uid,
+              error: claimsError,
+            });
+          }
+
+          logger.info('verifyAndSavePortOneProfile: success', {
+            uid,
+            identityVerificationId,
+            phone: maskPhone(normalizedPhoneNumber),
+            hasCiHash: Boolean(ciHash),
+          });
+
+          return {
+            success: true,
+            uid,
+          };
+        } catch (error) {
+          throw handleFunctionError(error, {
+            operation: 'verifyAndSavePortOneProfile',
+            context: {
+              userId: request.auth?.uid,
+              identityVerificationId: (
+                request.data as VerifyAndSavePortOneProfileData | undefined
+              )?.identityVerificationId,
+            },
+          });
+        }
+      }
+    ),
+);

--- a/functions/src/auth/verifyPortOneIdentity.ts
+++ b/functions/src/auth/verifyPortOneIdentity.ts
@@ -1,0 +1,185 @@
+import { createHmac } from 'node:crypto';
+import { PortOneClient } from '@portone/server-sdk';
+import { onCall } from 'firebase-functions/v2/https';
+import { logger } from 'firebase-functions';
+import * as admin from 'firebase-admin';
+import { ValidationError, ERROR_CODES } from '../errors/AppError';
+import { handleFunctionError } from '../errors/errorHandler';
+import { requireMaxLength, requireString } from '../errors/validators';
+import { withCallableGuard } from '../middleware/callableGuard';
+import { isValidKoreanPhone, maskPhone, toE164 } from '../utils/phone';
+
+interface VerifyPortOneIdentityData {
+  identityVerificationId: string;
+}
+
+interface VerifyPortOneIdentityResult {
+  success: true;
+  identityVerified: true;
+  phoneVerified: boolean;
+  hasDuplicatePhone: boolean;
+  hasDuplicateIdentity: boolean;
+  identity: {
+    provider: 'portone';
+    channel: 'inicis_unified';
+    identityVerificationId: string;
+    verifiedAt: string;
+    name: string;
+    birthDate: string;
+    gender?: 'male' | 'female';
+    phoneNumber?: string;
+    ciHash?: string;
+    isForeigner?: boolean;
+  };
+}
+
+function normalizeBirthDate(value?: string): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.replace(/-/g, '');
+  return /^\d{8}$/.test(normalized) ? normalized : null;
+}
+
+function normalizeGender(value?: string): 'male' | 'female' | undefined {
+  switch (value) {
+    case 'MALE':
+      return 'male';
+    case 'FEMALE':
+      return 'female';
+    default:
+      return undefined;
+  }
+}
+
+function createDeterministicHash(value: string, secret: string): string {
+  return createHmac('sha256', secret).update(value).digest('hex');
+}
+
+function getPortOneSecret(): string {
+  const secret = process.env.PORTONE_API_SECRET?.trim();
+
+  if (!secret) {
+    logger.error('verifyPortOneIdentity: PORTONE_API_SECRET missing');
+    throw new Error('PORTONE_API_SECRET is not configured');
+  }
+
+  return secret;
+}
+
+export const verifyPortOneIdentity = onCall(
+  { region: 'asia-northeast3' },
+  (request) =>
+    withCallableGuard(
+      request,
+      {
+        operation: 'verifyPortOneIdentity',
+        rateLimit: {
+          maxRequests: 3,
+          authenticatedMaxRequests: 10,
+          keyPrefix: 'ratelimit:verify-portone-identity',
+        },
+        requireRecaptcha: false,
+      },
+      async (request) => {
+        try {
+          const uid = request.auth?.uid ?? null;
+          const data = request.data as VerifyPortOneIdentityData;
+          const identityVerificationId = requireString(
+            data.identityVerificationId,
+            '본인인증 ID'
+          );
+          requireMaxLength(identityVerificationId, 200, '본인인증 ID');
+
+          const portOneSecret = getPortOneSecret();
+          const client = PortOneClient({ secret: portOneSecret });
+          const identityVerification =
+            await client.identityVerification.getIdentityVerification({
+              identityVerificationId,
+            });
+
+          if (identityVerification.status !== 'VERIFIED') {
+            throw new ValidationError(ERROR_CODES.VALIDATION_FORMAT, {
+              userMessage: '포트원 본인인증이 아직 완료되지 않았습니다.',
+            });
+          }
+
+          const verifiedCustomer = identityVerification.verifiedCustomer;
+          const normalizedBirthDate = normalizeBirthDate(verifiedCustomer.birthDate);
+          if (!normalizedBirthDate) {
+            throw new ValidationError(ERROR_CODES.VALIDATION_FORMAT, {
+              userMessage: '본인인증 생년월일 정보를 확인할 수 없습니다.',
+            });
+          }
+
+          const normalizedPhoneNumber =
+            typeof verifiedCustomer.phoneNumber === 'string' &&
+            isValidKoreanPhone(verifiedCustomer.phoneNumber)
+              ? toE164(verifiedCustomer.phoneNumber)
+              : undefined;
+          const ciHash =
+            typeof verifiedCustomer.ci === 'string' && verifiedCustomer.ci.length > 0
+              ? createDeterministicHash(verifiedCustomer.ci, portOneSecret)
+              : undefined;
+
+          const db = admin.firestore();
+          const [phoneConflictSnapshot, identityConflictSnapshot] = await Promise.all([
+            normalizedPhoneNumber
+              ? db.collection('users').where('phone', '==', normalizedPhoneNumber).limit(2).get()
+              : Promise.resolve(null),
+            ciHash
+              ? db.collection('users').where('identity.ciHash', '==', ciHash).limit(2).get()
+              : Promise.resolve(null),
+          ]);
+
+          const hasDuplicatePhone = Boolean(
+            phoneConflictSnapshot?.docs.some((doc) => (uid ? doc.id !== uid : true))
+          );
+          const hasDuplicateIdentity = Boolean(
+            identityConflictSnapshot?.docs.some((doc) => (uid ? doc.id !== uid : true))
+          );
+
+          logger.info('verifyPortOneIdentity: verified', {
+            uid,
+            identityVerificationId,
+            phoneVerified: Boolean(normalizedPhoneNumber),
+            hasDuplicatePhone,
+            hasDuplicateIdentity,
+            phone: normalizedPhoneNumber ? maskPhone(normalizedPhoneNumber) : undefined,
+          });
+
+          const response: VerifyPortOneIdentityResult = {
+            success: true,
+            identityVerified: true,
+            phoneVerified: Boolean(normalizedPhoneNumber),
+            hasDuplicatePhone,
+            hasDuplicateIdentity,
+            identity: {
+              provider: 'portone',
+              channel: 'inicis_unified',
+              identityVerificationId,
+              verifiedAt: identityVerification.verifiedAt,
+              name: verifiedCustomer.name,
+              birthDate: normalizedBirthDate,
+              gender: normalizeGender(verifiedCustomer.gender),
+              phoneNumber: normalizedPhoneNumber,
+              ciHash,
+              isForeigner: verifiedCustomer.isForeigner,
+            },
+          };
+
+          return response;
+        } catch (error) {
+          throw handleFunctionError(error, {
+            operation: 'verifyPortOneIdentity',
+            context: {
+              userId: request.auth?.uid,
+              identityVerificationId: (request.data as VerifyPortOneIdentityData | undefined)
+                ?.identityVerificationId,
+            },
+          });
+        }
+      }
+    ),
+);

--- a/uniqn-mobile/.env.example
+++ b/uniqn-mobile/.env.example
@@ -60,3 +60,12 @@ EXPO_PUBLIC_FIREBASE_REGION=asia-northeast3
 # EXPO_PUBLIC_ENABLE_ANALYTICS=true
 # EXPO_PUBLIC_ENABLE_CRASH_REPORTING=true
 # EXPO_PUBLIC_ENABLE_DEBUG_MODE=false
+
+# ============================================================================
+# PortOne KG Inicis identity verification (optional)
+# ============================================================================
+# EXPO_PUBLIC_PORTONE_STORE_ID=store-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+# EXPO_PUBLIC_PORTONE_INICIS_CHANNEL_KEY=channel-key-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+# EXPO_PUBLIC_PORTONE_INICIS_DIRECT_AGENCY=PASS
+# EXPO_PUBLIC_PORTONE_INICIS_LOGO_URL=https://uniqn.app/portone-logo.png
+# EXPO_PUBLIC_PORTONE_INICIS_FRGND_INFO=N

--- a/uniqn-mobile/app.config.ts
+++ b/uniqn-mobile/app.config.ts
@@ -260,6 +260,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     '@react-native-firebase/auth',
     'expo-apple-authentication',
     'expo-router',
+    '@portone/react-native-sdk/plugin',
     'expo-secure-store',
     [
       'expo-splash-screen',
@@ -349,6 +350,14 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     appleLoginEnabled: process.env.EXPO_PUBLIC_ENABLE_APPLE_LOGIN !== 'false',
     // reCAPTCHA v3 사이트 키 (웹 전용, 전화번호 중복체크 봇 방지)
     recaptchaSiteKey: process.env.EXPO_PUBLIC_RECAPTCHA_SITE_KEY || '',
+    // PortOne KG Inicis identity verification
+    portOne: {
+      storeId: process.env.EXPO_PUBLIC_PORTONE_STORE_ID || '',
+      inicisChannelKey: process.env.EXPO_PUBLIC_PORTONE_INICIS_CHANNEL_KEY || '',
+      inicisDirectAgency: process.env.EXPO_PUBLIC_PORTONE_INICIS_DIRECT_AGENCY || '',
+      inicisLogoUrl: process.env.EXPO_PUBLIC_PORTONE_INICIS_LOGO_URL || '',
+      inicisFrgndInfo: process.env.EXPO_PUBLIC_PORTONE_INICIS_FRGND_INFO || 'N',
+    },
   },
 
   // 업데이트 설정 (EAS Update)

--- a/uniqn-mobile/app/(app)/employer-register.tsx
+++ b/uniqn-mobile/app/(app)/employer-register.tsx
@@ -148,6 +148,13 @@ export default function EmployerRegisterScreen() {
         ...updatedProfile,
         createdAt: updatedProfile.createdAt?.toDate?.() ?? new Date(),
         updatedAt: updatedProfile.updatedAt?.toDate?.() ?? new Date(),
+        identityVerifiedAt: updatedProfile.identityVerifiedAt?.toDate?.() ?? undefined,
+        identity: updatedProfile.identity
+          ? {
+              ...updatedProfile.identity,
+              verifiedAt: updatedProfile.identity.verifiedAt?.toDate?.() ?? new Date(),
+            }
+          : undefined,
         employerAgreements: updatedProfile.employerAgreements
           ? {
               termsAgreedAt:

--- a/uniqn-mobile/app/(auth)/signup.tsx
+++ b/uniqn-mobile/app/(auth)/signup.tsx
@@ -92,6 +92,7 @@ export default function SignUpScreen() {
           birthDate: data.birthDate,
           gender: data.gender,
           phone: data.verifiedPhone || '',
+          identityVerificationId: data.identityVerificationId,
           termsAgreed: data.termsAgreed,
           privacyAgreed: data.privacyAgreed,
           marketingAgreed: data.marketingAgreed,

--- a/uniqn-mobile/package-lock.json
+++ b/uniqn-mobile/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@gorhom/bottom-sheet": "^5.2.8",
         "@hookform/resolvers": "^5.2.2",
+        "@portone/react-native-sdk": "^0.6.0",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/netinfo": "11.5.2",
         "@react-native-firebase/app": "^23.8.6",
@@ -29,6 +30,7 @@
         "expo-image": "~55.0.6",
         "expo-image-manipulator": "~55.0.11",
         "expo-image-picker": "~55.0.14",
+        "expo-intent-launcher": "~55.0.11",
         "expo-linking": "~55.0.9",
         "expo-local-authentication": "~55.0.9",
         "expo-notifications": "~55.0.14",
@@ -57,6 +59,7 @@
         "react-native-screens": "~4.23.0",
         "react-native-svg": "15.15.3",
         "react-native-web": "^0.21.0",
+        "react-native-webview": "13.16.0",
         "react-native-worklets": "0.7.2",
         "tailwindcss": "^3.4.19",
         "zod": "^4.1.13",
@@ -65,6 +68,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260210.0",
         "@playwright/test": "^1.58.2",
+        "@portone/browser-sdk": "^0.1.3",
         "@testing-library/react-native": "^13.3.3",
         "@types/jest": "^29.5.14",
         "@types/react": "~19.2.10",
@@ -4102,6 +4106,25 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@portone/browser-sdk": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@portone/browser-sdk/-/browser-sdk-0.1.3.tgz",
+      "integrity": "sha512-GRmXb8gBLs/23CES1YRvzMggbL8+tFeH5WS9YSA6WUPu5/9kgRKKZLeC25N2raq3zVJd9OfDTeSf0tUr27vF1Q=="
+    },
+    "node_modules/@portone/react-native-sdk": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@portone/react-native-sdk/-/react-native-sdk-0.6.0.tgz",
+      "integrity": "sha512-QW1w+ozgqFtuwUeAsou8ILB0b/IVrsXDlhCkc2X8H1SG0KqOTrrO65GD6WLgniARgiUhqxbpuoDTzfTeMAMDGw==",
+      "license": "(Apache-2.0 OR MIT)",
+      "peerDependencies": {
+        "@portone/browser-sdk": "*",
+        "expo": "*",
+        "expo-intent-launcher": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-webview": "*"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -9545,6 +9568,15 @@
       "dependencies": {
         "expo-image-loader": "~55.0.0"
       },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-intent-launcher": {
+      "version": "55.0.11",
+      "resolved": "https://registry.npmjs.org/expo-intent-launcher/-/expo-intent-launcher-55.0.11.tgz",
+      "integrity": "sha512-C0KyAnYCMd4/Gx0bRL2i6F67kjidTFshXYFUQ1h43XB73d0RCJeWF9CnIQSOGTLaXY+laLDoM+pbZ8P5WANDkw==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*"
       }
@@ -18000,6 +18032,20 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
+    },
+    "node_modules/react-native-webview": {
+      "version": "13.16.0",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.16.0.tgz",
+      "integrity": "sha512-Nh13xKZWW35C0dbOskD7OX01nQQavOzHbCw9XoZmar4eXCo7AvrYJ0jlUfRVVIJzqINxHlpECYLdmAdFsl9xDA==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/react-native-worklets": {
       "version": "0.7.2",

--- a/uniqn-mobile/package.json
+++ b/uniqn-mobile/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@gorhom/bottom-sheet": "^5.2.8",
     "@hookform/resolvers": "^5.2.2",
+    "@portone/react-native-sdk": "^0.6.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "11.5.2",
     "@react-native-firebase/app": "^23.8.6",
@@ -52,6 +53,7 @@
     "expo-image": "~55.0.6",
     "expo-image-manipulator": "~55.0.11",
     "expo-image-picker": "~55.0.14",
+    "expo-intent-launcher": "~55.0.11",
     "expo-linking": "~55.0.9",
     "expo-local-authentication": "~55.0.9",
     "expo-notifications": "~55.0.14",
@@ -80,6 +82,7 @@
     "react-native-screens": "~4.23.0",
     "react-native-svg": "15.15.3",
     "react-native-web": "^0.21.0",
+    "react-native-webview": "13.16.0",
     "react-native-worklets": "0.7.2",
     "tailwindcss": "^3.4.19",
     "zod": "^4.1.13",
@@ -88,6 +91,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260210.0",
     "@playwright/test": "^1.58.2",
+    "@portone/browser-sdk": "^0.1.3",
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.14",
     "@types/react": "~19.2.10",

--- a/uniqn-mobile/src/components/auth/PortOneIdentityVerification.tsx
+++ b/uniqn-mobile/src/components/auth/PortOneIdentityVerification.tsx
@@ -1,0 +1,264 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { View, Text, useWindowDimensions } from 'react-native';
+import { IdentityVerification } from '@portone/react-native-sdk';
+import { CheckCircleIcon, ShieldCheckIcon, XCircleIcon } from '@/components/icons';
+import { Button } from '@/components/ui/Button';
+import { Modal } from '@/components/ui/Modal';
+import { extractUserMessage } from '@/errors';
+import {
+  type PortOneInicisIdentityRequest,
+  type PortOneIdentityVerificationResult,
+  type VerifiedPortOneIdentity,
+  buildPortOneInicisIdentityRequest,
+  callVerifyPortOneIdentity,
+  clearPendingPortOneIdentityRequest,
+  savePendingPortOneIdentityRequest,
+  savePortOneIdentityVerificationResult,
+} from '@/services/auth/portOneIdentityService';
+import { logger } from '@/utils/logger';
+
+export interface PortOneIdentityVerificationProps {
+  onVerified: (identity: VerifiedPortOneIdentity) => void;
+  onError?: (error: Error) => void;
+  initialIdentity?: VerifiedPortOneIdentity | null;
+  disabled?: boolean;
+  customerId?: string;
+  customerFullName?: string;
+  customerPhoneNumber?: string;
+}
+
+function formatBirthDate(value: string): string {
+  if (!/^\d{8}$/.test(value)) {
+    return value;
+  }
+
+  return `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`;
+}
+
+function getGenderLabel(value?: 'male' | 'female'): string {
+  if (value === 'male') return '남성';
+  if (value === 'female') return '여성';
+  return '확인 필요';
+}
+
+export function PortOneIdentityVerification({
+  onVerified,
+  onError,
+  initialIdentity = null,
+  disabled = false,
+  customerId,
+  customerFullName,
+  customerPhoneNumber,
+}: PortOneIdentityVerificationProps) {
+  const { height } = useWindowDimensions();
+  const [modalVisible, setModalVisible] = useState(false);
+  const [request, setRequest] = useState<PortOneInicisIdentityRequest | null>(null);
+  const [verifiedIdentity, setVerifiedIdentity] = useState<VerifiedPortOneIdentity | null>(
+    initialIdentity
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  useEffect(() => {
+    setVerifiedIdentity(initialIdentity);
+  }, [initialIdentity]);
+
+  const handleVerificationFailure = useCallback(
+    (error: unknown, fallbackMessage?: string) => {
+      clearPendingPortOneIdentityRequest();
+      setModalVisible(false);
+      setIsProcessing(false);
+
+      const resolvedMessage =
+        fallbackMessage ??
+        (error instanceof Error ? error.message : extractUserMessage(error)) ??
+        '본인인증 처리 중 오류가 발생했습니다.';
+
+      setErrorMessage(resolvedMessage);
+
+      const normalizedError =
+        error instanceof Error ? error : new Error(fallbackMessage ?? 'PortOne identity failed');
+
+      logger.error('PortOne identity verification failed', normalizedError, {
+        component: 'PortOneIdentityVerification',
+      });
+      onError?.(normalizedError);
+    },
+    [onError]
+  );
+
+  const handleVerificationComplete = useCallback(
+    async (result: PortOneIdentityVerificationResult) => {
+      savePortOneIdentityVerificationResult(result);
+      clearPendingPortOneIdentityRequest();
+      setModalVisible(false);
+
+      if (result.code || result.message) {
+        handleVerificationFailure(
+          new Error(result.message ?? '본인인증이 완료되지 않았습니다.'),
+          result.message ?? '본인인증이 완료되지 않았습니다.'
+        );
+        return;
+      }
+
+      setIsProcessing(true);
+      setErrorMessage(null);
+
+      try {
+        const verification = await callVerifyPortOneIdentity({
+          identityVerificationId: result.identityVerificationId,
+        });
+
+        if (verification.hasDuplicatePhone) {
+          throw new Error('이미 가입된 휴대폰 번호입니다.');
+        }
+
+        if (verification.hasDuplicateIdentity) {
+          throw new Error('이미 가입된 본인인증 정보입니다.');
+        }
+
+        if (!verification.phoneVerified || !verification.identity.phoneNumber) {
+          throw new Error('본인인증 결과에 휴대폰 번호가 없습니다. 채널 설정을 확인해주세요.');
+        }
+
+        if (!verification.identity.gender) {
+          throw new Error('본인인증 결과에 성별 정보가 없습니다. 인증 수단을 다시 선택해주세요.');
+        }
+
+        setVerifiedIdentity(verification.identity);
+        onVerified(verification.identity);
+      } catch (error) {
+        handleVerificationFailure(error);
+      } finally {
+        setIsProcessing(false);
+      }
+    },
+    [handleVerificationFailure, onVerified]
+  );
+
+  const handleSdkError = useCallback(
+    (error: Error) => {
+      handleVerificationFailure(error);
+    },
+    [handleVerificationFailure]
+  );
+
+  const startVerification = useCallback(() => {
+    try {
+      const nextRequest = buildPortOneInicisIdentityRequest({
+        customerId,
+        customerFullName,
+        customerPhoneNumber,
+      });
+
+      savePendingPortOneIdentityRequest(nextRequest);
+      setRequest(nextRequest);
+      setErrorMessage(null);
+      setVerifiedIdentity(null);
+      setModalVisible(true);
+    } catch (error) {
+      handleVerificationFailure(error);
+    }
+  }, [customerFullName, customerId, customerPhoneNumber, handleVerificationFailure]);
+
+  const modalHeight = Math.max(420, Math.floor(height * 0.7));
+
+  return (
+    <View className="w-full">
+      {verifiedIdentity ? (
+        <View className="rounded-xl border border-success-200 bg-success-50 p-4 dark:border-success-900/40 dark:bg-success-900/10">
+          <View className="mb-3 flex-row items-center">
+            <CheckCircleIcon size={20} color="#22c55e" />
+            <Text className="ml-2 font-semibold text-success-700 dark:text-success-400">
+              이니시스 본인인증 완료
+            </Text>
+          </View>
+
+          <View className="gap-2 rounded-lg bg-white p-3 dark:bg-surface">
+            <View className="flex-row justify-between">
+              <Text className="text-sm text-gray-500 dark:text-gray-400">이름</Text>
+              <Text className="font-medium text-gray-900 dark:text-white">
+                {verifiedIdentity.name}
+              </Text>
+            </View>
+            <View className="flex-row justify-between">
+              <Text className="text-sm text-gray-500 dark:text-gray-400">생년월일</Text>
+              <Text className="font-medium text-gray-900 dark:text-white">
+                {formatBirthDate(verifiedIdentity.birthDate)}
+              </Text>
+            </View>
+            <View className="flex-row justify-between">
+              <Text className="text-sm text-gray-500 dark:text-gray-400">성별</Text>
+              <Text className="font-medium text-gray-900 dark:text-white">
+                {getGenderLabel(verifiedIdentity.gender)}
+              </Text>
+            </View>
+            <View className="flex-row justify-between">
+              <Text className="text-sm text-gray-500 dark:text-gray-400">휴대폰 번호</Text>
+              <Text className="font-medium text-gray-900 dark:text-white">
+                {verifiedIdentity.phoneNumber}
+              </Text>
+            </View>
+          </View>
+
+          <Button
+            onPress={startVerification}
+            variant="outline"
+            disabled={disabled || isProcessing}
+            className="mt-3"
+            fullWidth
+          >
+            다시 인증하기
+          </Button>
+        </View>
+      ) : (
+        <View className="rounded-xl border border-gray-200 bg-gray-50 p-4 dark:border-surface-overlay dark:bg-surface-elevated">
+          <View className="mb-3 flex-row items-center">
+            <ShieldCheckIcon size={20} color="#4f46e5" />
+            <Text className="ml-2 font-semibold text-gray-900 dark:text-white">
+              이니시스 본인인증
+            </Text>
+          </View>
+          <Text className="mb-4 text-sm leading-5 text-gray-600 dark:text-gray-300">
+            PASS, 토스, 카카오, 네이버 등 이니시스 통합인증 수단으로 본인인증을 진행합니다. 인증
+            완료 후 검증된 이름, 생년월일, 성별, 휴대폰 번호를 자동으로 반영합니다.
+          </Text>
+          <Button onPress={startVerification} disabled={disabled || isProcessing} fullWidth>
+            {isProcessing ? '인증 확인 중...' : '본인인증 시작'}
+          </Button>
+        </View>
+      )}
+
+      {errorMessage && (
+        <View className="mt-3 flex-row items-center rounded-lg bg-error-50 p-3 dark:bg-error-900/20">
+          <XCircleIcon size={18} color="#ef4444" />
+          <Text className="ml-2 flex-1 text-sm text-error-600 dark:text-error-400">
+            {errorMessage}
+          </Text>
+        </View>
+      )}
+
+      {request && (
+        <Modal
+          visible={modalVisible}
+          onClose={() => {
+            clearPendingPortOneIdentityRequest();
+            setModalVisible(false);
+          }}
+          title="본인인증"
+          size="full"
+        >
+          <View style={{ height: modalHeight }}>
+            <IdentityVerification
+              request={request}
+              onComplete={handleVerificationComplete}
+              onError={handleSdkError}
+            />
+          </View>
+        </Modal>
+      )}
+    </View>
+  );
+}
+
+export default PortOneIdentityVerification;

--- a/uniqn-mobile/src/components/auth/PortOneIdentityVerification.web.tsx
+++ b/uniqn-mobile/src/components/auth/PortOneIdentityVerification.web.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { Button } from '@/components/ui/Button';
+
+export interface PortOneIdentityVerificationProps {
+  onVerified: () => void;
+  onError?: (error: Error) => void;
+  initialIdentity?: unknown;
+  disabled?: boolean;
+  customerId?: string;
+  customerFullName?: string;
+  customerPhoneNumber?: string;
+}
+
+export function PortOneIdentityVerification({
+  disabled = false,
+}: PortOneIdentityVerificationProps) {
+  return (
+    <View className="rounded-xl border border-gray-200 bg-gray-50 p-4 dark:border-surface-overlay dark:bg-surface-elevated">
+      <Text className="mb-2 font-semibold text-gray-900 dark:text-white">이니시스 본인인증</Text>
+      <Text className="mb-4 text-sm leading-5 text-gray-600 dark:text-gray-300">
+        웹 환경에서는 아직 이니시스 본인인증 SDK를 연결하지 않았습니다. 현재는 모바일 앱에서만
+        사용할 수 있습니다.
+      </Text>
+      <Button disabled variant="outline" fullWidth>
+        모바일 앱에서 이용 가능
+      </Button>
+      {!disabled && (
+        <Text className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+          웹에서는 기존 문자 인증 fallback이 유지됩니다.
+        </Text>
+      )}
+    </View>
+  );
+}
+
+export default PortOneIdentityVerification;

--- a/uniqn-mobile/src/components/auth/signup/SignupForm.tsx
+++ b/uniqn-mobile/src/components/auth/signup/SignupForm.tsx
@@ -155,6 +155,7 @@ export function SignupForm({
         gender: data.gender,
         phoneVerified: data.phoneVerified as true,
         verifiedPhone: data.verifiedPhone,
+        identityVerificationId: data.identityVerificationId,
         // 서버사이드 OTP 검증 (소셜 로그인 link 모드)
         verificationId: data.verificationId,
         otpCode: data.otpCode,

--- a/uniqn-mobile/src/components/auth/signup/SignupStepIdentity.tsx
+++ b/uniqn-mobile/src/components/auth/signup/SignupStepIdentity.tsx
@@ -1,44 +1,63 @@
 /**
  * UNIQN Mobile - 회원가입 Step 2: 본인인증
  *
- * @description 이름/생년월일/성별 입력 + Firebase Phone Auth(SMS OTP) 전화번호 인증
- * @version 4.1.0
+ * @description 이름/생년월일/성별 입력 + 전화번호 인증
+ *              포트원 KG이니시스가 설정된 네이티브 환경에서는 이니시스 본인인증을 우선 사용
+ * @version 4.2.0
  */
 
-import React, { useState, useCallback, useEffect } from 'react';
-import { View, Text } from 'react-native';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Platform, View, Text } from 'react-native';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { PhoneVerification } from '@/components/auth/PhoneVerification';
+import { PortOneIdentityVerification } from '@/components/auth/PortOneIdentityVerification';
 import { BirthDateInput } from '@/components/auth/signup/BirthDateInput';
 import { GenderSelector } from '@/components/auth/signup/GenderSelector';
-import { getLinkedPhoneNumber } from '@/services/auth';
+import {
+  getLinkedPhoneNumber,
+  isPortOneInicisIdentityConfigured,
+  type VerifiedPortOneIdentity,
+} from '@/services/auth';
 import { signUpIdentitySchema } from '@/schemas';
 import type { SignUpIdentityData } from '@/schemas';
 import { logger } from '@/utils/logger';
-
-// ============================================================================
-// Types
-// ============================================================================
 
 interface SignupStepIdentityProps {
   onNext: (data: SignUpIdentityData) => void;
   onBack: () => void;
   initialData?: Partial<SignUpIdentityData>;
   isLoading?: boolean;
-  /** PhoneVerification 모드: signIn(기본)=새 계정 생성, link=기존 계정에 링크 */
   phoneMode?: 'signIn' | 'link';
-  /** Apple 소셜 로그인 사용자 여부 (이름 미제공 시 안내 메시지 표시) */
   isAppleUser?: boolean;
-  /** 제출 버튼 텍스트 (기본: '다음') */
   submitLabel?: string;
 }
 
-// ============================================================================
-// Component
-// ============================================================================
+function createInitialPortOneIdentity(
+  initialData?: Partial<SignUpIdentityData>
+): VerifiedPortOneIdentity | null {
+  if (
+    !initialData?.identityVerificationId ||
+    !initialData.name ||
+    !initialData.birthDate ||
+    !initialData.verifiedPhone
+  ) {
+    return null;
+  }
+
+  return {
+    provider: 'portone',
+    channel: 'inicis_unified',
+    identityVerificationId: initialData.identityVerificationId,
+    verifiedAt: new Date().toISOString(),
+    name: initialData.name,
+    birthDate: initialData.birthDate,
+    gender: initialData.gender,
+    phoneNumber: initialData.verifiedPhone,
+  };
+}
 
 export function SignupStepIdentity({
   onNext,
@@ -49,14 +68,19 @@ export function SignupStepIdentity({
   isAppleUser = false,
   submitLabel = '다음',
 }: SignupStepIdentityProps) {
+  const usePortOneIdentity = Platform.OS !== 'web' && isPortOneInicisIdentityConfigured();
   const [verifiedPhone, setVerifiedPhone] = useState<string | null>(
     initialData?.verifiedPhone || null
+  );
+  const [portOneIdentity, setPortOneIdentity] = useState<VerifiedPortOneIdentity | null>(() =>
+    createInitialPortOneIdentity(initialData)
   );
 
   const {
     control,
     handleSubmit,
     setValue,
+    watch,
     formState: { errors },
   } = useForm<SignUpIdentityData>({
     resolver: zodResolver(signUpIdentitySchema),
@@ -66,14 +90,21 @@ export function SignupStepIdentity({
       gender: initialData?.gender,
       phoneVerified: initialData?.phoneVerified || false,
       verifiedPhone: initialData?.verifiedPhone || '',
+      identityVerificationId: initialData?.identityVerificationId,
     },
   });
 
-  const handleVerified = useCallback(
+  const watchedName = watch('name');
+  const isIdentityLocked = usePortOneIdentity && Boolean(portOneIdentity);
+
+  const handlePhoneVerified = useCallback(
     (phone: string, otpData?: { verificationId: string; otpCode: string }) => {
       setVerifiedPhone(phone);
-      setValue('phoneVerified', true);
-      setValue('verifiedPhone', phone);
+      setPortOneIdentity(null);
+      setValue('phoneVerified', true, { shouldValidate: true });
+      setValue('verifiedPhone', phone, { shouldValidate: true });
+      setValue('identityVerificationId', undefined);
+
       if (otpData) {
         setValue('verificationId', otpData.verificationId);
         setValue('otpCode', otpData.otpCode);
@@ -82,20 +113,45 @@ export function SignupStepIdentity({
     [setValue]
   );
 
-  // 소셜 모드: 이미 link된 전화번호 자동 감지 (중단 복구 / 뒤로가기 후 재진입)
+  const handlePortOneVerified = useCallback(
+    (identity: VerifiedPortOneIdentity) => {
+      if (!identity.phoneNumber || !identity.gender) {
+        logger.warn('PortOne identity missing required fields', {
+          component: 'SignupStepIdentity',
+          identityVerificationId: identity.identityVerificationId,
+        });
+        return;
+      }
+
+      setPortOneIdentity(identity);
+      setVerifiedPhone(identity.phoneNumber);
+      setValue('name', identity.name, { shouldValidate: true });
+      setValue('birthDate', identity.birthDate, { shouldValidate: true });
+      setValue('gender', identity.gender, { shouldValidate: true });
+      setValue('phoneVerified', true, { shouldValidate: true });
+      setValue('verifiedPhone', identity.phoneNumber, { shouldValidate: true });
+      setValue('identityVerificationId', identity.identityVerificationId, {
+        shouldValidate: true,
+      });
+      setValue('verificationId', undefined);
+      setValue('otpCode', undefined);
+    },
+    [setValue]
+  );
+
   useEffect(() => {
-    if (phoneMode !== 'link') return;
+    if (phoneMode !== 'link' || usePortOneIdentity) return;
 
     const linkedPhone = getLinkedPhoneNumber();
-    if (linkedPhone) {
-      logger.info('소셜 모드: 이미 전화번호 링크됨', {
-        component: 'SignupStepIdentity',
-      });
-      setVerifiedPhone(linkedPhone);
-      setValue('phoneVerified', true);
-      setValue('verifiedPhone', linkedPhone);
-    }
-  }, [phoneMode, setValue]);
+    if (!linkedPhone) return;
+
+    logger.info('Social signup linked phone restored', {
+      component: 'SignupStepIdentity',
+    });
+    setVerifiedPhone(linkedPhone);
+    setValue('phoneVerified', true, { shouldValidate: true });
+    setValue('verifiedPhone', linkedPhone, { shouldValidate: true });
+  }, [phoneMode, setValue, usePortOneIdentity]);
 
   const onSubmit = useCallback(
     (data: SignUpIdentityData) => {
@@ -106,9 +162,8 @@ export function SignupStepIdentity({
 
   return (
     <View className="w-full flex-col gap-5">
-      {/* 이름 입력 */}
       <View>
-        <Text className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+        <Text className="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
           이름 (실명)
         </Text>
         <Controller
@@ -120,73 +175,92 @@ export function SignupStepIdentity({
               value={value}
               onChangeText={onChange}
               onBlur={onBlur}
-              editable={!isLoading}
+              editable={!isLoading && !isIdentityLocked}
               accessibilityLabel="이름 입력"
               error={errors.name?.message}
             />
           )}
         />
         {isAppleUser && !initialData?.name && (
-          <View className="mt-2 rounded-lg bg-blue-50 dark:bg-blue-900/20 p-3">
+          <View className="mt-2 rounded-lg bg-blue-50 p-3 dark:bg-blue-900/20">
             <Text className="text-xs text-blue-700 dark:text-blue-300">
-              Apple은 최초 로그인 시에만 이름을 제공합니다. 이전에 이름 공유를 거부했거나 앱을
-              재설치한 경우 직접 입력해주세요.
+              Apple은 최초 로그인 시에만 이름을 제공합니다. 이전에 이름 공유를 거부했거나 삭제한
+              경우 직접 입력해주세요.
             </Text>
           </View>
         )}
       </View>
 
-      {/* 생년월일 입력 */}
       <View>
-        <Text className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">생년월일</Text>
+        <Text className="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">생년월일</Text>
         <Controller
           control={control}
           name="birthDate"
           render={({ field: { onChange, value } }) => (
-            <BirthDateInput value={value} onChange={onChange} disabled={isLoading} />
+            <BirthDateInput
+              value={value}
+              onChange={onChange}
+              disabled={isLoading || isIdentityLocked}
+            />
           )}
         />
         {errors.birthDate && (
-          <Text className="text-sm text-error-500 mt-1">{errors.birthDate.message}</Text>
+          <Text className="mt-1 text-sm text-error-500">{errors.birthDate.message}</Text>
         )}
       </View>
 
-      {/* 성별 선택 */}
       <View>
-        <Text className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">성별</Text>
+        <Text className="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">성별</Text>
         <Controller
           control={control}
           name="gender"
           render={({ field: { onChange, value } }) => (
-            <GenderSelector value={value} onChange={onChange} disabled={isLoading} />
+            <GenderSelector
+              value={value}
+              onChange={onChange}
+              disabled={isLoading || isIdentityLocked}
+            />
           )}
         />
         {errors.gender && (
-          <Text className="text-sm text-error-500 mt-1">{errors.gender.message}</Text>
+          <Text className="mt-1 text-sm text-error-500">{errors.gender.message}</Text>
         )}
       </View>
 
-      {/* 전화번호 인증 */}
       <View>
-        <Text className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-          전화번호 인증
+        <Text className="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+          {usePortOneIdentity ? '본인인증' : '전화번호 인증'}
         </Text>
-        <PhoneVerification
-          onVerified={handleVerified}
-          onError={(error) =>
-            logger.error('전화번호 인증 오류', { component: 'SignupStepIdentity', error })
-          }
-          initialPhone={verifiedPhone || initialData?.verifiedPhone}
-          disabled={isLoading}
-          compact
-          mode={phoneMode}
-        />
+        {usePortOneIdentity ? (
+          <PortOneIdentityVerification
+            onVerified={handlePortOneVerified}
+            onError={(error) =>
+              logger.error('PortOne identity verification error', error, {
+                component: 'SignupStepIdentity',
+              })
+            }
+            initialIdentity={portOneIdentity}
+            disabled={isLoading}
+            customerFullName={watchedName || undefined}
+          />
+        ) : (
+          <PhoneVerification
+            onVerified={handlePhoneVerified}
+            onError={(error) =>
+              logger.error('Phone verification error', { component: 'SignupStepIdentity', error })
+            }
+            initialPhone={verifiedPhone || initialData?.verifiedPhone}
+            disabled={isLoading}
+            compact
+            mode={phoneMode}
+          />
+        )}
       </View>
+
       {errors.phoneVerified && !verifiedPhone && (
-        <Text className="text-sm text-error-500 -mt-2">{errors.phoneVerified.message}</Text>
+        <Text className="-mt-2 text-sm text-error-500">{errors.phoneVerified.message}</Text>
       )}
 
-      {/* 버튼 영역 */}
       <View className="mt-4 flex-col gap-3">
         <Button onPress={handleSubmit(onSubmit)} disabled={isLoading} fullWidth>
           {submitLabel}

--- a/uniqn-mobile/src/constants/firestoreFields.ts
+++ b/uniqn-mobile/src/constants/firestoreFields.ts
@@ -32,6 +32,9 @@ export const USER_FIELDS = {
   role: 'role',
   isActive: 'isActive',
   phoneVerified: 'phoneVerified',
+  identityVerified: 'identityVerified',
+  identityVerifiedAt: 'identityVerifiedAt',
+  identityProvider: 'identityProvider',
   birthDate: 'birthDate',
   userId: 'userId',
 } as const;

--- a/uniqn-mobile/src/lib/mmkvStorage.ts
+++ b/uniqn-mobile/src/lib/mmkvStorage.ts
@@ -368,6 +368,8 @@ export const STORAGE_KEYS = {
   FORM_DRAFT: 'form-draft',
   SEARCH_HISTORY: 'search-history',
   RECENT_JOBS: 'recent-jobs',
+  PORTONE_IDENTITY_REQUEST: 'portone-identity-request',
+  PORTONE_IDENTITY_RESULT: 'portone-identity-result',
 
   // 토큰 갱신
   TOKEN_REFRESH_STATE: 'token-refresh-state',

--- a/uniqn-mobile/src/schemas/auth.schema.ts
+++ b/uniqn-mobile/src/schemas/auth.schema.ts
@@ -210,6 +210,7 @@ export const signUpIdentitySchema = z.object({
     message: '전화번호 인증이 필요합니다',
   }),
   verifiedPhone: phoneSchema,
+  identityVerificationId: z.string().min(1).max(200).optional(),
   /** 서버사이드 OTP 검증용 (소셜 로그인 link 모드) */
   verificationId: z.string().min(1).max(2000).optional(),
   otpCode: z

--- a/uniqn-mobile/src/services/auth/authCoreService.ts
+++ b/uniqn-mobile/src/services/auth/authCoreService.ts
@@ -6,6 +6,7 @@
 
 import {
   signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
   sendPasswordResetEmail,
   EmailAuthProvider,
   linkWithCredential,
@@ -53,6 +54,7 @@ import {
   type VerifyAndSavePayload,
   callVerifyAndSaveProfile,
 } from './authTypes';
+import { callVerifyAndSavePortOneProfile } from './portOneIdentityService';
 import { getUserProfile as fetchUserProfile } from './userProfileService';
 
 // ============================================================================
@@ -452,6 +454,141 @@ function trackSignupAnalytics(uid: string, role: 'staff' | 'employer' | 'admin')
     account_created_date: new Date().toISOString().split('T')[0],
     has_verified_phone: true,
   });
+}
+
+async function rollbackFreshEmailSignupAccount(uid: string): Promise<void> {
+  let deleted = false;
+
+  try {
+    const nativeUser = getNativeAuth?.()?.currentUser;
+    if (nativeUser && nativeUser.uid === uid && nativeDeleteUser) {
+      await nativeDeleteUser(nativeUser);
+      deleted = true;
+    }
+  } catch (nativeError) {
+    logger.warn('Fresh signup rollback native delete failed', {
+      component: 'authService',
+      uid,
+      error: nativeError instanceof Error ? nativeError.message : String(nativeError),
+    });
+  }
+
+  try {
+    const webUser = getFirebaseAuth().currentUser;
+    if (webUser && webUser.uid === uid) {
+      await webDeleteUser(webUser);
+      deleted = true;
+    }
+  } catch (webError) {
+    logger.warn('Fresh signup rollback web delete failed', {
+      component: 'authService',
+      uid,
+      error: webError instanceof Error ? webError.message : String(webError),
+    });
+  }
+
+  try {
+    await syncSignOut();
+  } catch {
+    // Ignore cleanup failures during rollback.
+  }
+
+  if (!deleted) {
+    logger.warn('Fresh signup rollback could not confirm user deletion', {
+      component: 'authService',
+      uid,
+    });
+  }
+}
+
+async function signUpWithPortOneIdentity(data: SignUpFormData): Promise<AuthResult> {
+  const identityVerificationId = data.identityVerificationId;
+  if (!identityVerificationId) {
+    throw new AuthError(ERROR_CODES.AUTH_INVALID_CREDENTIALS, {
+      userMessage: '본인인증 정보가 누락되었습니다. 다시 시도해주세요.',
+    });
+  }
+
+  logger.info('PortOne identity signup started', {
+    component: 'authService',
+    email: maskEmail(data.email),
+    platform: Platform.OS,
+  });
+
+  let createdUid: string | null = null;
+  let profilePersisted = false;
+
+  try {
+    const webCredential = await createUserWithEmailAndPassword(
+      getFirebaseAuth(),
+      data.email,
+      data.password
+    );
+    const webUser = webCredential.user;
+    createdUid = webUser.uid;
+
+    protectAuthFlow(createdUid, 'email_signup');
+
+    if (Platform.OS !== 'web') {
+      const nativeAuth = requireNativeAuth();
+      if (!nativeSignInWithEmailAndPassword) {
+        throw new AuthError(ERROR_CODES.AUTH_INVALID_CREDENTIALS, {
+          userMessage: '네이티브 인증 SDK가 준비되지 않았습니다.',
+        });
+      }
+
+      await nativeSignInWithEmailAndPassword(nativeAuth, data.email, data.password);
+      await verifyDualSDKConsistency('signUpWithPortOneIdentity');
+    }
+
+    await waitForWebAuthSession(createdUid);
+
+    await callVerifyAndSavePortOneProfile({
+      identityVerificationId,
+      termsAgreed: data.termsAgreed,
+      privacyAgreed: data.privacyAgreed,
+      marketingAgreed: data.marketingAgreed,
+      email: data.email,
+      mode: 'signup',
+    });
+    profilePersisted = true;
+
+    await webUser.getIdToken(true);
+
+    const profile = await getUserProfile(createdUid);
+    if (!profile) {
+      throw new AuthError(ERROR_CODES.AUTH_USER_NOT_FOUND, {
+        userMessage: '회원가입은 완료되었지만 프로필 정보를 가져오지 못했습니다.',
+      });
+    }
+
+    logger.info('PortOne identity signup completed', {
+      component: 'authService',
+      uid: createdUid,
+    });
+    trackSignupAnalytics(createdUid, 'staff');
+
+    return { user: webUser, profile };
+  } catch (error) {
+    if (profilePersisted) {
+      try {
+        await syncSignOut();
+      } catch {
+        // Ignore cleanup failures after profile persistence.
+      }
+      throw createPostCommitSessionRestoreError(error);
+    }
+
+    if (createdUid) {
+      await rollbackFreshEmailSignupAccount(createdUid);
+    }
+
+    throw error;
+  } finally {
+    if (createdUid) {
+      clearProtectedAuthFlow(createdUid);
+    }
+  }
 }
 
 // ============================================================================
@@ -892,6 +1029,10 @@ export async function checkNicknameExists(nickname: string, excludeUid?: string)
  */
 export async function signUp(data: SignUpFormData): Promise<AuthResult> {
   try {
+    if (data.identityVerificationId) {
+      return await signUpWithPortOneIdentity(data);
+    }
+
     logger.info('?뚯썝媛???쒕룄', {
       email: maskEmail(data.email),
       platform: Platform.OS,

--- a/uniqn-mobile/src/services/auth/authTypes.ts
+++ b/uniqn-mobile/src/services/auth/authTypes.ts
@@ -40,6 +40,8 @@ export interface SocialProfileData {
   gender: 'male' | 'female';
   /** 전화번호 (E.164 형식: +821012345678) */
   phone: string;
+  /** 포트원 본인인증 ID */
+  identityVerificationId?: string;
   // 약관
   termsAgreed: boolean;
   privacyAgreed: boolean;

--- a/uniqn-mobile/src/services/auth/index.ts
+++ b/uniqn-mobile/src/services/auth/index.ts
@@ -9,6 +9,19 @@
 // Auth Types (공유 타입)
 // ============================================================================
 export { type UserProfile, type AuthResult, type SocialProfileData } from './authTypes';
+export type {
+  PortOneInicisIdentityConfig,
+  PortOneInicisIdentityRequest,
+  PortOneInicisIdentityRequestInput,
+  PortOneIdentityVerificationResult,
+  PendingPortOneIdentityRequest,
+  PortOneInicisDirectAgency,
+  VerifiedPortOneIdentity,
+  VerifyAndSavePortOneProfilePayload,
+  VerifyAndSavePortOneProfileResult,
+  VerifyPortOneIdentityPayload,
+  VerifyPortOneIdentityResult,
+} from './portOneIdentityService';
 
 // ============================================================================
 // Auth Core Service (로그인, 회원가입, 세션)
@@ -36,6 +49,20 @@ export {
   requireCurrentUserRole,
   requireAdminUser,
 } from './authorizationService';
+export {
+  buildPortOneInicisIdentityRequest,
+  callVerifyAndSavePortOneProfile,
+  callVerifyPortOneIdentity,
+  clearPendingPortOneIdentityRequest,
+  clearPortOneIdentityVerificationResult,
+  consumePortOneIdentityVerificationResult,
+  createPortOneIdentityVerificationId,
+  getPendingPortOneIdentityRequest,
+  getPortOneInicisIdentityConfig,
+  isPortOneInicisIdentityConfigured,
+  savePendingPortOneIdentityRequest,
+  savePortOneIdentityVerificationResult,
+} from './portOneIdentityService';
 
 // ============================================================================
 // Social Login Service (Apple, Google, 카카오)

--- a/uniqn-mobile/src/services/auth/portOneIdentityService.ts
+++ b/uniqn-mobile/src/services/auth/portOneIdentityService.ts
@@ -1,0 +1,280 @@
+import Constants from 'expo-constants';
+import type { Customer, IdentityVerificationRequest } from '@portone/browser-sdk/v2';
+import { httpsCallable } from 'firebase/functions';
+import { getFirebaseFunctions } from '@/lib/firebase';
+import { getStorageItem, removeStorageItem, setStorageItem, STORAGE_KEYS } from '@/lib/mmkvStorage';
+import { ERROR_CODES, ValidationError, isRetryableError } from '@/errors';
+import { logger } from '@/utils/logger';
+import { generateUUID } from '@/utils/generateId';
+
+export type PortOneInicisDirectAgency =
+  | 'PAYCO'
+  | 'PASS'
+  | 'TOSS'
+  | 'KFTC'
+  | 'KAKAO'
+  | 'NAVER'
+  | 'SAMSUNG'
+  | 'SHINHAN'
+  | 'KB'
+  | 'HANA'
+  | 'WOORI'
+  | 'NH'
+  | 'KAKAOBANK'
+  | 'SMS';
+
+export interface PortOneInicisIdentityConfig {
+  storeId: string;
+  channelKey: string;
+  directAgency?: PortOneInicisDirectAgency;
+  logoUrl?: string;
+  frgndInfo: 'Y' | 'N';
+  isReady: boolean;
+}
+
+export interface PortOneInicisIdentityRequestInput {
+  identityVerificationId?: string;
+  customerId?: string;
+  customerFullName?: string;
+  customerPhoneNumber?: string;
+  customData?: string;
+  directAgency?: PortOneInicisDirectAgency;
+  logoUrl?: string;
+  frgndInfo?: 'Y' | 'N';
+}
+
+export type PortOneInicisIdentityRequest = IdentityVerificationRequest;
+
+export interface PendingPortOneIdentityRequest {
+  provider: 'portone_inicis';
+  request: PortOneInicisIdentityRequest;
+  createdAt: number;
+}
+
+export interface PortOneIdentityVerificationResult {
+  identityVerificationId: string;
+  identityVerificationTxId: string;
+  code?: string;
+  message?: string;
+  pgCode?: string;
+  pgMessage?: string;
+}
+
+export interface VerifiedPortOneIdentity {
+  provider: 'portone';
+  channel: 'inicis_unified';
+  identityVerificationId: string;
+  verifiedAt: string;
+  name: string;
+  birthDate: string;
+  gender?: 'male' | 'female';
+  phoneNumber?: string;
+  ciHash?: string;
+  isForeigner?: boolean;
+}
+
+export interface VerifyPortOneIdentityPayload {
+  identityVerificationId: string;
+}
+
+export interface VerifyPortOneIdentityResult {
+  success: true;
+  identityVerified: true;
+  phoneVerified: boolean;
+  hasDuplicatePhone: boolean;
+  hasDuplicateIdentity: boolean;
+  identity: VerifiedPortOneIdentity;
+}
+
+export interface VerifyAndSavePortOneProfilePayload {
+  identityVerificationId: string;
+  nickname?: string;
+  region?: string;
+  experienceYears?: number;
+  career?: string;
+  note?: string;
+  termsAgreed: boolean;
+  privacyAgreed: boolean;
+  marketingAgreed: boolean;
+  email?: string;
+  mode: 'signup' | 'social';
+}
+
+export interface VerifyAndSavePortOneProfileResult {
+  success: boolean;
+  uid: string;
+}
+
+interface ExpoExtraWithPortOne {
+  portOne?: {
+    storeId?: string;
+    inicisChannelKey?: string;
+    inicisDirectAgency?: string;
+    inicisLogoUrl?: string;
+    inicisFrgndInfo?: string;
+  };
+}
+
+function sanitizePhoneNumber(phoneNumber?: string): string | undefined {
+  if (!phoneNumber) {
+    return undefined;
+  }
+
+  const digitsOnly = phoneNumber.replace(/[^0-9]/g, '');
+  return digitsOnly.length > 0 ? digitsOnly : undefined;
+}
+
+export function createPortOneIdentityVerificationId(prefix = 'inicis-identity'): string {
+  return `${prefix}-${generateUUID()}`;
+}
+
+export function getPortOneInicisIdentityConfig(): PortOneInicisIdentityConfig {
+  const extra = Constants.expoConfig?.extra as ExpoExtraWithPortOne | undefined;
+  const portOne = extra?.portOne;
+
+  const storeId = portOne?.storeId?.trim() ?? '';
+  const channelKey = portOne?.inicisChannelKey?.trim() ?? '';
+  const directAgency = portOne?.inicisDirectAgency?.trim() as PortOneInicisDirectAgency | undefined;
+  const logoUrl = portOne?.inicisLogoUrl?.trim() || undefined;
+  const frgndInfo = portOne?.inicisFrgndInfo === 'Y' ? 'Y' : 'N';
+
+  return {
+    storeId,
+    channelKey,
+    directAgency,
+    logoUrl,
+    frgndInfo,
+    isReady: storeId.length > 0 && channelKey.length > 0,
+  };
+}
+
+export function isPortOneInicisIdentityConfigured(): boolean {
+  return getPortOneInicisIdentityConfig().isReady;
+}
+
+export function buildPortOneInicisIdentityRequest(
+  input: PortOneInicisIdentityRequestInput = {}
+): PortOneInicisIdentityRequest {
+  const config = getPortOneInicisIdentityConfig();
+
+  if (!config.isReady) {
+    throw new ValidationError(ERROR_CODES.VALIDATION_REQUIRED, {
+      userMessage: '포트원 KG이니시스 본인인증 설정이 아직 완료되지 않았습니다.',
+    });
+  }
+
+  const customer: Customer = {};
+  if (input.customerId) {
+    customer.customerId = input.customerId;
+  }
+  if (input.customerFullName) {
+    customer.fullName = input.customerFullName.trim();
+  }
+
+  const sanitizedPhoneNumber = sanitizePhoneNumber(input.customerPhoneNumber);
+  if (sanitizedPhoneNumber) {
+    customer.phoneNumber = sanitizedPhoneNumber;
+  }
+
+  return {
+    storeId: config.storeId,
+    channelKey: config.channelKey,
+    identityVerificationId: input.identityVerificationId ?? createPortOneIdentityVerificationId(),
+    customer: Object.keys(customer).length > 0 ? customer : undefined,
+    customData: input.customData,
+    bypass: {
+      inicisUnified: {
+        flgFixedUser: 'N',
+        directAgency: input.directAgency ?? config.directAgency,
+        logoUrl: input.logoUrl ?? config.logoUrl,
+        FRGNDInfo: input.frgndInfo ?? config.frgndInfo,
+      },
+    },
+  };
+}
+
+export function savePendingPortOneIdentityRequest(request: PortOneInicisIdentityRequest): void {
+  setStorageItem<PendingPortOneIdentityRequest>(STORAGE_KEYS.PORTONE_IDENTITY_REQUEST, {
+    provider: 'portone_inicis',
+    request,
+    createdAt: Date.now(),
+  });
+}
+
+export function getPendingPortOneIdentityRequest(): PendingPortOneIdentityRequest | null {
+  return getStorageItem<PendingPortOneIdentityRequest>(STORAGE_KEYS.PORTONE_IDENTITY_REQUEST);
+}
+
+export function clearPendingPortOneIdentityRequest(): void {
+  removeStorageItem(STORAGE_KEYS.PORTONE_IDENTITY_REQUEST);
+}
+
+export function savePortOneIdentityVerificationResult(
+  result: PortOneIdentityVerificationResult
+): void {
+  setStorageItem(STORAGE_KEYS.PORTONE_IDENTITY_RESULT, result);
+}
+
+export function consumePortOneIdentityVerificationResult(): PortOneIdentityVerificationResult | null {
+  const result = getStorageItem<PortOneIdentityVerificationResult>(
+    STORAGE_KEYS.PORTONE_IDENTITY_RESULT
+  );
+  removeStorageItem(STORAGE_KEYS.PORTONE_IDENTITY_RESULT);
+  return result;
+}
+
+export function clearPortOneIdentityVerificationResult(): void {
+  removeStorageItem(STORAGE_KEYS.PORTONE_IDENTITY_RESULT);
+}
+
+export async function callVerifyPortOneIdentity(
+  payload: VerifyPortOneIdentityPayload
+): Promise<VerifyPortOneIdentityResult> {
+  const verifyIdentity = httpsCallable<VerifyPortOneIdentityPayload, VerifyPortOneIdentityResult>(
+    getFirebaseFunctions(),
+    'verifyPortOneIdentity'
+  );
+
+  try {
+    const response = await verifyIdentity(payload);
+    return response.data;
+  } catch (error) {
+    if (!isRetryableError(error)) {
+      throw error;
+    }
+
+    logger.warn('verifyPortOneIdentity network error - retrying once', {
+      component: 'portOneIdentityService',
+      error: error instanceof Error ? error.message : String(error),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    const response = await verifyIdentity(payload);
+    return response.data;
+  }
+}
+
+export async function callVerifyAndSavePortOneProfile(
+  payload: VerifyAndSavePortOneProfilePayload
+): Promise<VerifyAndSavePortOneProfileResult> {
+  const verifyAndSave = httpsCallable<
+    VerifyAndSavePortOneProfilePayload,
+    VerifyAndSavePortOneProfileResult
+  >(getFirebaseFunctions(), 'verifyAndSavePortOneProfile');
+
+  try {
+    const response = await verifyAndSave(payload);
+    return response.data;
+  } catch (error) {
+    if (!isRetryableError(error)) {
+      throw error;
+    }
+
+    logger.warn('verifyAndSavePortOneProfile network error - retrying once', {
+      component: 'portOneIdentityService',
+      error: error instanceof Error ? error.message : String(error),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    const response = await verifyAndSave(payload);
+    return response.data;
+  }
+}

--- a/uniqn-mobile/src/services/auth/socialLoginService.ts
+++ b/uniqn-mobile/src/services/auth/socialLoginService.ts
@@ -48,6 +48,7 @@ import {
   type SocialProfileData,
   callVerifyAndSaveProfile,
 } from './authTypes';
+import { callVerifyAndSavePortOneProfile } from './portOneIdentityService';
 import { requestAppleAuthorization } from './appleAuthService';
 import { getUserProfile } from './userProfileService';
 
@@ -1005,18 +1006,28 @@ export async function completeSocialProfile(
     // 공통 CF 호출: 서버사이드 phone 검증 + Firestore 저장 + Claims 설정
     // 프로필(닉네임 등)은 가입 후 profile-setup 화면에서 입력
     protectAuthFlow(uid, 'social_signup', SOCIAL_SIGNUP_FLOW_PROTECTION_TTL_MS);
-    await callVerifyAndSaveProfile({
-      verifiedPhone: data.phone,
-      name: data.name,
-      birthDate: data.birthDate,
-      gender: data.gender,
-      termsAgreed: data.termsAgreed,
-      privacyAgreed: data.privacyAgreed,
-      marketingAgreed: data.marketingAgreed ?? false,
-      mode: 'social',
-      verificationId: data.verificationId,
-      otpCode: data.otpCode,
-    });
+    if (data.identityVerificationId) {
+      await callVerifyAndSavePortOneProfile({
+        identityVerificationId: data.identityVerificationId,
+        termsAgreed: data.termsAgreed,
+        privacyAgreed: data.privacyAgreed,
+        marketingAgreed: data.marketingAgreed ?? false,
+        mode: 'social',
+      });
+    } else {
+      await callVerifyAndSaveProfile({
+        verifiedPhone: data.phone,
+        name: data.name,
+        birthDate: data.birthDate,
+        gender: data.gender,
+        termsAgreed: data.termsAgreed,
+        privacyAgreed: data.privacyAgreed,
+        marketingAgreed: data.marketingAgreed ?? false,
+        mode: 'social',
+        verificationId: data.verificationId,
+        otpCode: data.otpCode,
+      });
+    }
 
     // Custom Claims 갱신 (CF가 setCustomUserClaims 호출 후, 클라이언트 토큰 새로고침)
     try {

--- a/uniqn-mobile/src/types/index.ts
+++ b/uniqn-mobile/src/types/index.ts
@@ -37,6 +37,7 @@ export type {
 export type {
   UserProfile,
   FirestoreUserProfile,
+  PortOneIdentityProfile,
   EditableProfileFields,
   ProfileViewFields,
   MyDataEditableFields,

--- a/uniqn-mobile/src/types/user.ts
+++ b/uniqn-mobile/src/types/user.ts
@@ -19,6 +19,19 @@ import type { UserRole } from './role';
 // Core Types
 // ============================================================================
 
+export interface PortOneIdentityProfile<T = Date> {
+  provider: 'portone';
+  channel: 'inicis_unified';
+  identityVerificationId: string;
+  verifiedAt: T;
+  name: string;
+  birthDate: string;
+  gender?: 'male' | 'female';
+  phoneNumber?: string;
+  ciHash?: string;
+  isForeigner?: boolean;
+}
+
 /**
  * 사용자 프로필
  *
@@ -50,6 +63,14 @@ export interface UserProfile<T = Date> {
   // 전화번호 인증 (Firebase Phone Auth)
   /** 전화번호 인증 완료 여부 */
   phoneVerified?: boolean;
+  /** 포트원 본인인증 완료 여부 */
+  identityVerified?: boolean;
+  /** 포트원 본인인증 완료 시간 */
+  identityVerifiedAt?: T;
+  /** 본인인증 제공 서비스 */
+  identityProvider?: 'portone_inicis';
+  /** 본인인증 원본 데이터 */
+  identity?: PortOneIdentityProfile<T>;
 
   // 추가 정보
   /** 성별 (회원가입 Step2 입력, 수정 불가) */

--- a/uniqn-mobile/src/utils/profileConverter.ts
+++ b/uniqn-mobile/src/utils/profileConverter.ts
@@ -39,6 +39,21 @@ export function toStoreProfile(profile: {
   role: string;
   photoURL?: string | null;
   phoneVerified?: boolean;
+  identityVerified?: boolean;
+  identityVerifiedAt?: unknown;
+  identityProvider?: 'portone_inicis';
+  identity?: {
+    provider: 'portone';
+    channel: 'inicis_unified';
+    identityVerificationId: string;
+    verifiedAt: unknown;
+    name: string;
+    birthDate: string;
+    gender?: 'male' | 'female';
+    phoneNumber?: string;
+    ciHash?: string;
+    isForeigner?: boolean;
+  };
   birthDate?: string;
   gender?: 'male' | 'female';
   socialProvider?: string;
@@ -76,6 +91,17 @@ export function toStoreProfile(profile: {
     role: profile.role as UserProfile['role'],
     photoURL: profile.photoURL,
     phoneVerified: profile.phoneVerified,
+    identityVerified: profile.identityVerified,
+    identityVerifiedAt: profile.identityVerifiedAt
+      ? toOptionalDate(profile.identityVerifiedAt)
+      : undefined,
+    identityProvider: profile.identityProvider,
+    identity: profile.identity
+      ? {
+          ...profile.identity,
+          verifiedAt: toRequiredDate(profile.identity.verifiedAt),
+        }
+      : undefined,
     birthDate: profile.birthDate,
     gender: profile.gender,
     socialProvider: profile.socialProvider as UserProfile['socialProvider'],


### PR DESCRIPTION
## Summary
- Firebase Functions: `verifyPortOneIdentity` / `verifyAndSavePortOneProfile` 콜러블 추가
- 모바일: `PortOneIdentityVerification` 컴포넌트(native/web) 및 서비스 계층 신규
- 회원가입 본인인증 단계 연동 (일반/구인자)
- `UserProfile.identity` + `PortOneIdentityProfile` 타입 추가

## Scope
27 files changed · +1,708 / -70

## Quality Gate
- ✅ `npm run quality`
- ✅ `functions: npm run build`