### PR TITLE
fix(repo): EventQR/Admin 컬럼 누락 + templateService Firebase 잔재 제거

### DIFF
--- a/uniqn-mobile/src/repositories/supabase/AdminRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/AdminRepository.ts
@@ -34,7 +34,7 @@ const TABLES = {
   REPORTS: 'reports',
 } as const;
 const USER_COLUMNS =
-  'id,name,email,role,phone,photo_url,created_at,updated_at,is_active,phone_verified' as const;
+  'id,name,email,role,phone,photo_url,created_at,updated_at,is_active,phone_verified,last_login_at' as const;
 
 // ============================================================================
 // Helpers

--- a/uniqn-mobile/src/repositories/supabase/EventQRRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/EventQRRepository.ts
@@ -25,7 +25,7 @@ const TABLES = {
   EVENT_QR_CODES: 'event_qr_codes',
 } as const;
 const TABLE_COLUMNS =
-  'id,code,created_at,expires_at,is_active,job_posting_id,type,user_id,work_date' as const;
+  'id,code,created_at,expires_at,is_active,job_posting_id,type,user_id,work_date,assignment_group_id,time_slot' as const;
 
 // ============================================================================
 // Helpers

--- a/uniqn-mobile/src/services/jobs/__tests__/templateService.test.ts
+++ b/uniqn-mobile/src/services/jobs/__tests__/templateService.test.ts
@@ -102,16 +102,6 @@ describe('templateService', () => {
       expect(result).toEqual([]);
     });
 
-    it('권한 에러 시 빈 배열을 반환해야 한다', async () => {
-      const permissionError = new Error('permission denied') as Error & { code?: string };
-      permissionError.code = 'permission-denied';
-      mockRepo.getTemplates.mockRejectedValue(permissionError);
-
-      const result = await getTemplates('new-user');
-
-      expect(result).toEqual([]);
-    });
-
     it('기타 에러 시 handleServiceError를 호출해야 한다', async () => {
       const genericError = new Error('Unknown error');
       mockRepo.getTemplates.mockRejectedValue(genericError);

--- a/uniqn-mobile/src/services/jobs/templateService.ts
+++ b/uniqn-mobile/src/services/jobs/templateService.ts
@@ -25,11 +25,6 @@ export async function getTemplates(userId: string): Promise<JobPostingTemplate[]
   try {
     return await templateRepository.getTemplates(userId);
   } catch (error) {
-    // 권한 에러는 빈 배열 반환 (사용자 경험 개선)
-    const firebaseError = error as { code?: string };
-    if (firebaseError.code === 'permission-denied') {
-      return [];
-    }
     throw handleServiceError(error, {
       operation: '템플릿 목록 조회',
       component: 'templateService',


### PR DESCRIPTION
## Summary
- T-C1: `EventQRRepository` `TABLE_COLUMNS`에 `assignment_group_id`, `time_slot` 추가 → WF-10 scope 필터 복원
- T-C2: `AdminRepository` `USER_COLUMNS`에 `last_login_at` 추가 → WF-17 관리자 상세 표시
- T-C3: `templateService.ts` Firebase `permission-denied` 분기 3줄 제거 (Supabase 전환 후 dead code) → WF-19

## Test plan
- [x] `npm run quality` PASS (type-check + lint + format)
- [x] `npm test -- templateService` 24/24 PASS
- [x] Firebase permission-denied 전용 테스트 케이스 제거 (dead code에 대한 테스트)
- [ ] 머지 후 WF-10 QR 스캔, WF-17 관리자 사용자 목록 수동 확인 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)