### PR TITLE
fix(security): W6.2 백로그 정리 — is_active 가드 + payroll 트리거 + 토너먼트 EF 회수 + observability

### DIFF
--- a/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
@@ -5,6 +5,7 @@
  * @version 1.0.0
  */
 
+import * as Sentry from '@sentry/react-native';
 import { supabase } from '@/lib/supabase';
 import { logger } from '@/utils/logger';
 import { toError, BusinessError, PermissionError, ERROR_CODES, isAppError } from '@/errors';
@@ -340,11 +341,23 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
       const { error } = await supabase.rpc('increment_view_count', { posting_id: jobPostingId });
       if (error) {
         logger.warn('공고 조회수 증가 실패', { jobPostingId, error: error.message });
+        Sentry.addBreadcrumb({
+          category: 'swallow',
+          level: 'warning',
+          message: '공고 조회수 증가 RPC 실패 — 무시됨',
+          data: { jobPostingId, error: error.message },
+        });
         return;
       }
       logger.debug('공고 조회수 증가', { jobPostingId });
     } catch (error) {
       logger.warn('공고 조회수 증가 실패', { jobPostingId, error: toError(error) });
+      Sentry.addBreadcrumb({
+        category: 'swallow',
+        level: 'warning',
+        message: '공고 조회수 증가 예외 — 무시됨',
+        data: { jobPostingId, error: String(error) },
+      });
     }
   }
 

--- a/uniqn-mobile/src/repositories/supabase/TemplateRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/TemplateRepository.ts
@@ -10,6 +10,7 @@
  * 3. 사용 통계 업데이트
  */
 
+import * as Sentry from '@sentry/react-native';
 import { supabase } from '@/lib/supabase';
 import { logger } from '@/utils/logger';
 import { BusinessError, PermissionError, ERROR_CODES, isAppError } from '@/errors';
@@ -131,6 +132,12 @@ export class SupabaseTemplateRepository implements ITemplateRepository {
         .then(({ error: rpcError }) => {
           if (rpcError) {
             logger.warn('템플릿 사용 통계 업데이트 실패', { templateId, error: rpcError });
+            Sentry.addBreadcrumb({
+              category: 'swallow',
+              level: 'warning',
+              message: '템플릿 사용 통계 업데이트 실패 — 무시됨',
+              data: { templateId, error: String(rpcError) },
+            });
           }
         });
 

--- a/uniqn-mobile/src/services/notifications/internal/notificationReadStateService.ts
+++ b/uniqn-mobile/src/services/notifications/internal/notificationReadStateService.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { supabase } from '@/lib/supabase';
 import { handleServiceError } from '@/errors/serviceErrorHandler';
 import { toError } from '@/errors';
@@ -45,6 +46,12 @@ async function resetUnreadCounterWithRetry(
     userId,
     attempts: MAX_RETRIES,
   });
+  Sentry.addBreadcrumb({
+    category: 'swallow',
+    level: 'warning',
+    message: '미읽음 카운터 리셋 최종 실패 — 무시됨',
+    data: { userId, attempts: MAX_RETRIES },
+  });
   return false;
 }
 
@@ -60,6 +67,12 @@ async function decrementUnreadCounterWithRetry(delta: number): Promise<boolean> 
     logger.warn('미읽음 카운터 감소 실패 - onSnapshot/foreground sync에서 보정 예정', {
       delta,
       error: toError(counterError).message,
+    });
+    Sentry.addBreadcrumb({
+      category: 'swallow',
+      level: 'warning',
+      message: '미읽음 카운터 감소 실패 — 무시됨',
+      data: { delta, error: String(counterError) },
     });
     return false;
   }
@@ -85,6 +98,12 @@ export async function syncUnreadCounterFromServer(
   } catch (error) {
     logger.warn('카운터 동기화 실패', {
       error: error instanceof Error ? error.message : String(error),
+    });
+    Sentry.addBreadcrumb({
+      category: 'swallow',
+      level: 'warning',
+      message: '카운터 동기화 실패 — 무시됨',
+      data: { userId, error: String(error) },
     });
     return null;
   }

