### PR TITLE
fix(hooks): pre-commit hook worktree repoRoot 동적 해석

### DIFF
--- a/scripts/git-hooks/pre-commit.js
+++ b/scripts/git-hooks/pre-commit.js
@@ -40,13 +40,17 @@ function main() {
     return;
   }
 
+  const path = require('path');
+
   const eslintTargets = mobileFiles
     .filter((file) => matchesExtension(file, ESLINT_EXTENSIONS))
-    .map((file) => relativeTo(uniqnMobileDir, file));
+    .map((file) => relativeTo(uniqnMobileDir, file))
+    .filter((rel) => fileExists(path.join(uniqnMobileDir, rel)));
 
   const prettierTargets = mobileFiles
     .filter((file) => matchesExtension(file, PRETTIER_EXTENSIONS))
-    .map((file) => relativeTo(uniqnMobileDir, file));
+    .map((file) => relativeTo(uniqnMobileDir, file))
+    .filter((rel) => fileExists(path.join(uniqnMobileDir, rel)));
 
   if (eslintTargets.length > 0) {
     console.log(`[hook] pre-commit: ESLint --fix (${eslintTargets.length}개 파일)`);

--- a/scripts/git-hooks/shared.js
+++ b/scripts/git-hooks/shared.js
@@ -1,10 +1,26 @@
 #!/usr/bin/env node
 
-const { spawnSync } = require('child_process');
+const { spawnSync, execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-const repoRoot = path.resolve(__dirname, '..', '..');
+// Resolve repoRoot from the active git working tree (cwd), not from __dirname.
+// Git invokes hooks with cwd = worktree top, so `git rev-parse --show-toplevel`
+// returns the correct worktree path even when this script lives in main repo.
+function resolveRepoRoot() {
+  try {
+    const top = execSync('git rev-parse --show-toplevel', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (top) return path.normalize(top);
+  } catch {
+    // fall through
+  }
+  return process.cwd();
+}
+
+const repoRoot = resolveRepoRoot();
 const uniqnMobileDir = path.join(repoRoot, 'uniqn-mobile');
 const functionsDir = path.join(repoRoot, 'functions');
 


### PR DESCRIPTION
## Summary
- `shared.js`의 `repoRoot`를 `git rev-parse --show-toplevel`로 동적 해석
- worktree에서 hook 실행 시 main repo가 아닌 현재 worktree를 대상으로 동작
- `pre-commit.js`에 fileExists 가드 보강

## Root cause
`.git/hooks/pre-commit` 래퍼는 main repo의 `scripts/git-hooks/pre-commit.js`를 `require`하므로, 워크트리에서 git hook이 호출돼도 `__dirname` 기준 `repoRoot`는 항상 main repo로 해석됨. 결과적으로 `getStagedFiles()`가 워크트리의 staged 파일을 못 보고, 재스테이징 시 `git add`가 main repo에서 실행돼 워크트리의 새 파일을 unstage 하는 현상 발생.

## Fix
git CLI는 hook 실행 시 cwd를 워크트리 top으로 설정하므로, `git rev-parse --show-toplevel`이 정확한 워크트리 경로를 반환. shared.js가 이 값을 사용하면 모든 후속 git/path 연산이 올바른 워크트리를 대상으로 실행됨.

## Discovery
PR #22 (W3.1 cancel_application_atomically) 작성 중 W3.1 agent가 `--no-verify`로 우회해야 했던 그 버그입니다.

## Test plan
- [x] main repo cwd에서 `repoRoot` = `T-HOLDEM` 확인
- [x] worktree cwd에서 main repo의 `shared.js` 로드 시 `repoRoot` = worktree path 확인
- [x] 본 PR 자체가 fixed hook으로 commit 성공 (hook 출력 정상)
- [ ] 향후 worktree에서 신규 파일 commit 정상 동작 확인 (다음 worktree 작업 시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)