### PR TITLE
fix(admin): users.last_login_at 컬럼 미존재 400 에러 수정

### DIFF
--- a/uniqn-mobile/app/(admin)/users/[id].tsx
+++ b/uniqn-mobile/app/(admin)/users/[id].tsx
@@ -235,13 +235,6 @@ export default function AdminUserDetailPage() {
           label="가입일"
           value={formatDate(user.createdAt)}
         />
-        {user.lastLoginAt && (
-          <InfoRow
-            icon={<CalendarIcon size={20} color={SECONDARY_PALETTE[500]} />}
-            label="최근 로그인"
-            value={formatDate(user.lastLoginAt)}
-          />
-        )}
         <InfoRow
           icon={
             user.isVerified ? (

--- a/uniqn-mobile/src/repositories/supabase/AdminRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/AdminRepository.ts
@@ -34,7 +34,7 @@ const TABLES = {
   REPORTS: 'reports',
 } as const;
 const USER_COLUMNS =
-  'id,name,email,role,phone,photo_url,created_at,updated_at,is_active,phone_verified,last_login_at' as const;
+  'id,name,email,role,phone,photo_url,created_at,updated_at,is_active,phone_verified' as const;
 
 // ============================================================================
 // Helpers
@@ -51,7 +51,6 @@ function rowToAdminUser(row: Record<string, unknown>): AdminUser {
     photoURL: row.photo_url as string | undefined,
     createdAt: row.created_at ? new Date(row.created_at as string) : new Date(),
     updatedAt: row.updated_at ? new Date(row.updated_at as string) : new Date(),
-    lastLoginAt: row.last_login_at ? new Date(row.last_login_at as string) : undefined,
     isActive: row.is_active !== false,
     isVerified: row.phone_verified === true,
   };

--- a/uniqn-mobile/src/types/admin.ts
+++ b/uniqn-mobile/src/types/admin.ts
@@ -24,7 +24,6 @@ export interface AdminUser {
   photoURL?: string;
   createdAt: Date;
   updatedAt: Date;
-  lastLoginAt?: Date;
   isActive: boolean;
   isVerified: boolean;
 }
@@ -109,7 +108,7 @@ export interface AdminUserFilters {
 /**
  * 정렬 가능 필드
  */
-export type AdminUserSortField = 'name' | 'email' | 'role' | 'createdAt' | 'lastLoginAt';
+export type AdminUserSortField = 'name' | 'email' | 'role' | 'createdAt';
 
 /**
  * 정렬 필드 레이블
@@ -119,7 +118,6 @@ export const ADMIN_USER_SORT_LABELS: Record<AdminUserSortField, string> = {
   email: '이메일',
   role: '역할',
   createdAt: '가입일',
-  lastLoginAt: '최근 로그인',
 };
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- 관리자 사용자 목록/상세/최근 가입자 조회 시 `column users.last_login_at does not exist` (HTTP 400) 에러 수정
- Firebase → Supabase 이전(2026-04-11) 시 누락된 필드로, 실제 `public.users` 테이블에 해당 컬럼 없음
- 클라이언트 참조(Repository/Types/UI) 전부 제거

## Root Cause
Supabase `public.users` 실제 스키마에 `last_login_at` 컬럼이 없음. Firebase 시절부터 있던 필드가 이전 시 누락되어 있었고, 클라이언트는 이를 계속 요청하고 있었음. UI는 `{user.lastLoginAt && ...}` 조건부라 값 없이도 렌더링은 정상이었으나, 쿼리 자체가 400 실패로 페이지 전체 로딩 불가.

## Changes
- `AdminRepository.ts`: `USER_COLUMNS`에서 `last_login_at` 제거, `rowToAdminUser` 매핑 제거 (영향 3개 메서드: `getUsers`, `getRecentUsers`, `getUserById`)
- `types/admin.ts`: `AdminUser.lastLoginAt` 필드, `AdminUserSortField`의 `'lastLoginAt'`, 정렬 라벨 제거
- `app/(admin)/users/[id].tsx`: "최근 로그인" InfoRow 블록 제거

## Scope Check
다른 admin 페이지(announcements, board-reports, employer-applications, inquiries, reports, stats, tournaments) 전수 정적 조사 — 동일 유형 스키마 불일치 없음 확인.

## Test plan
- [ ] `/admin/users` 목록 조회 성공 (400 없음)
- [ ] `/admin/users/[id]` 상세 페이지 "최근 로그인" 없이 정상 렌더
- [ ] `/admin` 대시보드 홈 "최근 가입자" 섹션 정상 표시
- [ ] 정렬 옵션에 "최근 로그인" 항목이 안 보이는지
- [ ] 타입체크 통과 (worktree에서 \`tsc --noEmit\` exit 0 확인 완료)

## Follow-ups (별도 PR)
- Firebase 잔재 정리 여부 (`functions/`, `firebase.json`, `.firebaserc`) — 실제 사용 여부 재확인 필요
- "최근 로그인" 기능이 실제 필요하면 `auth.users.last_sign_in_at` 연동 설계

🤖 Generated with [Claude Code](https://claude.com/claude-code)