### PR TITLE
feat(edge): T-A3 notification counter Edge Function 3개 회수

### DIFF
--- a/uniqn-mobile/supabase/functions/decrement-unread-counter/index.ts
+++ b/uniqn-mobile/supabase/functions/decrement-unread-counter/index.ts
@@ -1,0 +1,75 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: '인증이 필요합니다' }), {
+        status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+    );
+
+    const userClient = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!,
+      { global: { headers: { Authorization: authHeader } } },
+    );
+    const { data: { user }, error: authError } = await userClient.auth.getUser();
+    if (authError || !user) {
+      return new Response(JSON.stringify({ error: '인증 실패' }), {
+        status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { delta } = await req.json();
+    const decrementBy = typeof delta === 'number' && delta >= 1 && delta <= 1000 ? Math.floor(delta) : 1;
+
+    // users 테이블의 unread_count 감소 (최소 0)
+    const { error: updateError } = await supabase.rpc('decrement_unread_counter', {
+      p_user_id: user.id,
+      p_delta: decrementBy,
+    });
+
+    if (updateError) {
+      // RPC가 없으면 직접 UPDATE
+      const { data: userData } = await supabase
+        .from('users')
+        .select('unread_notification_count')
+        .eq('id', user.id)
+        .single();
+
+      const currentCount = userData?.unread_notification_count ?? 0;
+      const newCount = Math.max(0, currentCount - decrementBy);
+
+      await supabase
+        .from('users')
+        .update({ unread_notification_count: newCount })
+        .eq('id', user.id);
+    }
+
+    return new Response(
+      JSON.stringify({ success: true }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: error instanceof Error ? error.message : '알 수 없는 오류' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+});

--- a/uniqn-mobile/supabase/functions/initialize-unread-counter/index.ts
+++ b/uniqn-mobile/supabase/functions/initialize-unread-counter/index.ts
@@ -1,0 +1,75 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: CORS_HEADERS });
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+
+    // 인증 헤더가 없으면 0을 반환 (graceful 캘덙)
+    if (!authHeader) {
+      return new Response(JSON.stringify({ unreadCount: 0 }), {
+        headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_ANON_KEY') ?? '',
+      { global: { headers: { Authorization: authHeader } } }
+    );
+
+    // 세션에서 사용자 확인
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    // 인증 안된 사용자면 0을 반환 (graceful 캘덙)
+    if (authError || !user) {
+      return new Response(JSON.stringify({ unreadCount: 0 }), {
+        headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // notification_counters 테이블에서 캐시된 카운터 조회
+    const { data: counterRow } = await supabase
+      .from('notification_counters')
+      .select('unread_count')
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    if (counterRow !== null) {
+      return new Response(JSON.stringify({ unreadCount: counterRow.unread_count ?? 0 }), {
+        headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // 캐시 없으면 notifications 테이블에서 직접 계산
+    const { data: countResult } = await supabase.rpc('get_unread_notification_count', {
+      p_user_id: user.id,
+    });
+
+    const unreadCount = (countResult as number) ?? 0;
+
+    // 계산 결과를 notification_counters에 upsert
+    await supabase
+      .from('notification_counters')
+      .upsert({ user_id: user.id, unread_count: unreadCount, updated_at: new Date().toISOString() });
+
+    return new Response(JSON.stringify({ unreadCount }), {
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('initialize-unread-counter error:', err);
+    // 에러 시에도 0으로 graceful 캘낙
+    return new Response(JSON.stringify({ unreadCount: 0 }), {
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/uniqn-mobile/supabase/functions/reset-unread-counter/index.ts
+++ b/uniqn-mobile/supabase/functions/reset-unread-counter/index.ts
@@ -1,0 +1,80 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: '인증이 필요합니다' }), {
+        status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+    );
+
+    const userClient = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!,
+      { global: { headers: { Authorization: authHeader } } },
+    );
+    const { data: { user }, error: authError } = await userClient.auth.getUser();
+    if (authError || !user) {
+      return new Response(JSON.stringify({ error: '인증 실패' }), {
+        status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // 카운터를 0으로 리셋
+    const { error: updateError } = await supabase
+      .from('users')
+      .update({ unread_notification_count: 0 })
+      .eq('id', user.id);
+
+    if (updateError) {
+      return new Response(JSON.stringify({ error: '카운터 리셋 실패' }), {
+        status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // 선택적: 알림의 _batchUpdate 플래그 정리
+    const body = await req.json().catch(() => ({}));
+    const notificationIds = body?.notificationIds;
+    if (Array.isArray(notificationIds) && notificationIds.length > 0) {
+      const validIds = notificationIds
+        .filter((id: unknown) => typeof id === 'string' && id.length <= 128)
+        .slice(0, 500);
+
+      if (validIds.length > 0) {
+        // 모든 알림을 읽음 처리
+        await supabase
+          .from('notifications')
+          .update({ is_read: true })
+          .eq('recipient_id', user.id)
+          .in('id', validIds)
+          .then(() => {});
+      }
+    }
+
+    return new Response(
+      JSON.stringify({ success: true }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: error instanceof Error ? error.message : '알 수 없는 오류' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+});


### PR DESCRIPTION
## Summary

T-A3: 운영 Supabase에서 notification counter 관련 Edge Function 3개 회수 및 로컬 보존.

- **reset-unread-counter** (v1, ACTIVE) — FOUND in production
  - `users.unread_notification_count` 를 0으로 리셋
  - 선택적 `notificationIds` 전달 시 `notifications.is_read = true` 일괄 처리
  - CORS, JWT 인증, 입력 검증 포함

- **decrement-unread-counter** (v1, ACTIVE) — FOUND in production
  - `decrement_unread_counter` RPC 호출 (floor 0 보장)
  - RPC 실패 시 `users.unread_notification_count` 직접 UPDATE fallback
  - delta 범위 검증 (1~1000)

- **initialize-unread-counter** (v2, ACTIVE, verify_jwt=false) — FOUND in production
  - `notification_counters` 캐시 조회 우선
  - 캐시 없으면 `get_unread_notification_count` RPC로 계산 후 upsert
  - 비인증 요청은 graceful하게 `{ unreadCount: 0 }` 반환

- **tsconfig.json**: `supabase/functions` 제외 추가 (Deno 런타임 모듈 tsc 오류 방지)
- **eslint.config.js**: `supabase/functions` 무시 추가 (Deno JSR import ESLint 오류 방지)

## Test plan

- [ ] `deploy_edge_function` 은 이 PR 승인 후 별도로 진행
- [ ] 함수별 계약: reset=POST /functions/v1/reset-unread-counter, decrement=POST /functions/v1/decrement-unread-counter, initialize=POST /functions/v1/initialize-unread-counter
- [ ] `initialize-unread-counter` 는 `verify_jwt: false` — 앱 시작 시 비인증 상태에서도 호출 가능 확인
- [ ] pre-push quality gate 통과 확인 (lint + format:check 클린)

🤖 Generated with [Claude Code](https://claude.com/claude-code)