--- a/uniqn-mobile/supabase/functions/approve-job-posting/index.ts
+++ b/uniqn-mobile/supabase/functions/approve-job-posting/index.ts
@@ -1,0 +1,130 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: '인증이 필요합니다' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    );
+
+    // 사용자 인증 확인
+    const userClient = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!,
+      { global: { headers: { Authorization: authHeader } } }
+    );
+    const {
+      data: { user },
+      error: authError,
+    } = await userClient.auth.getUser();
+    if (authError || !user) {
+      return new Response(JSON.stringify({ error: '인증 실패' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // admin 권한 확인
+    const role = user.app_metadata?.role;
+    if (role !== 'admin') {
+      return new Response(JSON.stringify({ error: '관리자 권한이 필요합니다' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { jobPostingId } = await req.json();
+    if (!jobPostingId || typeof jobPostingId !== 'string') {
+      return new Response(JSON.stringify({ error: 'jobPostingId가 필요합니다' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // 공고 조회 + 검증
+    const { data: posting, error: fetchError } = await supabase
+      .from('job_postings')
+      .select('id, type, tournament_config')
+      .eq('id', jobPostingId)
+      .single();
+
+    if (fetchError || !posting) {
+      return new Response(JSON.stringify({ error: '공고를 찾을 수 없습니다' }), {
+        status: 404,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (posting.type !== 'tournament') {
+      return new Response(JSON.stringify({ error: '토너먼트 공고만 승인할 수 있습니다' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const approvalStatus = posting.tournament_config?.approvalStatus;
+    if (approvalStatus !== 'pending') {
+      return new Response(JSON.stringify({ error: '대기 중인 공고만 승인할 수 있습니다' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // 승인 처리
+    const now = new Date().toISOString();
+    const updatedConfig = {
+      ...posting.tournament_config,
+      approvalStatus: 'approved',
+      approvedBy: user.id,
+      approvedAt: now,
+    };
+
+    const { error: updateError } = await supabase
+      .from('job_postings')
+      .update({
+        tournament_config: updatedConfig,
+        updated_at: now,
+      })
+      .eq('id', jobPostingId);
+
+    if (updateError) {
+      return new Response(JSON.stringify({ error: '승인 처리에 실패했습니다' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        jobPostingId,
+        approvedBy: user.id,
+        approvedAt: now,
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: error instanceof Error ? error.message : '알 수 없는 오류' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});

--- a/uniqn-mobile/supabase/functions/reject-job-posting/index.ts
+++ b/uniqn-mobile/supabase/functions/reject-job-posting/index.ts
@@ -1,0 +1,129 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: '인증이 필요합니다' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    );
+
+    const userClient = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!,
+      { global: { headers: { Authorization: authHeader } } }
+    );
+    const {
+      data: { user },
+      error: authError,
+    } = await userClient.auth.getUser();
+    if (authError || !user) {
+      return new Response(JSON.stringify({ error: '인증 실패' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (user.app_metadata?.role !== 'admin') {
+      return new Response(JSON.stringify({ error: '관리자 권한이 필요합니다' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { jobPostingId, reason } = await req.json();
+    if (!jobPostingId || typeof jobPostingId !== 'string') {
+      return new Response(JSON.stringify({ error: 'jobPostingId가 필요합니다' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+    if (!reason || typeof reason !== 'string' || reason.trim().length < 10) {
+      return new Response(JSON.stringify({ error: '거절 사유는 10자 이상이어야 합니다' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { data: posting, error: fetchError } = await supabase
+      .from('job_postings')
+      .select('id, type, tournament_config')
+      .eq('id', jobPostingId)
+      .single();
+
+    if (fetchError || !posting) {
+      return new Response(JSON.stringify({ error: '공고를 찾을 수 없습니다' }), {
+        status: 404,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (posting.type !== 'tournament') {
+      return new Response(JSON.stringify({ error: '토너먼트 공고만 거절할 수 있습니다' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (posting.tournament_config?.approvalStatus !== 'pending') {
+      return new Response(JSON.stringify({ error: '대기 중인 공고만 거절할 수 있습니다' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const now = new Date().toISOString();
+    const updatedConfig = {
+      ...posting.tournament_config,
+      approvalStatus: 'rejected',
+      rejectedBy: user.id,
+      rejectedAt: now,
+      rejectionReason: reason.trim(),
+    };
+
+    const { error: updateError } = await supabase
+      .from('job_postings')
+      .update({ tournament_config: updatedConfig, updated_at: now })
+      .eq('id', jobPostingId);
+
+    if (updateError) {
+      return new Response(JSON.stringify({ error: '거절 처리에 실패했습니다' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        jobPostingId,
+        rejectedBy: user.id,
+        rejectedAt: now,
+        reason: reason.trim(),
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: error instanceof Error ? error.message : '알 수 없는 오류' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});

--- a/uniqn-mobile/supabase/functions/resubmit-job-posting/index.ts
+++ b/uniqn-mobile/supabase/functions/resubmit-job-posting/index.ts
@@ -1,0 +1,118 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: '인증이 필요합니다' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    );
+
+    const userClient = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!,
+      { global: { headers: { Authorization: authHeader } } }
+    );
+    const {
+      data: { user },
+      error: authError,
+    } = await userClient.auth.getUser();
+    if (authError || !user) {
+      return new Response(JSON.stringify({ error: '인증 실패' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { jobPostingId } = await req.json();
+    if (!jobPostingId || typeof jobPostingId !== 'string') {
+      return new Response(JSON.stringify({ error: 'jobPostingId가 필요합니다' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { data: posting, error: fetchError } = await supabase
+      .from('job_postings')
+      .select('id, type, owner_id, tournament_config')
+      .eq('id', jobPostingId)
+      .single();
+
+    if (fetchError || !posting) {
+      return new Response(JSON.stringify({ error: '공고를 찾을 수 없습니다' }), {
+        status: 404,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (posting.owner_id !== user.id) {
+      return new Response(JSON.stringify({ error: '본인의 공고만 재제출할 수 있습니다' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (posting.type !== 'tournament') {
+      return new Response(JSON.stringify({ error: '토너먼트 공고만 재제출할 수 있습니다' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (posting.tournament_config?.approvalStatus !== 'rejected') {
+      return new Response(JSON.stringify({ error: '거절된 공고만 재제출할 수 있습니다' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const now = new Date().toISOString();
+    const updatedConfig = {
+      ...posting.tournament_config,
+      approvalStatus: 'pending',
+      resubmittedAt: now,
+    };
+    // 거절 관련 필드 제거
+    delete updatedConfig.rejectedBy;
+    delete updatedConfig.rejectedAt;
+    delete updatedConfig.rejectionReason;
+
+    const { error: updateError } = await supabase
+      .from('job_postings')
+      .update({ tournament_config: updatedConfig, updated_at: now })
+      .eq('id', jobPostingId);
+
+    if (updateError) {
+      return new Response(JSON.stringify({ error: '재제출 처리에 실패했습니다' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify({ success: true, jobPostingId, resubmittedAt: now }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: error instanceof Error ? error.message : '알 수 없는 오류' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});

--- a/uniqn-mobile/supabase/migrations/20260415120000_add_is_active_guard_to_critical_rpcs.sql
+++ b/uniqn-mobile/supabase/migrations/20260415120000_add_is_active_guard_to_critical_rpcs.sql
@@ -1,0 +1,429 @@
+-- =============================================================================
+-- T-E4-rest: Critical RPC is_active 가드 추가
+-- =============================================================================
+-- 목적: 세션 중 계정이 비활성화된 경우 (public.users.is_active = false),
+--       critical write RPC 호출이 거부되도록 보장한다.
+--
+-- 대상 RPC (3개):
+--   1. cancel_application_atomically  — 가드는 1단계 LOCK 이후, 2단계 Idempotency 이전
+--   2. process_qr_checkin_atomically  — 가드는 1단계 LOCK 이후, defensive validations 이전
+--   3. confirm_application            — 가드는 BEGIN 직후
+--
+-- 원본: 운영 DB pg_proc에서 verbatim 추출 후 is_active 가드 블록만 삽입.
+--       기존 로직은 그대로 유지.
+--
+-- 실패 시 반환값:
+--   - cancel_application_atomically / process_qr_checkin_atomically:
+--       jsonb { success: false, error: 'account_disabled' } (jsonb 반환 패턴 유지)
+--   - confirm_application:
+--       RAISE EXCEPTION 'ACCOUNT_DISABLED: ...' (기존 RAISE EXCEPTION 패턴 유지)
+-- =============================================================================
+
+
+-- =============================================================================
+-- 1. cancel_application_atomically — is_active guard on p_actor_id
+-- =============================================================================
+CREATE OR REPLACE FUNCTION public.cancel_application_atomically(
+  p_application_id uuid,
+  p_actor_type text,
+  p_actor_id uuid,
+  p_cancel_reason text DEFAULT NULL::text,
+  p_rejection_reason text DEFAULT NULL::text
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_application applications%ROWTYPE;
+  v_job_posting job_postings%ROWTYPE;
+  v_active_confirmation_entry jsonb;
+  v_active_confirmation_index int;
+  v_confirmation_history jsonb := '[]'::jsonb;
+  v_deleted_work_log_count int := 0;
+  v_now text := to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"');
+  v_now_ts timestamptz := now();
+  v_assignment_count int := 0;
+  v_new_filled int;
+  v_new_status text;
+  v_updated_cancellation_request jsonb;
+BEGIN
+  -- 1. Lock application row
+  SELECT * INTO v_application FROM applications
+  WHERE id = p_application_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'application_not_found');
+  END IF;
+
+  -- is_active guard (T-E4-rest)
+  IF NOT EXISTS (
+    SELECT 1 FROM public.users
+    WHERE id = p_actor_id AND is_active = true
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'account_disabled');
+  END IF;
+
+  -- 2. Idempotency
+  IF p_actor_type = 'staff_initiates' AND v_application.status = 'applied' THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true);
+  END IF;
+  IF p_actor_type = 'staff_approves_cancel_request' AND v_application.status = 'cancelled' THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true);
+  END IF;
+
+  -- 3. State validation (actor-specific)
+  IF p_actor_type = 'staff_initiates' THEN
+    IF v_application.status != 'confirmed' THEN
+      RETURN jsonb_build_object('success', false, 'error', 'invalid_status_for_cancellation');
+    END IF;
+  ELSIF p_actor_type = 'staff_approves_cancel_request' THEN
+    IF v_application.status != 'cancellation_pending' THEN
+      RETURN jsonb_build_object('success', false, 'error', 'invalid_status_for_approval');
+    END IF;
+    IF (v_application.cancellation_request->>'status') != 'pending' THEN
+      RETURN jsonb_build_object('success', false, 'error', 'cancellation_request_not_pending');
+    END IF;
+  ELSE
+    RETURN jsonb_build_object('success', false, 'error', 'invalid_actor_type');
+  END IF;
+
+  -- 4. Lock job_posting
+  SELECT * INTO v_job_posting FROM job_postings
+  WHERE id = v_application.job_posting_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'job_posting_not_found');
+  END IF;
+
+  -- 5. Manual permission check
+  IF p_actor_type = 'staff_approves_cancel_request' THEN
+    IF v_job_posting.owner_id != p_actor_id THEN
+      RETURN jsonb_build_object('success', false, 'error', 'unauthorized');
+    END IF;
+  ELSIF p_actor_type = 'staff_initiates' THEN
+    IF v_application.applicant_id != p_actor_id THEN
+      RETURN jsonb_build_object('success', false, 'error', 'unauthorized');
+    END IF;
+  END IF;
+
+  -- 6. confirmation_history 갱신
+  v_confirmation_history := COALESCE(v_application.confirmation_history, '[]'::jsonb);
+  SELECT value, ordinality - 1
+  INTO v_active_confirmation_entry, v_active_confirmation_index
+  FROM jsonb_array_elements(v_confirmation_history) WITH ORDINALITY
+  WHERE (value->>'cancelled_at') IS NULL
+  LIMIT 1;
+
+  IF v_active_confirmation_entry IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'no_active_confirmation');
+  END IF;
+
+  v_confirmation_history := jsonb_set(v_confirmation_history,
+    ARRAY[v_active_confirmation_index::text, 'cancelled_at'], to_jsonb(v_now));
+  v_confirmation_history := jsonb_set(v_confirmation_history,
+    ARRAY[v_active_confirmation_index::text, 'cancelled_by'], to_jsonb(p_actor_id));
+  v_confirmation_history := jsonb_set(v_confirmation_history,
+    ARRAY[v_active_confirmation_index::text, 'cancellation_reason'],
+    COALESCE(to_jsonb(p_cancel_reason), 'null'::jsonb));
+
+  -- 7. New status + cancellation_request update
+  IF p_actor_type = 'staff_initiates' THEN
+    v_new_status := 'applied';
+  ELSE
+    v_new_status := 'cancelled';
+    v_updated_cancellation_request := v_application.cancellation_request
+      || jsonb_build_object('status', 'approved', 'reviewed_at', v_now, 'reviewed_by', p_actor_id);
+  END IF;
+
+  -- 8. Update applications  ← FIX: 명시적 cast
+  UPDATE applications SET
+    status = v_new_status::application_status,
+    confirmation_history = v_confirmation_history,
+    cancellation_request = COALESCE(v_updated_cancellation_request, cancellation_request),
+    cancelled_at = v_now_ts,
+    updated_at = v_now_ts
+  WHERE id = p_application_id;
+
+  -- 9. job_postings: filled_positions 재계산
+  SELECT COUNT(*)::int INTO v_assignment_count
+  FROM jsonb_array_elements(v_active_confirmation_entry->'assignments') a
+  CROSS JOIN LATERAL jsonb_array_elements((a->>'dates')::jsonb) d;
+
+  v_new_filled := GREATEST(0, v_job_posting.filled_positions - v_assignment_count);
+
+  UPDATE job_postings SET
+    filled_positions = v_new_filled,
+    status = CASE
+      WHEN status = 'closed' AND v_new_filled < total_positions THEN 'active'::posting_status
+      ELSE status
+    END,
+    updated_at = v_now_ts
+  WHERE id = v_job_posting.id;
+
+  -- 10. work_logs DELETE
+  DELETE FROM work_logs
+  WHERE application_id = p_application_id
+    AND status = 'scheduled';
+  GET DIAGNOSTICS v_deleted_work_log_count = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'application_id', p_application_id,
+    'new_status', v_new_status,
+    'assignment_count', v_assignment_count,
+    'new_filled_positions', v_new_filled,
+    'deleted_work_log_count', v_deleted_work_log_count,
+    'cancelled_at', v_now
+  );
+END;
+$function$;
+
+
+-- =============================================================================
+-- 2. process_qr_checkin_atomically — is_active guard on p_staff_id
+-- =============================================================================
+CREATE OR REPLACE FUNCTION public.process_qr_checkin_atomically(
+  p_work_log_id uuid,
+  p_staff_id uuid,
+  p_job_posting_id uuid,
+  p_action text,
+  p_check_time timestamp with time zone DEFAULT now(),
+  p_expected_date text DEFAULT NULL::text
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_work_log work_logs%ROWTYPE;
+  v_job_posting_status text;
+  v_now text := to_char(p_check_time AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"');
+  v_work_duration numeric := 0;
+  v_check_in_text text;
+  v_check_in_ts timestamptz;
+  v_duration_minutes numeric;
+BEGIN
+  -- 1. Lock work_log row
+  SELECT * INTO v_work_log
+  FROM work_logs
+  WHERE id = p_work_log_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'work_log_not_found');
+  END IF;
+
+  -- is_active guard (T-E4-rest)
+  IF NOT EXISTS (
+    SELECT 1 FROM public.users
+    WHERE id = p_staff_id AND is_active = true
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'account_disabled');
+  END IF;
+
+  -- 2. Lock job_posting row
+  SELECT status::text INTO v_job_posting_status
+  FROM job_postings
+  WHERE id = p_job_posting_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'job_posting_not_found');
+  END IF;
+
+  -- 3. Defensive validations
+  IF v_work_log.staff_id IS DISTINCT FROM p_staff_id THEN
+    RETURN jsonb_build_object('success', false, 'error', 'staff_id_mismatch');
+  END IF;
+
+  IF v_work_log.job_posting_id IS DISTINCT FROM p_job_posting_id THEN
+    RETURN jsonb_build_object('success', false, 'error', 'job_posting_id_mismatch');
+  END IF;
+
+  IF p_expected_date IS NOT NULL
+     AND COALESCE(v_work_log.is_fixed_posting, false) = false
+     AND v_work_log.date IS DISTINCT FROM p_expected_date THEN
+    RETURN jsonb_build_object('success', false, 'error', 'date_mismatch');
+  END IF;
+
+  IF v_job_posting_status != 'active' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'job_posting_inactive');
+  END IF;
+
+  IF v_work_log.payroll_status::text = 'completed' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'already_settled');
+  END IF;
+
+  IF p_action = 'checkIn' THEN
+    IF v_work_log.status::text IN ('checked_in', 'checked_out') THEN
+      RETURN jsonb_build_object('success', false, 'error', 'already_checked_in');
+    END IF;
+
+    UPDATE work_logs SET
+      status = 'checked_in',
+      check_in_time = to_jsonb(v_now),
+      updated_at = p_check_time
+    WHERE id = p_work_log_id;
+
+    RETURN jsonb_build_object(
+      'success', true,
+      'action', 'checkIn',
+      'check_in_time', v_now,
+      'work_duration', 0
+    );
+
+  ELSIF p_action = 'checkOut' THEN
+    IF v_work_log.status::text != 'checked_in' THEN
+      RETURN jsonb_build_object('success', false, 'error', 'not_checked_in');
+    END IF;
+
+    IF v_work_log.check_in_time IS NOT NULL THEN
+      v_check_in_text := CASE
+        WHEN jsonb_typeof(v_work_log.check_in_time) = 'string'
+          THEN v_work_log.check_in_time #>> '{}'
+        ELSE NULL
+      END;
+
+      IF v_check_in_text IS NOT NULL THEN
+        BEGIN
+          v_check_in_ts := v_check_in_text::timestamptz;
+          v_duration_minutes := EXTRACT(EPOCH FROM (p_check_time - v_check_in_ts)) / 60;
+          v_work_duration := GREATEST(0, ROUND((v_duration_minutes / 60)::numeric * 100) / 100);
+        EXCEPTION WHEN OTHERS THEN
+          v_work_duration := 0;
+        END;
+      END IF;
+    END IF;
+
+    UPDATE work_logs SET
+      status = 'checked_out',
+      check_out_time = to_jsonb(v_now),
+      work_duration = v_work_duration,
+      updated_at = p_check_time
+    WHERE id = p_work_log_id;
+
+    RETURN jsonb_build_object(
+      'success', true,
+      'action', 'checkOut',
+      'check_out_time', v_now,
+      'work_duration', v_work_duration
+    );
+
+  ELSE
+    RETURN jsonb_build_object('success', false, 'error', 'invalid_action');
+  END IF;
+END;
+$function$;
+
+
+-- =============================================================================
+-- 3. confirm_application — is_active guard on p_owner_id
+-- =============================================================================
+-- NOTE: confirm_application 은 기존에 RAISE EXCEPTION 패턴을 사용하므로
+--       is_active 가드도 동일한 패턴(RAISE EXCEPTION)으로 통일한다.
+--       jsonb { account_disabled } 반환 패턴은 다른 두 RPC와 반환 타입이 다르므로
+--       기존 일관성을 유지하는 쪽이 caller 호환성이 높다.
+-- =============================================================================
+CREATE OR REPLACE FUNCTION public.confirm_application(
+  p_application_id uuid,
+  p_owner_id uuid,
+  p_assignments jsonb DEFAULT '[]'::jsonb,
+  p_original_application jsonb DEFAULT NULL::jsonb,
+  p_confirmation_history jsonb DEFAULT '[]'::jsonb,
+  p_notes text DEFAULT NULL::text,
+  p_is_fixed_posting boolean DEFAULT false
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_app record;
+  v_job record;
+  v_work_log_ids uuid[] := '{}';
+  v_wl_id uuid;
+  v_assignment jsonb;
+  v_now timestamptz := now();
+BEGIN
+  -- is_active guard (T-E4-rest)
+  IF NOT EXISTS (
+    SELECT 1 FROM public.users
+    WHERE id = p_owner_id AND is_active = true
+  ) THEN
+    RAISE EXCEPTION 'ACCOUNT_DISABLED: owner account is disabled (%)', p_owner_id;
+  END IF;
+
+  SELECT * INTO v_app FROM applications WHERE id = p_application_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'APPLICATION_NOT_FOUND: %', p_application_id; END IF;
+  IF v_app.status != 'applied' THEN RAISE EXCEPTION 'INVALID_STATUS: 현재 상태 %, applied만 확정 가능', v_app.status; END IF;
+
+  SELECT * INTO v_job FROM job_postings WHERE id = v_app.job_posting_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'POSTING_NOT_FOUND: %', v_app.job_posting_id; END IF;
+  IF v_job.owner_id != p_owner_id THEN RAISE EXCEPTION 'PERMISSION_DENIED: 공고 소유자만 확정 가능'; END IF;
+
+  IF NOT p_is_fixed_posting AND jsonb_array_length(p_assignments) > 0 THEN
+    FOR v_assignment IN SELECT * FROM jsonb_array_elements(p_assignments)
+    LOOP
+      INSERT INTO work_logs (
+        staff_id, job_posting_id, application_id,
+        assignment_group_id, date, time_slot,
+        staff_name, staff_nickname, staff_photo_url,
+        role, custom_role, owner_id,
+        status, is_fixed_posting,
+        created_at, updated_at
+      ) VALUES (
+        v_app.applicant_id, v_app.job_posting_id, p_application_id,
+        v_assignment->>'groupId', v_assignment->>'date', v_assignment->>'timeSlot',
+        v_app.applicant_name, v_app.applicant_nickname, v_app.applicant_photo_url,
+        COALESCE((v_assignment->>'role')::staff_role, v_app.applicant_role, 'staff'),
+        v_assignment->>'customRole', p_owner_id,
+        'scheduled', false, v_now, v_now
+      ) RETURNING id INTO v_wl_id;
+      v_work_log_ids := array_append(v_work_log_ids, v_wl_id);
+    END LOOP;
+  END IF;
+
+  UPDATE applications SET
+    status = 'confirmed', assignments = p_assignments,
+    original_application = COALESCE(p_original_application, original_application),
+    confirmation_history = p_confirmation_history, confirmed_at = v_now,
+    processed_by = p_owner_id::text, processed_at = v_now,
+    notes = COALESCE(p_notes, notes), updated_at = v_now
+  WHERE id = p_application_id;
+
+  UPDATE job_postings SET
+    filled_positions = filled_positions + jsonb_array_length(p_assignments),
+    stats = jsonb_set(jsonb_set(stats, '{confirmedApplicants}',
+      to_jsonb(COALESCE((stats->>'confirmedApplicants')::int, 0) + 1)),
+      '{filledPositions}',
+      to_jsonb(COALESCE((stats->>'filledPositions')::int, 0) + jsonb_array_length(p_assignments))),
+    updated_at = v_now
+  WHERE id = v_app.job_posting_id;
+
+  RETURN jsonb_build_object(
+    'applicationId', p_application_id,
+    'workLogIds', to_jsonb(v_work_log_ids),
+    'assignmentCount', jsonb_array_length(p_assignments)
+  );
+END;
+$function$;
+
+
+-- =============================================================================
+-- Grants (기존 권한 유지 — CREATE OR REPLACE 시 이미 보존되나 명시적으로 재선언)
+-- =============================================================================
+GRANT EXECUTE ON FUNCTION public.cancel_application_atomically(uuid, text, uuid, text, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.process_qr_checkin_atomically(uuid, uuid, uuid, text, timestamptz, text) TO authenticated;
+REVOKE ALL ON FUNCTION public.confirm_application(uuid, uuid, jsonb, jsonb, jsonb, text, boolean) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.confirm_application(uuid, uuid, jsonb, jsonb, jsonb, text, boolean) TO authenticated;
+
+COMMENT ON FUNCTION public.cancel_application_atomically(uuid, text, uuid, text, text) IS
+  '취소 흐름 원자화 RPC + is_active 가드 (T-E4-rest). 세션 중 계정이 비활성화되면 account_disabled 에러로 거부.';
+
+COMMENT ON FUNCTION public.process_qr_checkin_atomically(uuid, uuid, uuid, text, timestamptz, text) IS
+  'QR check-in/out 원자화 RPC + is_active 가드 (T-E4-rest). 세션 중 계정이 비활성화되면 account_disabled 에러로 거부.';
+
+COMMENT ON FUNCTION public.confirm_application(uuid, uuid, jsonb, jsonb, jsonb, text, boolean) IS
+  '지원서 확정 RPC + is_active 가드 (T-E4-rest). 세션 중 owner 계정이 비활성화되면 ACCOUNT_DISABLED 예외로 거부.';

--- a/uniqn-mobile/supabase/migrations/20260415130000_work_logs_payroll_trigger.sql
+++ b/uniqn-mobile/supabase/migrations/20260415130000_work_logs_payroll_trigger.sql
@@ -1,0 +1,56 @@
+-- T-E5: work_logs payroll 컬럼 보호 트리거
+-- 목적: staff 권한이 자기 work_log 행의 payroll 관련 컬럼을 직접 UPDATE로 조작하지 못하도록 차단
+-- 배경: RLS wl_update 정책은 row 단위 허가만 하고 컬럼 단위 제한이 없음.
+--       서비스 레이어(SettlementRepository/WorkLogRepository 등)는 employer/admin 권한으로만 payroll을 변경하지만,
+--       staff JWT로 직접 supabase.from('work_logs').update({payroll_status}) 호출이 가능했음.
+--
+-- 허용: service_role, admin, employer
+-- 차단: staff (payroll_amount, payroll_status, payroll_date, payroll_notes 변경 시 예외)
+--
+-- 참조: docs/qa/2026-04-14 W6.1 보안 강화 백로그
+
+CREATE OR REPLACE FUNCTION public.protect_work_log_payroll_columns()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = 'public'
+AS $$
+DECLARE
+  v_role text;
+BEGIN
+  -- service_role (Postgres role)은 모든 변경 허용 (서버 사이드 RPC/Edge Function)
+  IF current_setting('request.jwt.claim.role', true) = 'service_role' THEN
+    RETURN NEW;
+  END IF;
+
+  -- 앱 권한 (app_metadata.role): admin / employer 허용
+  v_role := coalesce(auth.jwt() -> 'app_metadata' ->> 'role', '');
+
+  IF v_role IN ('admin', 'employer') THEN
+    RETURN NEW;
+  END IF;
+
+  -- staff (또는 기타): payroll 관련 컬럼 변경 시 예외 발생
+  IF (OLD.payroll_amount IS DISTINCT FROM NEW.payroll_amount)
+     OR (OLD.payroll_status IS DISTINCT FROM NEW.payroll_status)
+     OR (OLD.payroll_date   IS DISTINCT FROM NEW.payroll_date)
+     OR (OLD.payroll_notes  IS DISTINCT FROM NEW.payroll_notes) THEN
+    RAISE EXCEPTION 'staff_cannot_modify_payroll_fields'
+      USING ERRCODE = '42501', -- insufficient_privilege
+            DETAIL  = 'payroll_amount / payroll_status / payroll_date / payroll_notes 컬럼은 staff가 직접 변경할 수 없습니다.';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.protect_work_log_payroll_columns() IS
+  'T-E5: staff 권한의 work_logs payroll 컬럼 직접 수정 차단. employer/admin/service_role은 허용.';
+
+-- 기존 트리거 제거 후 재생성 (idempotent)
+DROP TRIGGER IF EXISTS protect_work_log_payroll ON public.work_logs;
+
+CREATE TRIGGER protect_work_log_payroll
+  BEFORE UPDATE ON public.work_logs
+  FOR EACH ROW
+  EXECUTE FUNCTION public.protect_work_log_payroll_columns();


### PR DESCRIPTION
## Summary

Wave 6.2 — Phase 0 카탈로그 마지막 백로그 Task 4건 완료. T-E4-rest(보안), T-E5(보안), T-A5(Edge Function), T-C4(옵저버빌리티).

### 변경 사항

| Task | 내용 | 영향 파일 |
|------|------|-----------|
| **T-E4-rest** (P1 보안) | 3개 critical RPC에 `is_active` 가드 추가 — 세션 중 계정 비활성화 시 즉시 거부 | `migrations/20260415120000_add_is_active_guard_to_critical_rpcs.sql` |
| **T-E5** (P2 보안) | `work_logs` payroll 컬럼 BEFORE UPDATE 트리거 — staff 직접 조작 차단 | `migrations/20260415130000_work_logs_payroll_trigger.sql` |
| **T-A5** (P2) | 토너먼트 Edge Function 3개 운영 환경에서 회수: `approve/reject/resubmit-job-posting` | `supabase/functions/{approve,reject,resubmit}-job-posting/index.ts` |
| **T-C4** (P2 옵저버빌리티) | swallow catch 블록 3곳에 `Sentry.addBreadcrumb()` 추가 — silent fail 추적 가능 | `TemplateRepository.ts`, `JobPostingRepository.ts`, `notificationReadStateService.ts` |

### T-D2 상태 (continue-on-error 유지)

e2e CI 분석 결과: 26개 실패 중 22개는 UI 기능 미구현 (공고 필터 칩, 게시판, admin 패널 등), 4개는 cancellation-lifecycle 타이밍. DB RPC 자체는 정상 동작 확인. `continue-on-error: true` 유지.

### T-E6 (skip)

rate limiting은 이번 세션 skip — P2 백로그로 유지.

### DB 마이그레이션 (2개 운영 적용 완료)

- `20260415063629_add_is_active_guard_to_critical_rpcs_v2` — T-E4: 3개 RPC 재작성
- `20260415063641_work_logs_payroll_trigger` — T-E5: 트리거 생성

### 보안 영향

- **T-E4**: 세션 탈취 + 계정 비활성화 조합 공격 시 critical RPC (취소/QR/확정) 에서 `account_disabled` 거부
- **T-E5**: defense-in-depth — 서비스 레이어 외부에서 payroll 필드 조작 불가 (RLS 단독 방어 보완)

## Test plan

- [ ] quality: type-check + lint + format ✅ 통과 확인
- [ ] 절대 경로 grep: `git diff | grep -E 'C:/Users|T-HOLDEM-w'` → CLEAN ✅
- [ ] Supabase migrations: 62개 적용 확인 ✅
- [ ] is_active 가드 DB 동작: 비활성 사용자로 cancel_application_atomically 호출 → `account_disabled` 반환 확인
- [ ] payroll 트리거 DB 동작: staff JWT로 payroll_status UPDATE → 42501 예외 확인
- [ ] Edge Function 파일 구조: `supabase/functions/{approve,reject,resubmit}-job-posting/index.ts` 존재 확인
- [ ] Sentry breadcrumb: incrementViewCount RPC 실패 시 breadcrumb 호출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)