### PR TITLE
feat(atomicity): outbox 패턴 + sync_schedule_board RPC root fix (W3.3 복구 + 강화)

### DIFF
--- a/uniqn-mobile/src/services/jobs/__tests__/jobManagementService.outbox.test.ts
+++ b/uniqn-mobile/src/services/jobs/__tests__/jobManagementService.outbox.test.ts
@@ -1,0 +1,220 @@
+/**
+ * T-B8 회귀: jobManagementService → schedule_board_sync_outbox enqueue 검증
+ *
+ * 기존 syncScheduleBoardSafely (fire-and-forget)가 outbox insert로 교체되었음을 확인.
+ * 6개 mutation이 각각 올바른 action으로 outbox에 row를 enqueue하는지 검증.
+ */
+
+import {
+  bulkUpdateJobPostingStatus,
+  closeJobPosting,
+  createJobPosting,
+  deleteJobPosting,
+  reopenJobPosting,
+  updateJobPosting,
+} from '@/services/jobs/jobManagementService';
+import type { CreateJobPostingInput, JobPosting, StaffRole } from '@/types';
+import { JOB_POSTING_SCHEMA_VERSION } from '@/types/jobPosting';
+
+const mockCreateWithTransaction = jest.fn();
+const mockUpdateWithTransaction = jest.fn();
+const mockDeleteWithTransaction = jest.fn();
+const mockCloseWithTransaction = jest.fn();
+const mockReopenWithTransaction = jest.fn();
+const mockBulkUpdateStatus = jest.fn();
+const mockOutboxInsert = jest.fn();
+
+jest.mock('@/repositories', () => ({
+  jobPostingRepository: {
+    createWithTransaction: (...args: unknown[]) => mockCreateWithTransaction(...args),
+    updateWithTransaction: (...args: unknown[]) => mockUpdateWithTransaction(...args),
+    deleteWithTransaction: (...args: unknown[]) => mockDeleteWithTransaction(...args),
+    closeWithTransaction: (...args: unknown[]) => mockCloseWithTransaction(...args),
+    reopenWithTransaction: (...args: unknown[]) => mockReopenWithTransaction(...args),
+    bulkUpdateStatus: (...args: unknown[]) => mockBulkUpdateStatus(...args),
+    getStatsByOwnerId: jest.fn(),
+    getById: jest.fn(),
+    updateStatus: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn((table: string) => {
+      if (table === 'schedule_board_sync_outbox') {
+        return {
+          insert: (...args: unknown[]) => {
+            mockOutboxInsert(...args);
+            return Promise.resolve({ error: null });
+          },
+        };
+      }
+      return {
+        insert: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        update: jest.fn().mockReturnThis(),
+        delete: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+      };
+    }),
+  },
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('@/errors/serviceErrorHandler', () => ({
+  handleServiceError: jest.fn((error: unknown) =>
+    error instanceof Error ? error : new Error(String(error))
+  ),
+}));
+
+function createInput(): CreateJobPostingInput {
+  return {
+    postingType: 'regular',
+    title: 'Test Job',
+    description: 'Description',
+    location: { name: 'Seoul', address: '강남' },
+    schedule: {
+      kind: 'dated',
+      primaryDate: '2026-04-15',
+      allDates: ['2026-04-15'],
+      requirements: [
+        {
+          date: '2026-04-15',
+          timeSlots: [
+            {
+              startTime: '18:00',
+              roles: [{ role: 'dealer' as StaffRole, count: 1, filled: 0 }],
+            },
+          ],
+        },
+      ],
+    },
+    roleCatalog: [{ role: 'dealer' as StaffRole, salary: { type: 'hourly', amount: 15000 } }],
+    compensation: { mode: 'by_role' },
+    questions: { items: [] },
+  };
+}
+
+function createPosting(): JobPosting {
+  return {
+    id: 'job-test-1',
+    schemaVersion: JOB_POSTING_SCHEMA_VERSION,
+    title: 'Test Job',
+    description: 'Description',
+    status: 'active',
+    ownerId: 'employer-1',
+    ownerName: 'Owner',
+    postingType: 'regular',
+    workDate: '2026-04-15',
+    workDates: ['2026-04-15'],
+    roleKeys: ['dealer'],
+    totalPositions: 1,
+    filledPositions: 0,
+    viewCount: 0,
+    stats: {
+      totalApplicants: 0,
+      activeApplicants: 0,
+      confirmedApplicants: 0,
+      cancellationPendingApplicants: 0,
+      filledPositions: 0,
+    },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    location: { name: 'Seoul', address: '강남' },
+    schedule: createInput().schedule,
+    roleCatalog: createInput().roleCatalog,
+    compensation: createInput().compensation,
+    questions: createInput().questions,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('jobManagementService — outbox enqueue', () => {
+  it('createJobPosting → enqueue create', async () => {
+    mockCreateWithTransaction.mockResolvedValue({ id: 'job-1', jobPosting: createPosting() });
+    await createJobPosting(createInput(), 'employer-1', 'Owner');
+
+    expect(mockOutboxInsert).toHaveBeenCalledTimes(1);
+    expect(mockOutboxInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        job_posting_id: 'job-1',
+        action: 'create',
+        status: 'pending',
+        retry_count: 0,
+      })
+    );
+  });
+
+  it('updateJobPosting → enqueue update', async () => {
+    mockUpdateWithTransaction.mockResolvedValue(createPosting());
+    await updateJobPosting('job-2', {} as never, 'employer-1');
+
+    expect(mockOutboxInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ job_posting_id: 'job-2', action: 'update' })
+    );
+  });
+
+  it('deleteJobPosting → enqueue delete', async () => {
+    mockDeleteWithTransaction.mockResolvedValue(undefined);
+    await deleteJobPosting('job-3', 'employer-1');
+
+    expect(mockOutboxInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ job_posting_id: 'job-3', action: 'delete' })
+    );
+  });
+
+  it('closeJobPosting → enqueue close', async () => {
+    mockCloseWithTransaction.mockResolvedValue(undefined);
+    await closeJobPosting('job-4', 'employer-1');
+
+    expect(mockOutboxInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ job_posting_id: 'job-4', action: 'close' })
+    );
+  });
+
+  it('reopenJobPosting → enqueue reopen', async () => {
+    mockReopenWithTransaction.mockResolvedValue(undefined);
+    await reopenJobPosting('job-5', 'employer-1');
+
+    expect(mockOutboxInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ job_posting_id: 'job-5', action: 'reopen' })
+    );
+  });
+
+  it('bulkUpdateJobPostingStatus(closed) → enqueue close per id', async () => {
+    mockBulkUpdateStatus.mockResolvedValue(2);
+    await bulkUpdateJobPostingStatus(['job-a', 'job-b'], 'closed', 'employer-1');
+
+    expect(mockOutboxInsert).toHaveBeenCalledTimes(2);
+    expect(mockOutboxInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ job_posting_id: 'job-a', action: 'close' })
+    );
+    expect(mockOutboxInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ job_posting_id: 'job-b', action: 'close' })
+    );
+  });
+
+  it('bulkUpdateJobPostingStatus(active) → enqueue reopen per id', async () => {
+    mockBulkUpdateStatus.mockResolvedValue(1);
+    await bulkUpdateJobPostingStatus(['job-c'], 'active', 'employer-1');
+
+    expect(mockOutboxInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ job_posting_id: 'job-c', action: 'reopen' })
+    );
+  });
+
+  it('bulkUpdateJobPostingStatus(draft) → enqueue update per id', async () => {
+    mockBulkUpdateStatus.mockResolvedValue(1);
+    await bulkUpdateJobPostingStatus(['job-d'], 'draft', 'employer-1');
+
+    expect(mockOutboxInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ job_posting_id: 'job-d', action: 'update' })
+    );
+  });
+});

--- a/uniqn-mobile/src/services/jobs/jobManagementService.ts
+++ b/uniqn-mobile/src/services/jobs/jobManagementService.ts
@@ -1,11 +1,7 @@
 import { logger } from '@/utils/logger';
 import { handleServiceError } from '@/errors/serviceErrorHandler';
 import { jobPostingRepository } from '@/repositories';
-import {
-  archiveScheduleBoard,
-  syncScheduleBoardByJobPostingId,
-  syncScheduleBoardForJobPosting,
-} from '@/services/boardService';
+import { supabase } from '@/lib/supabase';
 import type { TaxSettings } from '@/utils/settlement';
 import type { CreateJobPostingResult, JobPostingStats } from '@/repositories';
 import type {
@@ -17,17 +13,38 @@ import type {
 
 export type { CreateJobPostingResult, JobPostingStats };
 
-async function syncScheduleBoardSafely(
-  task: () => Promise<unknown>,
-  context: Record<string, unknown>
-) {
-  try {
-    await task();
-  } catch (error) {
-    logger.warn('Schedule board sync failed', {
+// =============================================================================
+// T-B7+B8: schedule_board_sync_outbox 패턴
+// =============================================================================
+// fire-and-forget syncScheduleBoardSafely 제거. 모든 board sync 의도를
+// outbox 테이블에 영속화하고 sync-schedule-board-outbox Edge Function이
+// poll → sync_schedule_board RPC 호출 → status 업데이트로 처리.
+// =============================================================================
+
+type ScheduleBoardSyncAction = 'create' | 'update' | 'delete' | 'close' | 'reopen';
+
+async function enqueueScheduleBoardSync(
+  jobPostingId: string,
+  action: ScheduleBoardSyncAction,
+  payload: Record<string, unknown> = {}
+): Promise<void> {
+  const { error } = await supabase.from('schedule_board_sync_outbox').insert({
+    job_posting_id: jobPostingId,
+    action,
+    payload,
+    status: 'pending',
+    retry_count: 0,
+  });
+
+  if (error) {
+    // outbox insert 실패는 main mutation을 롤백시키지 않음.
+    // 사용자 경험 보호 차원에서 warn 로그만 남기고, outbox failed_retry_limit
+    // 모니터링 + 수동 백필이 안전망. 이는 아키텍처 결정.
+    logger.warn('Schedule board sync enqueue 실패', {
       component: 'jobManagementService',
-      ...context,
-      error: error instanceof Error ? error.message : String(error),
+      jobPostingId,
+      action,
+      error: error.message,
     });
   }
 }
@@ -50,10 +67,9 @@ export async function createJobPosting(
 ): Promise<CreateJobPostingResult> {
   try {
     const result = await createSinglePosting(input, ownerId, ownerName);
-    await syncScheduleBoardSafely(() => syncScheduleBoardForJobPosting(result.jobPosting), {
+    await enqueueScheduleBoardSync(result.id, 'create', {
       jobPostingId: result.id,
       ownerId,
-      action: 'create',
     });
     return result;
   } catch (error) {
@@ -74,11 +90,7 @@ export async function updateJobPosting(
     logger.info('공고 수정 시작', { jobPostingId, ownerId });
 
     const result = await jobPostingRepository.updateWithTransaction(jobPostingId, input, ownerId);
-    await syncScheduleBoardSafely(() => syncScheduleBoardForJobPosting(result), {
-      jobPostingId,
-      ownerId,
-      action: 'update',
-    });
+    await enqueueScheduleBoardSync(jobPostingId, 'update', { jobPostingId, ownerId });
 
     logger.info('공고 수정 완료', { jobPostingId });
     return result;
@@ -95,11 +107,7 @@ export async function deleteJobPosting(jobPostingId: string, ownerId: string): P
   try {
     logger.info('공고 삭제 시작', { jobPostingId, ownerId });
     await jobPostingRepository.deleteWithTransaction(jobPostingId, ownerId);
-    await syncScheduleBoardSafely(() => archiveScheduleBoard(jobPostingId), {
-      jobPostingId,
-      ownerId,
-      action: 'delete',
-    });
+    await enqueueScheduleBoardSync(jobPostingId, 'delete', { jobPostingId, ownerId });
     logger.info('공고 삭제 완료', { jobPostingId });
   } catch (error) {
     throw handleServiceError(error, {
@@ -114,11 +122,7 @@ export async function closeJobPosting(jobPostingId: string, ownerId: string): Pr
   try {
     logger.info('공고 마감 시작', { jobPostingId, ownerId });
     await jobPostingRepository.closeWithTransaction(jobPostingId, ownerId);
-    await syncScheduleBoardSafely(() => syncScheduleBoardByJobPostingId(jobPostingId), {
-      jobPostingId,
-      ownerId,
-      action: 'close',
-    });
+    await enqueueScheduleBoardSync(jobPostingId, 'close', { jobPostingId, ownerId });
     logger.info('공고 마감 완료', { jobPostingId });
   } catch (error) {
     throw handleServiceError(error, {
@@ -133,11 +137,7 @@ export async function reopenJobPosting(jobPostingId: string, ownerId: string): P
   try {
     logger.info('공고 재오픈 시작', { jobPostingId, ownerId });
     await jobPostingRepository.reopenWithTransaction(jobPostingId, ownerId);
-    await syncScheduleBoardSafely(() => syncScheduleBoardByJobPostingId(jobPostingId), {
-      jobPostingId,
-      ownerId,
-      action: 'reopen',
-    });
+    await enqueueScheduleBoardSync(jobPostingId, 'reopen', { jobPostingId, ownerId });
     logger.info('공고 재오픈 완료', { jobPostingId });
   } catch (error) {
     throw handleServiceError(error, {
@@ -163,6 +163,23 @@ export async function getMyJobPostingStats(ownerId: string): Promise<JobPostingS
   }
 }
 
+/**
+ * bulkUpdateJobPostingStatus의 status별 outbox action 매핑.
+ *
+ * outbox CHECK 제약(create/update/delete/close/reopen)이 'bulk-status'를 허용하지
+ * 않으므로 status 값으로 분기:
+ * - closed → close
+ * - active → reopen (재오픈 의도)
+ * - 그 외 → update (단순 상태 변경)
+ *
+ * 처리 자체는 sync_schedule_board RPC가 현재 DB 상태로부터 멱등하게 수행.
+ */
+function bulkActionFor(status: JobPostingStatus): ScheduleBoardSyncAction {
+  if (status === 'closed') return 'close';
+  if (status === 'active') return 'reopen';
+  return 'update';
+}
+
 export async function bulkUpdateJobPostingStatus(
   jobPostingIds: string[],
   status: JobPostingStatus,
@@ -176,14 +193,11 @@ export async function bulkUpdateJobPostingStatus(
       status,
       ownerId
     );
+
+    const action = bulkActionFor(status);
     await Promise.all(
       jobPostingIds.map((jobPostingId) =>
-        syncScheduleBoardSafely(() => syncScheduleBoardByJobPostingId(jobPostingId), {
-          jobPostingId,
-          ownerId,
-          action: 'bulk-status',
-          status,
-        })
+        enqueueScheduleBoardSync(jobPostingId, action, { jobPostingId, status, ownerId })
       )
     );
 

--- a/uniqn-mobile/supabase/functions/sync-schedule-board-outbox/index.ts
+++ b/uniqn-mobile/supabase/functions/sync-schedule-board-outbox/index.ts
@@ -1,0 +1,197 @@
+// =============================================================================
+// T-B9: sync-schedule-board-outbox Edge Function
+// =============================================================================
+// 목적: schedule_board_sync_outbox 테이블의 pending 행을 처리. 각 행에 대해
+//       sync_schedule_board(p_job_posting_id) PL/pgSQL RPC를 호출하여 board sync
+//       자체는 단일 트랜잭션으로 race-free 실행. 본 함수는 polling + retry +
+//       status 전이만 책임짐.
+//
+// 호출 방식:
+//   - 수동: curl -X POST <function_url> (admin/cron)
+//   - 자동: Supabase scheduled function (cron) — 30초 주기 권장
+//
+// 인증: Authorization 헤더 검증. service_role 키 필요 (cron은 자동 첨부).
+// =============================================================================
+
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient, SupabaseClient } from 'jsr:@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+const BATCH_SIZE = 10;
+const MAX_RETRY = 3;
+
+interface OutboxRow {
+  id: string;
+  job_posting_id: string;
+  action: string;
+  payload: Record<string, unknown>;
+  status: string;
+  retry_count: number;
+  error_message: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ProcessResult {
+  id: string;
+  job_posting_id: string;
+  outcome: 'success' | 'retry' | 'failed_retry_limit';
+  error?: string;
+  retry_count?: number;
+}
+
+async function fetchPending(client: SupabaseClient): Promise<OutboxRow[]> {
+  const { data, error } = await client
+    .from('schedule_board_sync_outbox')
+    .select('*')
+    .eq('status', 'pending')
+    .order('created_at', { ascending: true })
+    .limit(BATCH_SIZE);
+
+  if (error) {
+    throw new Error(`outbox fetch failed: ${error.message}`);
+  }
+  return (data ?? []) as OutboxRow[];
+}
+
+async function markProcessing(client: SupabaseClient, id: string): Promise<void> {
+  const { error } = await client
+    .from('schedule_board_sync_outbox')
+    .update({ status: 'processing', updated_at: new Date().toISOString() })
+    .eq('id', id)
+    .eq('status', 'pending'); // optimistic — 이미 다른 worker가 처리 중이면 no-op
+  if (error) throw new Error(`mark processing failed: ${error.message}`);
+}
+
+async function applySync(client: SupabaseClient, jobPostingId: string): Promise<void> {
+  // 핵심: sync_schedule_board RPC가 board_posts + board_memberships를
+  // 단일 PostgreSQL 트랜잭션으로 처리. race-free root resolution.
+  const { data, error } = await client.rpc('sync_schedule_board', {
+    p_job_posting_id: jobPostingId,
+  });
+
+  if (error) {
+    throw new Error(`sync_schedule_board RPC failed: ${error.message}`);
+  }
+
+  const result = data as { success?: boolean; archived?: boolean; error?: string } | null;
+  if (!result?.success) {
+    throw new Error(`sync_schedule_board returned non-success: ${JSON.stringify(result)}`);
+  }
+}
+
+async function markSuccess(client: SupabaseClient, id: string): Promise<void> {
+  const { error } = await client
+    .from('schedule_board_sync_outbox')
+    .update({
+      status: 'success',
+      error_message: null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', id);
+  if (error) throw new Error(`mark success failed: ${error.message}`);
+}
+
+async function markRetryOrFailed(
+  client: SupabaseClient,
+  id: string,
+  currentRetryCount: number,
+  errorMessage: string
+): Promise<'retry' | 'failed_retry_limit'> {
+  const nextRetryCount = currentRetryCount + 1;
+  const reachedLimit = nextRetryCount > MAX_RETRY;
+  const nextStatus = reachedLimit ? 'failed_retry_limit' : 'pending';
+
+  const { error } = await client
+    .from('schedule_board_sync_outbox')
+    .update({
+      status: nextStatus,
+      retry_count: nextRetryCount,
+      error_message: errorMessage.slice(0, 1000),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', id);
+
+  if (error) throw new Error(`mark retry failed: ${error.message}`);
+  return reachedLimit ? 'failed_retry_limit' : 'retry';
+}
+
+async function processRow(client: SupabaseClient, row: OutboxRow): Promise<ProcessResult> {
+  try {
+    await markProcessing(client, row.id);
+    await applySync(client, row.job_posting_id);
+    await markSuccess(client, row.id);
+    return { id: row.id, job_posting_id: row.job_posting_id, outcome: 'success' };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const outcome = await markRetryOrFailed(client, row.id, row.retry_count, message);
+    return {
+      id: row.id,
+      job_posting_id: row.job_posting_id,
+      outcome,
+      error: message,
+      retry_count: row.retry_count + 1,
+    };
+  }
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  // 인증: Authorization 헤더 확인 (cron 또는 admin only)
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: '인증이 필요합니다' }), {
+      status: 401,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const client = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    );
+
+    const pending = await fetchPending(client);
+    if (pending.length === 0) {
+      return new Response(JSON.stringify({ processed: 0, success: 0, retried: 0, failed: 0 }), {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // 직렬 처리 — race 방지 + retry 카운터 정확성
+    const results: ProcessResult[] = [];
+    for (const row of pending) {
+      const result = await processRow(client, row);
+      results.push(result);
+    }
+
+    const summary = {
+      processed: results.length,
+      success: results.filter((r) => r.outcome === 'success').length,
+      retried: results.filter((r) => r.outcome === 'retry').length,
+      failed: results.filter((r) => r.outcome === 'failed_retry_limit').length,
+      results,
+    };
+
+    return new Response(JSON.stringify(summary), {
+      status: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('sync-schedule-board-outbox error', message);
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/uniqn-mobile/supabase/migrations/20260414120300_add_schedule_board_sync_outbox.sql
+++ b/uniqn-mobile/supabase/migrations/20260414120300_add_schedule_board_sync_outbox.sql
@@ -1,0 +1,61 @@
+-- =============================================================================
+-- T-B7: schedule_board_sync_outbox 테이블
+-- =============================================================================
+-- 목적: jobManagementService의 fire-and-forget board sync를 outbox 패턴으로
+--       대체하여 sync 실패 시 recovery 가능하게 함.
+--
+-- 참조: docs/qa/2026-04-14/team-b-atomicity-spec.md §4
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.schedule_board_sync_outbox (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_posting_id uuid NOT NULL,
+  action text NOT NULL CHECK (action IN ('create', 'update', 'delete', 'close', 'reopen')),
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  status text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'processing', 'success', 'failed_retry_limit')),
+  error_message text,
+  retry_count int NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- ON DELETE CASCADE는 의도적으로 사용하지 않음:
+-- delete 액션의 경우 job_posting 행이 이미 사라진 상태에서 outbox row가 처리되어야 함.
+-- 따라서 FK constraint도 두지 않고, RPC가 not-found 케이스를 명시적으로 처리.
+
+CREATE INDEX IF NOT EXISTS idx_schedule_board_sync_outbox_status_created
+  ON public.schedule_board_sync_outbox(status, created_at)
+  WHERE status IN ('pending', 'processing');
+
+CREATE INDEX IF NOT EXISTS idx_schedule_board_sync_outbox_job_posting
+  ON public.schedule_board_sync_outbox(job_posting_id);
+
+ALTER TABLE public.schedule_board_sync_outbox ENABLE ROW LEVEL SECURITY;
+
+-- service_role만 직접 접근. authenticated는 INSERT만 허용 (클라이언트가 enqueue).
+DROP POLICY IF EXISTS "schedule_board_sync_outbox_service_all" ON public.schedule_board_sync_outbox;
+CREATE POLICY "schedule_board_sync_outbox_service_all"
+  ON public.schedule_board_sync_outbox
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS "schedule_board_sync_outbox_authenticated_insert" ON public.schedule_board_sync_outbox;
+CREATE POLICY "schedule_board_sync_outbox_authenticated_insert"
+  ON public.schedule_board_sync_outbox
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    -- enqueue 시 status는 항상 pending이어야 함 (worker만 상태 전이)
+    status = 'pending'
+    AND retry_count = 0
+    AND error_message IS NULL
+  );
+
+GRANT INSERT ON public.schedule_board_sync_outbox TO authenticated;
+GRANT ALL ON public.schedule_board_sync_outbox TO service_role;
+
+COMMENT ON TABLE public.schedule_board_sync_outbox IS
+  'Schedule board sync 의도를 영속화하는 outbox 테이블. jobManagementService 6개 site가 작성, sync-schedule-board-outbox Edge Function이 polling으로 처리.';

--- a/uniqn-mobile/supabase/migrations/20260414120400_add_sync_schedule_board_rpc.sql
+++ b/uniqn-mobile/supabase/migrations/20260414120400_add_sync_schedule_board_rpc.sql
@@ -1,0 +1,295 @@
+-- =============================================================================
+-- Root fix: sync_schedule_board(uuid) PL/pgSQL RPC
+-- =============================================================================
+-- 목적: board_posts + board_memberships sync를 단일 PostgreSQL 트랜잭션으로
+--       처리. 기존 boardService.syncScheduleBoardForJobPosting (TS)의 SQL 포팅.
+--
+--       outbox processor (Edge Function)가 이 RPC를 호출하면, board sync 로직 자체는
+--       서버 사이드 단일 트랜잭션으로 race-free 실행됨. 이는 root resolution이며,
+--       향후 pg_cron 도입 시 Edge Function 자체도 제거 가능.
+--
+-- 호환성: TS boardService.executeUpsertSchedulePost / executeReplaceScheduleMemberships
+--         의 알고리즘과 동일 결과를 내도록 작성. 차이 발생 시 TS가 source of truth.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- helper 1: format_compensation_label(compensation jsonb) -> text
+-- TS: formatCompensationLabel(jobPosting)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._format_compensation_label(p_compensation jsonb)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+  v_amount numeric;
+  v_type text;
+  v_label text;
+BEGIN
+  IF p_compensation IS NULL THEN
+    RETURN '';
+  END IF;
+
+  v_amount := NULLIF((p_compensation #>> '{defaultSalary,amount}'), '')::numeric;
+  v_type := p_compensation #>> '{defaultSalary,type}';
+
+  IF v_amount IS NULL OR v_type IS NULL THEN
+    RETURN '';
+  END IF;
+
+  v_label := CASE v_type
+    WHEN 'hourly' THEN '시급'
+    WHEN 'daily' THEN '일급'
+    WHEN 'monthly' THEN '월급'
+    WHEN 'other' THEN '급여'
+    ELSE '급여'
+  END;
+
+  -- to_char with FM removes leading whitespace; group by 3 digits with comma
+  RETURN v_label || ' ' || to_char(v_amount, 'FM999,999,999,999') || '원';
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- helper 2: build_schedule_board_body(job_postings_row) -> text
+-- TS: buildScheduleBoardBody(jobPosting)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._build_schedule_board_body(p_jp job_postings)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+  v_lines text[] := ARRAY[]::text[];
+  v_dates_label text;
+  v_compensation_label text;
+  v_location_name text;
+  v_description text;
+BEGIN
+  v_dates_label := CASE
+    WHEN p_jp.work_dates IS NOT NULL AND array_length(p_jp.work_dates, 1) > 0
+      THEN array_to_string(p_jp.work_dates, ', ')
+    ELSE COALESCE(p_jp.work_date, '')
+  END;
+
+  v_location_name := COALESCE(p_jp.location ->> 'name', '미정');
+  v_compensation_label := public._format_compensation_label(p_jp.compensation);
+
+  v_lines := v_lines || ('공고명: ' || COALESCE(p_jp.title, ''));
+  v_lines := v_lines || ('근무일: ' || v_dates_label);
+  v_lines := v_lines || ('장소: ' || v_location_name);
+
+  IF v_compensation_label <> '' THEN
+    v_lines := v_lines || ('급여: ' || v_compensation_label);
+  END IF;
+
+  v_lines := v_lines || (
+    '모집 인원: ' || COALESCE(p_jp.filled_positions, 0)::text
+    || '/' || COALESCE(p_jp.total_positions, 0)::text
+  );
+
+  v_description := COALESCE(p_jp.description, '');
+  IF length(trim(v_description)) > 0 THEN
+    v_lines := v_lines || '';
+    -- Note: TS uses sanitizeBoardText for description. SQL 포팅에서는
+    -- 단순 trim만 수행. XSS 방어는 클라이언트 렌더 단계에서 처리.
+    v_lines := v_lines || trim(v_description);
+  END IF;
+
+  RETURN array_to_string(v_lines, E'\n');
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- main: sync_schedule_board(p_job_posting_id uuid)
+-- TS: syncScheduleBoardForJobPosting + executeUpsertSchedulePost +
+--     executeReplaceScheduleMemberships
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.sync_schedule_board(p_job_posting_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = 'public'
+AS $$
+DECLARE
+  v_jp job_postings%ROWTYPE;
+  v_post_id text;
+  v_now timestamptz := now();
+  v_body text;
+  v_owner_name text;
+  v_compensation_label text;
+  v_base_date text;
+  v_member_count int := 0;
+  v_post_existed boolean;
+  v_job_summary jsonb;
+BEGIN
+  -- 1. job_posting 조회 (없으면 archived 처리)
+  SELECT * INTO v_jp FROM job_postings WHERE id = p_job_posting_id FOR UPDATE;
+
+  IF NOT FOUND THEN
+    -- 게시글 존재 시 archived로 마킹
+    v_post_id := 'schedule_' || p_job_posting_id::text;
+    UPDATE board_posts
+       SET status = 'archived',
+           updated_at = v_now,
+           last_activity_at = v_now
+     WHERE id = v_post_id;
+    RETURN jsonb_build_object(
+      'success', true,
+      'archived', true,
+      'job_posting_id', p_job_posting_id,
+      'post_id', v_post_id
+    );
+  END IF;
+
+  v_post_id := 'schedule_' || v_jp.id::text;
+  v_owner_name := COALESCE(v_jp.owner_name, '구인자');
+  v_body := public._build_schedule_board_body(v_jp);
+  v_compensation_label := public._format_compensation_label(v_jp.compensation);
+  v_base_date := COALESCE(
+    v_jp.work_date,
+    CASE WHEN v_jp.work_dates IS NOT NULL AND array_length(v_jp.work_dates, 1) > 0
+         THEN v_jp.work_dates[1] ELSE '' END,
+    ''
+  );
+
+  v_job_summary := jsonb_build_object(
+    'jobPostingId', v_jp.id::text,
+    'title', v_jp.title,
+    'workDate', COALESCE(v_jp.work_date, ''),
+    'workDates', COALESCE(to_jsonb(v_jp.work_dates), '[]'::jsonb),
+    'locationName', COALESCE(v_jp.location ->> 'name', ''),
+    'totalPositions', COALESCE(v_jp.total_positions, 0),
+    'filledPositions', COALESCE(v_jp.filled_positions, 0),
+    'compensationLabel', v_compensation_label,
+    'jobPostingStatus', COALESCE(v_jp.status::text, '')
+  );
+
+  -- 2. board_posts upsert
+  SELECT EXISTS (SELECT 1 FROM board_posts WHERE id = v_post_id) INTO v_post_existed;
+
+  IF v_post_existed THEN
+    UPDATE board_posts SET
+      board_type = 'schedule',
+      source = 'board',
+      title = v_jp.title,
+      body = v_body,
+      author_id = v_jp.owner_id,
+      author_name = v_owner_name,
+      author_role = 'employer',
+      visibility = 'participants_only',
+      linked_job_posting_id = v_jp.id,
+      is_auto_created = true,
+      image_attachments = '[]'::jsonb,
+      last_activity_at = v_now,
+      updated_at = v_now,
+      job_summary = v_job_summary
+    WHERE id = v_post_id;
+  ELSE
+    INSERT INTO board_posts (
+      id, board_type, source, title, body, author_id, author_name, author_role,
+      visibility, linked_job_posting_id, is_auto_created, image_attachments,
+      last_activity_at, updated_at, job_summary, status, is_locked, locked_by, locked_at,
+      like_count, dislike_count, comment_count, view_count, created_at
+    ) VALUES (
+      v_post_id, 'schedule', 'board', v_jp.title, v_body, v_jp.owner_id, v_owner_name, 'employer',
+      'participants_only', v_jp.id, true, '[]'::jsonb,
+      v_now, v_now, v_job_summary, 'active', false, NULL, NULL,
+      0, 0, 0, 0, v_now
+    );
+  END IF;
+
+  -- 3. board_memberships 재구성 (author + 활성 work_logs staff)
+  -- 3a. author 보장
+  INSERT INTO board_memberships (
+    id, board_type, user_id, post_id, job_posting_id, role, display_name,
+    can_read, can_comment, title, work_date, author_id, last_activity_at,
+    created_at, updated_at
+  ) VALUES (
+    gen_random_uuid(), 'schedule', v_jp.owner_id, v_post_id, v_jp.id, 'author',
+    v_owner_name,
+    true, true, v_jp.title, v_base_date, v_jp.owner_id, v_now,
+    v_now, v_now
+  )
+  ON CONFLICT (user_id, post_id) DO UPDATE SET
+    role = 'author',
+    display_name = EXCLUDED.display_name,
+    title = EXCLUDED.title,
+    work_date = EXCLUDED.work_date,
+    last_activity_at = v_now,
+    updated_at = v_now;
+
+  v_member_count := v_member_count + 1;
+
+  -- 3b. 활성 work_logs staff upsert (cancelled 제외, staff당 1행)
+  WITH active_staff AS (
+    SELECT DISTINCT ON (wl.staff_id)
+      wl.staff_id,
+      wl.staff_name,
+      wl.staff_nickname,
+      wl.date AS work_date,
+      COALESCE(wl.updated_at, wl.created_at, v_now) AS last_activity_at
+    FROM work_logs wl
+    WHERE wl.job_posting_id = v_jp.id
+      AND wl.status::text != 'cancelled'
+      AND wl.staff_id IS DISTINCT FROM v_jp.owner_id
+    ORDER BY wl.staff_id, wl.updated_at DESC NULLS LAST
+  ),
+  upserted AS (
+    INSERT INTO board_memberships (
+      id, board_type, user_id, post_id, job_posting_id, role, display_name,
+      can_read, can_comment, title, work_date, author_id, last_activity_at,
+      created_at, updated_at
+    )
+    SELECT
+      gen_random_uuid(), 'schedule', s.staff_id, v_post_id, v_jp.id, 'confirmed',
+      COALESCE(NULLIF(s.staff_nickname, ''), NULLIF(s.staff_name, ''),
+               '스태프 ' || right(s.staff_id::text, 4)),
+      true, true, v_jp.title, COALESCE(s.work_date, v_base_date), v_jp.owner_id,
+      s.last_activity_at, v_now, v_now
+    FROM active_staff s
+    ON CONFLICT (user_id, post_id) DO UPDATE SET
+      role = EXCLUDED.role,
+      display_name = EXCLUDED.display_name,
+      title = EXCLUDED.title,
+      work_date = EXCLUDED.work_date,
+      last_activity_at = EXCLUDED.last_activity_at,
+      updated_at = v_now
+    RETURNING user_id
+  )
+  SELECT count(*) INTO v_member_count FROM upserted;
+
+  -- 3c. 더 이상 활성이 아닌 staff 멤버십 삭제 (author 제외)
+  DELETE FROM board_memberships bm
+  WHERE bm.post_id = v_post_id
+    AND bm.board_type::text = 'schedule'
+    AND bm.user_id IS DISTINCT FROM v_jp.owner_id
+    AND NOT EXISTS (
+      SELECT 1 FROM work_logs wl
+      WHERE wl.job_posting_id = v_jp.id
+        AND wl.staff_id = bm.user_id
+        AND wl.status::text != 'cancelled'
+    );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'archived', false,
+    'job_posting_id', p_job_posting_id,
+    'post_id', v_post_id,
+    'created', NOT v_post_existed,
+    'member_count', v_member_count + 1  -- staff + author
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.sync_schedule_board(uuid) TO service_role;
+-- authenticated에는 권한 부여하지 않음. outbox processor (service_role)만 호출.
+
+COMMENT ON FUNCTION public.sync_schedule_board(uuid) IS
+  'Schedule board sync (board_posts + board_memberships)를 단일 트랜잭션으로 처리. outbox processor가 호출. boardService.syncScheduleBoardForJobPosting (TS)의 PL/pgSQL 포팅이며 동일 결과 보장이 목표. job_posting이 없으면 board_posts를 archived로 마킹.';
+
+COMMENT ON FUNCTION public._format_compensation_label(jsonb) IS
+  'sync_schedule_board 헬퍼: jobPosting.compensation jsonb → 한국어 급여 라벨';
+
+COMMENT ON FUNCTION public._build_schedule_board_body(job_postings) IS
+  'sync_schedule_board 헬퍼: job_postings 행 → 게시글 본문 markdown 텍스트';


### PR DESCRIPTION
## Summary
- T-B7: `schedule_board_sync_outbox` 테이블 + RLS 마이그레이션
- T-B8: `jobManagementService` 6 site fire-and-forget → outbox enqueue 교체
- T-B9: `sync-schedule-board-outbox` Edge Function (poll + retry)
- T-B10: 회귀 테스트 8종 + outbox 모니터링 가이드
- **Root fix**: `sync_schedule_board(uuid)` PL/pgSQL RPC 신규

## Why (복구)
[PR #20](https://github.com/snosnosno/uniqn/pull/20)이 worktree pre-commit hook 버그([fix PR #23](https://github.com/snosnosno/uniqn/pull/23))로 빈 commit이 머지되어 작업이 master에 반영되지 않았습니다. 본 PR이 fixed hook 환경에서 동일 작업을 재수행한 것입니다.

## Why (root fix)
원본 W3.3 설계는 Edge Function이 `boardService` TS 로직을 다시 호출해야 했습니다. 이는 두 가지 문제:
1. **별도 트랜잭션**: board_posts upsert와 board_memberships replace가 분리 → race window 잔존
2. **Deno↔Node 코드 중복**: TS 헬퍼를 Edge Function 내부에 다시 작성

`sync_schedule_board` PL/pgSQL RPC를 도입하면:
- board sync 자체가 **단일 PostgreSQL 트랜잭션**으로 race-free 실행
- Edge Function은 outbox 큐 처리만 책임 (1줄 RPC 호출)
- 향후 `pg_cron` 도입 시 Edge Function 자체도 제거 가능
- TS `boardService.syncScheduleBoardForJobPosting`은 점진적 deprecation 가능

## Implementation

### sync_schedule_board RPC (root fix)
- 헬퍼 함수 2개:
  - `_format_compensation_label(jsonb) → text` — TS `formatCompensationLabel` 포팅
  - `_build_schedule_board_body(job_postings) → text` — TS `buildScheduleBoardBody` 포팅
- 메인 함수:
  - job_posting `FOR UPDATE` 락
  - 부재 시 board_post `archived` 마킹 (delete 액션 처리)
  - board_posts INSERT or UPDATE
  - 활성 work_logs staff → board_memberships upsert
  - 비활성 staff → board_memberships DELETE (author 보호)
- `SECURITY DEFINER`, `service_role` 전용 EXECUTE

### 6개 site action 매핑
| Site | action |
|------|--------|
| createJobPosting | create |
| updateJobPosting | update |
| deleteJobPosting | delete |
| closeJobPosting | close |
| reopenJobPosting | reopen |
| bulkUpdateJobPostingStatus | closed→close, active→reopen, 그 외→update |

`bulkUpdateJobPostingStatus`의 status별 매핑은 outbox CHECK 제약(`create/update/delete/close/reopen`)이 'bulk-status'를 허용하지 않기 때문. 처리는 RPC가 멱등하게 수행.

### Edge Function 처리 흐름
1. `pending` 행 fetch (limit 10, created_at 오름차순)
2. 직렬 loop (race + retry 카운터 정확성)
3. mark `processing` → `sync_schedule_board(p_job_posting_id)` RPC 호출 → mark `success`
4. 실패 시 `retry_count + 1`, 3회 초과면 `failed_retry_limit`

### 안전성 결정
- `enqueueScheduleBoardSync` 실패는 **메인 mutation을 롤백시키지 않음** (UX 보호 + 멱등 RPC가 안전망)
- outbox `failed_retry_limit` 모니터링이 별도 후속 작업

## ⚠️ 적용 보류
이 PR은 파일만 포함합니다. 머지 후 사용자 승인 하에:
1. `mcp__supabase__apply_migration` × 2 (outbox 테이블 + sync_schedule_board RPC)
2. `mcp__supabase__deploy_edge_function` × 1
3. cron / scheduled invocation 설정 (선택)

## Test plan
- [x] `npm run quality` PASS
- [x] `npm test -- jobManagementService` 17/17 (신규 8 + 기존 9)
- [x] `npm test` 전체 208 suites / 3415 tests PASS
- [ ] 머지 후 마이그레이션 적용
- [ ] sync-schedule-board-outbox Edge Function 배포
- [ ] outbox row insert → Edge Function 호출 → board_posts/board_memberships 변화 확인
- [ ] failed_retry_limit alert 동작 확인 (선택)
- [ ] outbox 모니터링 대시보드 (별도 task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)