### PR TITLE
feat(board): 게시판 UI 블라인드 밀도형 리디자인

### DIFF
--- a/uniqn-mobile/app/(admin)/tournaments/index.tsx
+++ b/uniqn-mobile/app/(admin)/tournaments/index.tsx
@@ -285,10 +285,10 @@ export default function AdminTournamentsPage() {
 
       try {
         if (modalState.mode === 'approve') {
-          await approve.mutateAsync({ postingId: modalState.posting.id });
+          await approve.mutateAsync({ jobPostingId: modalState.posting.id });
         } else {
           if (!reason) return;
-          await reject.mutateAsync({ postingId: modalState.posting.id, reason });
+          await reject.mutateAsync({ jobPostingId: modalState.posting.id, reason });
         }
         setModalState({ visible: false, mode: 'approve', posting: null });
       } catch {

--- a/uniqn-mobile/app/(app)/(tabs)/board/[boardType].tsx
+++ b/uniqn-mobile/app/(app)/(tabs)/board/[boardType].tsx
@@ -1,20 +1,28 @@
-import { SECONDARY_PALETTE } from '@/constants/colors';
 import { router, useLocalSearchParams } from 'expo-router';
-import { Pressable, RefreshControl, Text, View } from 'react-native';
+import { RefreshControl, Text, View } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { TabHeader } from '@/components/headers';
 import { EmptyState, ErrorState } from '@/components/ui';
-import { AddCircleOutlineIcon, DocumentTextOutlineIcon } from '@/components/icons';
+import { DocumentTextOutlineIcon } from '@/components/icons';
 import { BoardPostCard } from '@/components/board/BoardPostCard';
+import { BoardTabBar, type BoardTabKey } from '@/components/board/BoardTabBar';
+import { BoardWriteFab } from '@/components/board/BoardWriteFab';
 import { useBoardPosts } from '@/hooks/useBoard';
-import { useThemeStore } from '@/stores/themeStore';
 import { BOARD_TYPE_LABELS, type BoardType } from '@/types/board';
+import { SECONDARY_PALETTE } from '@/constants/colors';
 
 const SUPPORTED_BOARD_TYPES: BoardType[] = ['notice', 'schedule', 'free', 'tda', 'substitute'];
 
+function navigateToTab(tab: BoardTabKey) {
+  if (tab === 'home') {
+    router.replace('/(app)/(tabs)/board');
+    return;
+  }
+  router.replace(`/(app)/(tabs)/board/${tab}`);
+}
+
 export default function BoardListScreen() {
-  const isDarkMode = useThemeStore((state) => state.isDarkMode);
   const { boardType: rawBoardType } = useLocalSearchParams<{ boardType: string }>();
   const boardType = rawBoardType as BoardType;
   const isValidBoardType = SUPPORTED_BOARD_TYPES.includes(boardType);
@@ -39,21 +47,8 @@ export default function BoardListScreen() {
 
   return (
     <SafeAreaView className="flex-1 bg-surface-page" edges={['top']}>
-      <TabHeader
-        title={BOARD_TYPE_LABELS[boardType]}
-        rightAction={
-          isWritable ? (
-            <Pressable
-              onPress={() => router.push(`/(app)/(tabs)/board/write?boardType=${safeBoardType}`)}
-              className="rounded-sm p-2 active:bg-secondary-100 dark:active:bg-surface"
-              accessibilityRole="button"
-              accessibilityLabel="글쓰기"
-            >
-              <AddCircleOutlineIcon size={24} color={isDarkMode ? '#D4AF37' : '#8A7228'} />
-            </Pressable>
-          ) : null
-        }
-      />
+      <TabHeader title={BOARD_TYPE_LABELS[boardType]} />
+      <BoardTabBar activeTab={safeBoardType} onTabPress={navigateToTab} />
 
       {error ? (
         <View className="flex-1 items-center justify-center p-4">
@@ -74,13 +69,13 @@ export default function BoardListScreen() {
           )}
           keyExtractor={(item) => item.id}
           // @ts-expect-error - FlashList 2.x runtime prop is available but project types lag behind
-          estimatedItemSize={164}
-          contentContainerStyle={{ padding: 16, paddingBottom: 24 }}
+          estimatedItemSize={72}
+          contentContainerStyle={{ paddingHorizontal: 16, paddingVertical: 8, paddingBottom: 80 }}
           refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
           ListEmptyComponent={
             isLoading ? (
               <View className="flex-1 items-center justify-center py-20">
-                <Text className="text-sm text-secondary-500 dark:text-secondary-400 font-sans">
+                <Text className="text-sm font-sans text-secondary-500 dark:text-secondary-400">
                   게시글을 불러오는 중이에요...
                 </Text>
               </View>
@@ -106,6 +101,12 @@ export default function BoardListScreen() {
           }
         />
       )}
+
+      {isWritable ? (
+        <BoardWriteFab
+          onPress={() => router.push(`/(app)/(tabs)/board/write?boardType=${safeBoardType}`)}
+        />
+      ) : null}
     </SafeAreaView>
   );
 }

--- a/uniqn-mobile/app/(app)/(tabs)/board/index.tsx
+++ b/uniqn-mobile/app/(app)/(tabs)/board/index.tsx
@@ -1,61 +1,45 @@
-import type { ReactNode } from 'react';
 import { Pressable, RefreshControl, ScrollView, Text, View } from 'react-native';
 import { router } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { TabHeader } from '@/components/headers';
-import { Card, EmptyState, ErrorState, SkeletonListItem } from '@/components/ui';
-import {
-  CalendarIcon,
-  DocumentTextOutlineIcon,
-  HashtagIcon,
-  MessageIcon,
-  UsersIcon,
-} from '@/components/icons';
+import { EmptyState, ErrorState, SkeletonListItem } from '@/components/ui';
 import { BoardPostCard } from '@/components/board/BoardPostCard';
+import { BoardTabBar, type BoardTabKey } from '@/components/board/BoardTabBar';
+import { PinnedNoticeBanner } from '@/components/board/PinnedNoticeBanner';
 import { useBoardHome } from '@/hooks/useBoard';
 import { useAuth } from '@/hooks/useAuth';
-import { PRIMARY_COLORS } from '@/constants/colors';
 import type { BoardPost, BoardType } from '@/types';
-
-interface BoardEntryCardProps {
-  title: string;
-  icon: ReactNode;
-  boardType: BoardType;
-}
-
-function BoardEntryCard({ title, icon, boardType }: BoardEntryCardProps) {
-  return (
-    <Pressable
-      className="flex-1 items-center rounded-md border border-secondary-200 bg-white py-4 px-2 active:opacity-70 dark:border-surface-overlay dark:bg-surface-elevated"
-      onPress={() => router.push(`/(app)/(tabs)/board/${boardType}`)}
-      accessibilityRole="button"
-      accessibilityLabel={`${title} 게시판으로 이동`}
-    >
-      <View className="mb-2">{icon}</View>
-      <Text className="text-center text-xs font-sans-semibold text-content-primary dark:text-secondary-100">
-        {title}
-      </Text>
-    </Pressable>
-  );
-}
 
 interface BoardSectionProps {
   title: string;
   emptyTitle: string;
   posts: BoardPost[];
+  moreBoardType?: BoardType;
 }
 
-function BoardSection({ title, emptyTitle, posts }: BoardSectionProps) {
+function BoardSection({ title, emptyTitle, posts, moreBoardType }: BoardSectionProps) {
   return (
-    <View className="mb-6">
-      <Text className="mb-3 text-lg font-display-semibold text-content-primary dark:text-secondary-100">
-        {title}
-      </Text>
+    <View className="mb-4">
+      <View className="mb-2 flex-row items-center justify-between">
+        <Text className="text-xs font-sans-semibold uppercase tracking-wider text-secondary-600 dark:text-secondary-400">
+          {title}
+        </Text>
+        {moreBoardType ? (
+          <Pressable
+            onPress={() => router.replace(`/(app)/(tabs)/board/${moreBoardType}`)}
+            accessibilityRole="button"
+            accessibilityLabel={`${title} 더보기`}
+            className="active:opacity-70"
+          >
+            <Text className="text-xs font-sans text-primary-700 dark:text-primary-300">
+              더보기 ›
+            </Text>
+          </Pressable>
+        ) : null}
+      </View>
 
       {posts.length === 0 ? (
-        <Card>
-          <EmptyState title={emptyTitle} description="아직 표시할 게시글이 없어요." compact />
-        </Card>
+        <EmptyState title={emptyTitle} description="아직 표시할 게시글이 없어요." compact />
       ) : (
         posts.map((post) => (
           <BoardPostCard
@@ -69,6 +53,11 @@ function BoardSection({ title, emptyTitle, posts }: BoardSectionProps) {
   );
 }
 
+function navigateToTab(tab: BoardTabKey) {
+  if (tab === 'home') return;
+  router.replace(`/(app)/(tabs)/board/${tab}`);
+}
+
 export default function BoardHomeScreen() {
   const { role, isAdmin } = useAuth();
   const { data, isLoading, error, refetch, isRefetching } = useBoardHome();
@@ -76,6 +65,7 @@ export default function BoardHomeScreen() {
   return (
     <SafeAreaView className="flex-1 bg-surface-page" edges={['top']}>
       <TabHeader title="게시판" />
+      <BoardTabBar activeTab="home" onTabPress={navigateToTab} />
 
       {isLoading ? (
         <ScrollView className="flex-1" contentContainerClassName="p-4">
@@ -97,59 +87,28 @@ export default function BoardHomeScreen() {
           contentContainerClassName="p-4 pb-8"
           refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
         >
-          <View className="mb-6 gap-2">
-            <View className="flex-row gap-2">
-              <BoardEntryCard
-                title="공지사항"
-                icon={<DocumentTextOutlineIcon size={28} color={PRIMARY_COLORS[700]} />}
-                boardType="notice"
-              />
-              <BoardEntryCard
-                title="일정게시판"
-                icon={<CalendarIcon size={28} color="#0F766E" />}
-                boardType="schedule"
-              />
-              <BoardEntryCard
-                title="자유게시판"
-                icon={<MessageIcon size={28} color={PRIMARY_COLORS[700]} />}
-                boardType="free"
-              />
-            </View>
-            <View className="flex-row gap-2">
-              <BoardEntryCard
-                title="TDA 토론"
-                icon={<HashtagIcon size={28} color={PRIMARY_COLORS[500]} />}
-                boardType="tda"
-              />
-              <BoardEntryCard
-                title="대타 구인"
-                icon={<UsersIcon size={28} color={PRIMARY_COLORS[500]} />}
-                boardType="substitute"
-              />
-              <View className="flex-1" />
-            </View>
-          </View>
+          <PinnedNoticeBanner
+            notices={data?.pinnedNotices ?? []}
+            onPress={(notice) => router.push(`/(app)/(tabs)/board/post/${notice.id}`)}
+          />
 
           <BoardSection
-            title="고정 공지"
-            emptyTitle="등록된 고정 공지가 없어요"
-            posts={data?.pinnedNotices ?? []}
+            title="🔥 인기글"
+            emptyTitle="아직 인기글이 없어요"
+            posts={data?.popularCommunityPosts ?? []}
+            moreBoardType="free"
           />
           <BoardSection
             title={
               isAdmin
-                ? '최근 일정 활동'
+                ? '🕒 최근 일정 활동'
                 : role === 'employer'
-                  ? '내 공고 최근 활동'
-                  : '내 일정 최근 활동'
+                  ? '🕒 내 공고 최근 활동'
+                  : '🕒 내 일정 최근 활동'
             }
             emptyTitle="표시할 일정 활동이 없어요"
             posts={data?.recentSchedulePosts ?? []}
-          />
-          <BoardSection
-            title="커뮤니티 인기글"
-            emptyTitle="아직 인기글이 없어요"
-            posts={data?.popularCommunityPosts ?? []}
+            moreBoardType="schedule"
           />
         </ScrollView>
       )}

--- a/uniqn-mobile/app/(app)/(tabs)/board/post/[postId].tsx
+++ b/uniqn-mobile/app/(app)/(tabs)/board/post/[postId].tsx
@@ -974,91 +974,93 @@ export default function BoardPostDetailScreen() {
             ) : null}
           </View>
 
-          {post.boardType !== 'notice' ? (
-            <View className="mt-5 rounded-lg bg-surface-page p-4 dark:bg-surface-elevated">
-              <Text className="text-xs font-sans-semibold uppercase tracking-[0.8px] text-secondary-500 dark:text-secondary-400">
-                반응
-              </Text>
-              <View className="mt-3 flex-row flex-wrap gap-2">
-                <Button
-                  variant={data.myVote === 'like' ? 'primary' : 'outline'}
-                  size="sm"
-                  icon={
-                    <HeartIcon size={16} color={data.myVote === 'like' ? '#FFFFFF' : '#16A34A'} />
-                  }
-                  onPress={() => voteMutation.mutate('like')}
-                  disabled={!canInteract || isVoteSubmitting}
-                >
-                  좋아요 {post.likeCount}
-                </Button>
-                <Button
-                  variant={data.myVote === 'dislike' ? 'danger' : 'outline'}
-                  size="sm"
-                  icon={
-                    <CloseCircleOutlineIcon
-                      size={16}
-                      color={data.myVote === 'dislike' ? '#FFFFFF' : '#DC2626'}
-                    />
-                  }
-                  onPress={() => voteMutation.mutate('dislike')}
-                  disabled={!canInteract || isVoteSubmitting}
-                >
-                  싫어요 {post.dislikeCount}
-                </Button>
-              </View>
-            </View>
-          ) : null}
-
-          {showActionBar ? (
-            <View className="mt-5 rounded-lg bg-surface-page p-4 dark:bg-surface-elevated">
-              <Text className="text-xs font-sans-semibold uppercase tracking-[0.8px] text-secondary-500 dark:text-secondary-400">
-                게시글 작업
-              </Text>
-              <View className="mt-3 flex-row flex-wrap gap-2">
-                {canManagePost && post.boardType !== 'schedule' && !post.isLocked ? (
-                  <ActionChip
-                    testID={`board-post-edit-${post.id}`}
-                    accessibilityLabel="게시글 수정"
-                    label="수정"
-                    variant="primary"
-                    onPress={() => router.push(`/(app)/(tabs)/board/edit/${post.id}`)}
-                  />
-                ) : null}
-                {canManagePost ? (
-                  <ActionChip
-                    testID={`board-post-lock-${post.id}`}
-                    accessibilityLabel={post.isLocked ? '게시글 잠금 해제' : '게시글 잠금'}
-                    label={post.isLocked ? '잠금 해제' : '잠금'}
-                    disabled={isPostActionPending}
-                    onPress={handleTogglePostLock}
-                  />
-                ) : null}
-                {isAdmin && post.boardType !== 'notice' ? (
-                  <ActionChip
-                    testID={`board-post-hide-${post.id}`}
-                    accessibilityLabel="게시글 숨김"
-                    label="숨김"
-                    variant="danger"
-                    disabled={isPostActionPending}
-                    onPress={handleHidePost}
-                  />
-                ) : null}
-                {canReportPost ? (
-                  <ActionChip
-                    testID={`board-post-report-${post.id}`}
-                    accessibilityLabel="게시글 신고"
-                    label="신고"
-                    onPress={() =>
-                      setReportTarget({
-                        targetType: 'post',
-                        targetId: post.id,
-                      })
+          <View className="mt-5 flex-row flex-wrap gap-3">
+            {post.boardType !== 'notice' ? (
+              <View className="min-w-[180px] flex-1 rounded-lg bg-surface-page p-4 dark:bg-surface-elevated">
+                <Text className="text-xs font-sans-semibold uppercase tracking-[0.8px] text-secondary-500 dark:text-secondary-400">
+                  반응
+                </Text>
+                <View className="mt-3 flex-row flex-wrap gap-2">
+                  <Button
+                    variant={data.myVote === 'like' ? 'primary' : 'outline'}
+                    size="sm"
+                    icon={
+                      <HeartIcon size={16} color={data.myVote === 'like' ? '#FFFFFF' : '#16A34A'} />
                     }
-                  />
-                ) : null}
+                    onPress={() => voteMutation.mutate('like')}
+                    disabled={!canInteract || isVoteSubmitting}
+                  >
+                    좋아요 {post.likeCount}
+                  </Button>
+                  <Button
+                    variant={data.myVote === 'dislike' ? 'danger' : 'outline'}
+                    size="sm"
+                    icon={
+                      <CloseCircleOutlineIcon
+                        size={16}
+                        color={data.myVote === 'dislike' ? '#FFFFFF' : '#DC2626'}
+                      />
+                    }
+                    onPress={() => voteMutation.mutate('dislike')}
+                    disabled={!canInteract || isVoteSubmitting}
+                  >
+                    싫어요 {post.dislikeCount}
+                  </Button>
+                </View>
               </View>
-            </View>
-          ) : null}
+            ) : null}
+
+            {showActionBar ? (
+              <View className="min-w-[180px] flex-1 rounded-lg bg-surface-page p-4 dark:bg-surface-elevated">
+                <Text className="text-xs font-sans-semibold uppercase tracking-[0.8px] text-secondary-500 dark:text-secondary-400">
+                  게시글 작업
+                </Text>
+                <View className="mt-3 flex-row flex-wrap gap-2">
+                  {canManagePost && post.boardType !== 'schedule' && !post.isLocked ? (
+                    <ActionChip
+                      testID={`board-post-edit-${post.id}`}
+                      accessibilityLabel="게시글 수정"
+                      label="수정"
+                      variant="primary"
+                      onPress={() => router.push(`/(app)/(tabs)/board/edit/${post.id}`)}
+                    />
+                  ) : null}
+                  {canManagePost ? (
+                    <ActionChip
+                      testID={`board-post-lock-${post.id}`}
+                      accessibilityLabel={post.isLocked ? '게시글 잠금 해제' : '게시글 잠금'}
+                      label={post.isLocked ? '잠금 해제' : '잠금'}
+                      disabled={isPostActionPending}
+                      onPress={handleTogglePostLock}
+                    />
+                  ) : null}
+                  {isAdmin && post.boardType !== 'notice' ? (
+                    <ActionChip
+                      testID={`board-post-hide-${post.id}`}
+                      accessibilityLabel="게시글 숨김"
+                      label="숨김"
+                      variant="danger"
+                      disabled={isPostActionPending}
+                      onPress={handleHidePost}
+                    />
+                  ) : null}
+                  {canReportPost ? (
+                    <ActionChip
+                      testID={`board-post-report-${post.id}`}
+                      accessibilityLabel="게시글 신고"
+                      label="신고"
+                      onPress={() =>
+                        setReportTarget({
+                          targetType: 'post',
+                          targetId: post.id,
+                        })
+                      }
+                    />
+                  ) : null}
+                </View>
+              </View>
+            ) : null}
+          </View>
         </Card>
       </View>
     );

--- a/uniqn-mobile/app/(app)/(tabs)/board/post/[postId].tsx
+++ b/uniqn-mobile/app/(app)/(tabs)/board/post/[postId].tsx
@@ -974,93 +974,98 @@ export default function BoardPostDetailScreen() {
             ) : null}
           </View>
 
-          <View className="mt-5 flex-row flex-wrap gap-3">
-            {post.boardType !== 'notice' ? (
-              <View className="min-w-[180px] flex-1 rounded-lg bg-surface-page p-4 dark:bg-surface-elevated">
-                <Text className="text-xs font-sans-semibold uppercase tracking-[0.8px] text-secondary-500 dark:text-secondary-400">
-                  반응
-                </Text>
-                <View className="mt-3 flex-row flex-wrap gap-2">
-                  <Button
-                    variant={data.myVote === 'like' ? 'primary' : 'outline'}
-                    size="sm"
-                    icon={
-                      <HeartIcon size={16} color={data.myVote === 'like' ? '#FFFFFF' : '#16A34A'} />
-                    }
-                    onPress={() => voteMutation.mutate('like')}
-                    disabled={!canInteract || isVoteSubmitting}
-                  >
-                    좋아요 {post.likeCount}
-                  </Button>
-                  <Button
-                    variant={data.myVote === 'dislike' ? 'danger' : 'outline'}
-                    size="sm"
-                    icon={
-                      <CloseCircleOutlineIcon
-                        size={16}
-                        color={data.myVote === 'dislike' ? '#FFFFFF' : '#DC2626'}
-                      />
-                    }
-                    onPress={() => voteMutation.mutate('dislike')}
-                    disabled={!canInteract || isVoteSubmitting}
-                  >
-                    싫어요 {post.dislikeCount}
-                  </Button>
-                </View>
-              </View>
-            ) : null}
-
-            {showActionBar ? (
-              <View className="min-w-[180px] flex-1 rounded-lg bg-surface-page p-4 dark:bg-surface-elevated">
-                <Text className="text-xs font-sans-semibold uppercase tracking-[0.8px] text-secondary-500 dark:text-secondary-400">
-                  게시글 작업
-                </Text>
-                <View className="mt-3 flex-row flex-wrap gap-2">
-                  {canManagePost && post.boardType !== 'schedule' && !post.isLocked ? (
-                    <ActionChip
-                      testID={`board-post-edit-${post.id}`}
-                      accessibilityLabel="게시글 수정"
-                      label="수정"
-                      variant="primary"
-                      onPress={() => router.push(`/(app)/(tabs)/board/edit/${post.id}`)}
-                    />
-                  ) : null}
-                  {canManagePost ? (
-                    <ActionChip
-                      testID={`board-post-lock-${post.id}`}
-                      accessibilityLabel={post.isLocked ? '게시글 잠금 해제' : '게시글 잠금'}
-                      label={post.isLocked ? '잠금 해제' : '잠금'}
-                      disabled={isPostActionPending}
-                      onPress={handleTogglePostLock}
-                    />
-                  ) : null}
-                  {isAdmin && post.boardType !== 'notice' ? (
-                    <ActionChip
-                      testID={`board-post-hide-${post.id}`}
-                      accessibilityLabel="게시글 숨김"
-                      label="숨김"
-                      variant="danger"
-                      disabled={isPostActionPending}
-                      onPress={handleHidePost}
-                    />
-                  ) : null}
-                  {canReportPost ? (
-                    <ActionChip
-                      testID={`board-post-report-${post.id}`}
-                      accessibilityLabel="게시글 신고"
-                      label="신고"
-                      onPress={() =>
-                        setReportTarget({
-                          targetType: 'post',
-                          targetId: post.id,
-                        })
+          {post.boardType !== 'notice' || showActionBar ? (
+            <View className="mt-5 flex-row flex-wrap gap-3">
+              {post.boardType !== 'notice' ? (
+                <View className="min-w-[180px] flex-1 rounded-lg bg-surface-page p-4 dark:bg-surface-elevated">
+                  <Text className="text-xs font-sans-semibold uppercase tracking-[0.8px] text-secondary-500 dark:text-secondary-400">
+                    반응
+                  </Text>
+                  <View className="mt-3 flex-row flex-wrap gap-2">
+                    <Button
+                      variant={data.myVote === 'like' ? 'primary' : 'outline'}
+                      size="sm"
+                      icon={
+                        <HeartIcon
+                          size={16}
+                          color={data.myVote === 'like' ? '#FFFFFF' : '#16A34A'}
+                        />
                       }
-                    />
-                  ) : null}
+                      onPress={() => voteMutation.mutate('like')}
+                      disabled={!canInteract || isVoteSubmitting}
+                    >
+                      좋아요 {post.likeCount}
+                    </Button>
+                    <Button
+                      variant={data.myVote === 'dislike' ? 'danger' : 'outline'}
+                      size="sm"
+                      icon={
+                        <CloseCircleOutlineIcon
+                          size={16}
+                          color={data.myVote === 'dislike' ? '#FFFFFF' : '#DC2626'}
+                        />
+                      }
+                      onPress={() => voteMutation.mutate('dislike')}
+                      disabled={!canInteract || isVoteSubmitting}
+                    >
+                      싫어요 {post.dislikeCount}
+                    </Button>
+                  </View>
                 </View>
-              </View>
-            ) : null}
-          </View>
+              ) : null}
+
+              {showActionBar ? (
+                <View className="min-w-[180px] flex-1 rounded-lg bg-surface-page p-4 dark:bg-surface-elevated">
+                  <Text className="text-xs font-sans-semibold uppercase tracking-[0.8px] text-secondary-500 dark:text-secondary-400">
+                    게시글 작업
+                  </Text>
+                  <View className="mt-3 flex-row flex-wrap gap-2">
+                    {canManagePost && post.boardType !== 'schedule' && !post.isLocked ? (
+                      <ActionChip
+                        testID={`board-post-edit-${post.id}`}
+                        accessibilityLabel="게시글 수정"
+                        label="수정"
+                        variant="primary"
+                        onPress={() => router.push(`/(app)/(tabs)/board/edit/${post.id}`)}
+                      />
+                    ) : null}
+                    {canManagePost ? (
+                      <ActionChip
+                        testID={`board-post-lock-${post.id}`}
+                        accessibilityLabel={post.isLocked ? '게시글 잠금 해제' : '게시글 잠금'}
+                        label={post.isLocked ? '잠금 해제' : '잠금'}
+                        disabled={isPostActionPending}
+                        onPress={handleTogglePostLock}
+                      />
+                    ) : null}
+                    {isAdmin && post.boardType !== 'notice' ? (
+                      <ActionChip
+                        testID={`board-post-hide-${post.id}`}
+                        accessibilityLabel="게시글 숨김"
+                        label="숨김"
+                        variant="danger"
+                        disabled={isPostActionPending}
+                        onPress={handleHidePost}
+                      />
+                    ) : null}
+                    {canReportPost ? (
+                      <ActionChip
+                        testID={`board-post-report-${post.id}`}
+                        accessibilityLabel="게시글 신고"
+                        label="신고"
+                        onPress={() =>
+                          setReportTarget({
+                            targetType: 'post',
+                            targetId: post.id,
+                          })
+                        }
+                      />
+                    ) : null}
+                  </View>
+                </View>
+              ) : null}
+            </View>
+          ) : null}
         </Card>
       </View>
     );

--- a/uniqn-mobile/app/(employer)/my-postings/[id]/index.tsx
+++ b/uniqn-mobile/app/(employer)/my-postings/[id]/index.tsx
@@ -539,7 +539,7 @@ export default function JobPostingDetailScreen() {
                 </Pressable>
                 <View className="ml-2 flex-1">
                   <ResubmitButton
-                    postingId={posting.id}
+                    jobPostingId={posting.id}
                     size="md"
                     fullWidth
                     onSuccess={handleRefresh}

--- a/uniqn-mobile/e2e/tests/p2-standard/board.spec.ts
+++ b/uniqn-mobile/e2e/tests/p2-standard/board.spec.ts
@@ -132,12 +132,20 @@ test.describe('게시판 사용자 흐름', () => {
     await page.goto('/board', { waitUntil: 'domcontentloaded' });
     await basePage.waitForReady();
 
+    // 홈에서 탭 바 확인
     await expect(page.getByLabel('자유 탭')).toBeVisible();
 
+    // 자유 탭 클릭 → 카테고리 화면에서도 탭 바 유지
     await page.getByLabel('자유 탭').click();
     await page.waitForURL(/\/board\/free$/, { timeout: 10_000 });
+    await basePage.waitForReady();
 
     await expect(page.getByLabel('자유 탭')).toBeVisible();
     await expect(page.getByLabel('TDA 탭')).toBeVisible();
+
+    // 탭이 실제로 상호작용 가능한지 확인 (TDA로 전환)
+    await page.getByLabel('TDA 탭').click();
+    await page.waitForURL(/\/board\/tda$/, { timeout: 10_000 });
+    await basePage.waitForReady();
   });
 });

--- a/uniqn-mobile/e2e/tests/p2-standard/board.spec.ts
+++ b/uniqn-mobile/e2e/tests/p2-standard/board.spec.ts
@@ -7,22 +7,12 @@ test.describe('게시판 사용자 흐름', () => {
     await basePage.waitForReady();
 
     await expect(page.getByText('게시판').first()).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: /^공지사항 운영 공지와 업데이트 내용을 확인해요\./ })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: /^내 일정게시판 확정된 내 일정 게시판만 모아서 확인해요\./ })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: /^자유게시판 일반 이야기와 소식을 자유롭게 나눠요\./ })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: /^TDA 토론 규정, 운영, 핸드 리뷰를 주제로 토론해요\./ })
-    ).toBeVisible();
+    await expect(page.getByLabel('공지 탭')).toBeVisible();
+    await expect(page.getByLabel('일정 탭')).toBeVisible();
+    await expect(page.getByLabel('자유 탭')).toBeVisible();
+    await expect(page.getByLabel('TDA 탭')).toBeVisible();
 
-    await page
-      .getByRole('button', { name: /^자유게시판 일반 이야기와 소식을 자유롭게 나눠요\./ })
-      .click();
+    await page.getByLabel('자유 탭').click();
     await page.waitForURL(/\/board\/free$/, { timeout: 10_000 });
     await expect(
       page.getByRole('button', { name: /\[seed\] Free board post/ }).first()
@@ -136,5 +126,18 @@ test.describe('게시판 사용자 흐름', () => {
 
     await expect(page.getByText('게시글을 수정할 수 없어요')).toBeVisible();
     await expect(page.getByText('글 작성자나 관리자만 게시글을 수정할 수 있어요.')).toBeVisible();
+  });
+
+  test('상단 탭 바가 홈과 카테고리 화면 모두에서 보인다', async ({ page, basePage }) => {
+    await page.goto('/board', { waitUntil: 'domcontentloaded' });
+    await basePage.waitForReady();
+
+    await expect(page.getByLabel('자유 탭')).toBeVisible();
+
+    await page.getByLabel('자유 탭').click();
+    await page.waitForURL(/\/board\/free$/, { timeout: 10_000 });
+
+    await expect(page.getByLabel('자유 탭')).toBeVisible();
+    await expect(page.getByLabel('TDA 탭')).toBeVisible();
   });
 });

--- a/uniqn-mobile/src/components/board/BoardPostCard.tsx
+++ b/uniqn-mobile/src/components/board/BoardPostCard.tsx
@@ -1,6 +1,4 @@
-import { SECONDARY_PALETTE } from '@/constants/colors';
-import { Text, View } from 'react-native';
-import { Badge, Card } from '@/components/ui';
+import { Pressable, Text, View } from 'react-native';
 import {
   ChatbubbleEllipsesOutlineIcon,
   CloseCircleOutlineIcon,
@@ -9,7 +7,10 @@ import {
   LockIcon,
   PinIcon,
 } from '@/components/icons';
-import { BOARD_TYPE_LABELS, type BoardPost } from '@/types/board';
+import { BoardTypeBadge } from './BoardTypeBadge';
+import { formatCompactCount } from '@/utils/formatCompactCount';
+import { SECONDARY_PALETTE } from '@/constants/colors';
+import type { BoardPost } from '@/types/board';
 
 interface BoardPostCardProps {
   post: BoardPost;
@@ -18,82 +19,69 @@ interface BoardPostCardProps {
 
 function formatMetaDate(post: BoardPost): string {
   const value = post.lastActivityAt ?? post.createdAt ?? post.updatedAt;
-  if (!value) {
-    return '';
-  }
-
+  if (!value) return '';
   const date = value instanceof Date ? value : new Date(value);
-  return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(
-    date.getDate()
-  ).padStart(2, '0')}`;
+  const now = new Date();
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  if (date.getFullYear() !== now.getFullYear()) {
+    return `${date.getFullYear()}.${mm}.${dd}`;
+  }
+  return `${mm}.${dd}`;
 }
 
 export function BoardPostCard({ post, onPress }: BoardPostCardProps) {
-  const showEngagementMetrics = post.boardType !== 'notice';
-
   return (
-    <Card onPress={() => onPress(post)} className="mb-3">
-      <View className="flex-row items-start justify-between gap-3">
-        <View className="flex-1">
-          <View className="mb-2 flex-row flex-wrap items-center gap-2">
-            <Badge variant={post.boardType === 'schedule' ? 'primary' : 'secondary'} size="sm">
-              {BOARD_TYPE_LABELS[post.boardType]}
-            </Badge>
-            {post.isPinned ? <PinIcon size={16} color="#D4A017" /> : null}
-            {post.isLocked ? <LockIcon size={16} color="#DC2626" /> : null}
-          </View>
-
-          <Text className="mb-1 text-base font-sans-semibold text-content-primary dark:text-secondary-100">
-            {post.title}
+    <Pressable
+      onPress={() => onPress(post)}
+      accessibilityRole="button"
+      accessibilityLabel={`${post.title} 게시글 상세 보기`}
+      className="border-b border-secondary-200 dark:border-surface-overlay px-1 py-2.5 active:opacity-70"
+    >
+      <View className="flex-row items-center gap-2 mb-1">
+        <BoardTypeBadge boardType={post.boardType} />
+        {post.isPinned ? <PinIcon size={14} color="#D4AF37" /> : null}
+        {post.isLocked ? <LockIcon size={14} color="#DC2626" /> : null}
+        <Text
+          numberOfLines={1}
+          className="flex-1 text-base font-sans-semibold text-content-primary dark:text-secondary-100"
+        >
+          {post.title}
+        </Text>
+      </View>
+      <View className="flex-row flex-wrap items-center gap-x-2.5 gap-y-1 pl-1">
+        <Text className="text-xs font-sans text-secondary-500 dark:text-secondary-400">
+          {post.authorName}
+        </Text>
+        <Text className="text-xs font-sans text-secondary-500 dark:text-secondary-400">
+          {formatMetaDate(post)}
+        </Text>
+        <View className="flex-row items-center">
+          <ChatbubbleEllipsesOutlineIcon size={12} color="#D4AF37" />
+          <Text className="ml-1 text-xs font-sans-semibold text-primary-700 dark:text-primary-300">
+            {formatCompactCount(post.commentCount)}
           </Text>
-          <Text
-            className="mb-3 text-sm text-content-muted dark:text-secondary-400 font-sans"
-            numberOfLines={2}
-          >
-            {post.body}
+        </View>
+        <View className="flex-row items-center">
+          <EyeIcon size={12} color={SECONDARY_PALETTE[500]} />
+          <Text className="ml-1 text-xs font-sans text-secondary-500 dark:text-secondary-400">
+            {formatCompactCount(post.viewCount)}
           </Text>
-
-          <View className="flex-row flex-wrap items-center gap-3">
-            <Text className="text-xs text-secondary-500 dark:text-secondary-400 font-sans">
-              {post.authorName}
-            </Text>
-            <Text className="text-xs text-secondary-500 dark:text-secondary-400 font-sans">
-              {formatMetaDate(post)}
-            </Text>
-            {showEngagementMetrics ? (
-              <View className="flex-row items-center">
-                <ChatbubbleEllipsesOutlineIcon size={14} color={SECONDARY_PALETTE[500]} />
-                <Text className="ml-1 text-xs text-secondary-500 dark:text-secondary-400 font-sans">
-                  {post.commentCount}
-                </Text>
-              </View>
-            ) : null}
-            {showEngagementMetrics ? (
-              <View className="flex-row items-center">
-                <HeartIcon size={14} color="#16A34A" />
-                <Text className="ml-1 text-xs text-secondary-500 dark:text-secondary-400 font-sans">
-                  {post.likeCount}
-                </Text>
-              </View>
-            ) : null}
-            {showEngagementMetrics ? (
-              <View className="flex-row items-center">
-                <CloseCircleOutlineIcon size={14} color="#DC2626" />
-                <Text className="ml-1 text-xs text-secondary-500 dark:text-secondary-400 font-sans">
-                  {post.dislikeCount}
-                </Text>
-              </View>
-            ) : null}
-            <View className="flex-row items-center">
-              <EyeIcon size={14} color={SECONDARY_PALETTE[500]} />
-              <Text className="ml-1 text-xs text-secondary-500 dark:text-secondary-400 font-sans">
-                {post.viewCount}
-              </Text>
-            </View>
-          </View>
+        </View>
+        <View className="flex-row items-center">
+          <HeartIcon size={12} color="#16A34A" />
+          <Text className="ml-1 text-xs font-sans text-success-700 dark:text-success-500">
+            {formatCompactCount(post.likeCount)}
+          </Text>
+        </View>
+        <View className="flex-row items-center">
+          <CloseCircleOutlineIcon size={12} color="#DC2626" />
+          <Text className="ml-1 text-xs font-sans text-error-700 dark:text-error-500">
+            {formatCompactCount(post.dislikeCount)}
+          </Text>
         </View>
       </View>
-    </Card>
+    </Pressable>
   );
 }
 

--- a/uniqn-mobile/src/components/board/BoardTabBar.test.tsx
+++ b/uniqn-mobile/src/components/board/BoardTabBar.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { BoardTabBar } from './BoardTabBar';
+
+describe('BoardTabBar', () => {
+  it('renders all six tabs in order', () => {
+    const { getByText } = render(<BoardTabBar activeTab="home" onTabPress={jest.fn()} />);
+    for (const label of ['홈', '공지', '일정', '자유', 'TDA', '대타']) {
+      expect(getByText(label)).toBeTruthy();
+    }
+  });
+
+  it('marks the active tab with accessibility selected state', () => {
+    const { getByLabelText } = render(<BoardTabBar activeTab="free" onTabPress={jest.fn()} />);
+    const freeTab = getByLabelText('자유 탭');
+    expect(freeTab.props.accessibilityState?.selected).toBe(true);
+
+    const homeTab = getByLabelText('홈 탭');
+    expect(homeTab.props.accessibilityState?.selected).toBe(false);
+  });
+
+  it('invokes onTabPress with the pressed tab key', () => {
+    const onTabPress = jest.fn();
+    const { getByLabelText } = render(<BoardTabBar activeTab="home" onTabPress={onTabPress} />);
+    fireEvent.press(getByLabelText('TDA 탭'));
+    expect(onTabPress).toHaveBeenCalledWith('tda');
+  });
+});

--- a/uniqn-mobile/src/components/board/BoardTabBar.tsx
+++ b/uniqn-mobile/src/components/board/BoardTabBar.tsx
@@ -1,0 +1,65 @@
+import { Pressable, ScrollView, Text } from 'react-native';
+import type { BoardType } from '@/types/board';
+
+export type BoardTabKey = 'home' | BoardType;
+
+interface TabItem {
+  key: BoardTabKey;
+  label: string;
+}
+
+const TABS: TabItem[] = [
+  { key: 'home', label: '홈' },
+  { key: 'notice', label: '공지' },
+  { key: 'schedule', label: '일정' },
+  { key: 'free', label: '자유' },
+  { key: 'tda', label: 'TDA' },
+  { key: 'substitute', label: '대타' },
+];
+
+interface BoardTabBarProps {
+  activeTab: BoardTabKey;
+  onTabPress: (tab: BoardTabKey) => void;
+}
+
+/** 게시판 상단 탭 바 컴포넌트 */
+export function BoardTabBar({ activeTab, onTabPress }: BoardTabBarProps) {
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerClassName="flex-row gap-1.5 px-4 py-2"
+      className="border-b border-secondary-200 dark:border-surface-overlay"
+    >
+      {TABS.map(({ key, label }) => {
+        const isActive = activeTab === key;
+        return (
+          <Pressable
+            key={key}
+            onPress={() => onTabPress(key)}
+            accessibilityRole="tab"
+            accessibilityLabel={`${label} 탭`}
+            accessibilityState={{ selected: isActive }}
+            className={`rounded-xl px-3 py-1.5 ${
+              isActive
+                ? 'bg-primary-500 dark:bg-primary-400'
+                : 'bg-secondary-100 dark:bg-surface-elevated'
+            }`}
+          >
+            <Text
+              className={`text-sm font-sans-semibold ${
+                isActive
+                  ? 'text-white dark:text-black'
+                  : 'text-content-muted dark:text-secondary-300'
+              }`}
+            >
+              {label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </ScrollView>
+  );
+}
+
+export default BoardTabBar;

--- a/uniqn-mobile/src/components/board/BoardTabBar.tsx
+++ b/uniqn-mobile/src/components/board/BoardTabBar.tsx
@@ -28,8 +28,9 @@ export function BoardTabBar({ activeTab, onTabPress }: BoardTabBarProps) {
     <ScrollView
       horizontal
       showsHorizontalScrollIndicator={false}
-      contentContainerClassName="flex-row gap-1.5 px-4 py-2"
+      contentContainerClassName="flex-row items-center gap-1.5 px-4 py-2"
       className="border-b border-secondary-200 dark:border-surface-overlay"
+      style={{ flexGrow: 0, flexShrink: 0 }}
     >
       {TABS.map(({ key, label }) => {
         const isActive = activeTab === key;
@@ -40,7 +41,7 @@ export function BoardTabBar({ activeTab, onTabPress }: BoardTabBarProps) {
             accessibilityRole="tab"
             accessibilityLabel={`${label} 탭`}
             accessibilityState={{ selected: isActive }}
-            className={`rounded-xl px-3 py-1.5 ${
+            className={`self-center rounded-xl px-3 py-1.5 ${
               isActive
                 ? 'bg-primary-500 dark:bg-primary-400'
                 : 'bg-secondary-100 dark:bg-surface-elevated'

--- a/uniqn-mobile/src/components/board/BoardTypeBadge.test.tsx
+++ b/uniqn-mobile/src/components/board/BoardTypeBadge.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { BoardTypeBadge } from './BoardTypeBadge';
+import type { BoardType } from '@/types/board';
+
+describe('BoardTypeBadge', () => {
+  it.each<[BoardType, string]>([
+    ['notice', '공지'],
+    ['schedule', '일정'],
+    ['free', '자유'],
+    ['tda', 'TDA'],
+    ['substitute', '대타'],
+  ])('renders compact label for %s', (boardType, expected) => {
+    const { getByText } = render(<BoardTypeBadge boardType={boardType} />);
+    expect(getByText(expected)).toBeTruthy();
+  });
+
+  it('includes accessibility label with board type name', () => {
+    const { getByLabelText } = render(<BoardTypeBadge boardType="free" />);
+    expect(getByLabelText('자유 게시판 배지')).toBeTruthy();
+  });
+});

--- a/uniqn-mobile/src/components/board/BoardTypeBadge.tsx
+++ b/uniqn-mobile/src/components/board/BoardTypeBadge.tsx
@@ -1,0 +1,50 @@
+import { Text, View } from 'react-native';
+import type { BoardType } from '@/types/board';
+
+/**
+ * 게시판 타입에 맞는 색상 뱃지 렌더링
+ */
+
+const COMPACT_LABELS: Record<BoardType, string> = {
+  notice: '공지',
+  schedule: '일정',
+  free: '자유',
+  tda: 'TDA',
+  substitute: '대타',
+};
+
+const CONTAINER_STYLES: Record<BoardType, string> = {
+  notice: 'bg-info-100 dark:bg-info-700/30',
+  schedule: 'bg-success-100 dark:bg-success-700/30',
+  free: 'bg-primary-100 dark:bg-primary-900/30',
+  tda: 'bg-secondary-200 dark:bg-secondary-700/40',
+  substitute: 'bg-error-100 dark:bg-error-700/30',
+};
+
+const TEXT_STYLES: Record<BoardType, string> = {
+  notice: 'text-info-700 dark:text-info-500',
+  schedule: 'text-success-700 dark:text-success-500',
+  free: 'text-primary-700 dark:text-primary-300',
+  tda: 'text-secondary-700 dark:text-secondary-200',
+  substitute: 'text-error-700 dark:text-error-500',
+};
+
+interface BoardTypeBadgeProps {
+  boardType: BoardType;
+}
+
+export function BoardTypeBadge({ boardType }: BoardTypeBadgeProps) {
+  const label = COMPACT_LABELS[boardType];
+  return (
+    <View
+      className={`rounded-sm px-1.5 py-0.5 ${CONTAINER_STYLES[boardType]}`}
+      accessible
+      accessibilityRole="text"
+      accessibilityLabel={`${label} 게시판 배지`}
+    >
+      <Text className={`text-xs font-sans-semibold ${TEXT_STYLES[boardType]}`}>{label}</Text>
+    </View>
+  );
+}
+
+export default BoardTypeBadge;

--- a/uniqn-mobile/src/components/board/BoardWriteFab.test.tsx
+++ b/uniqn-mobile/src/components/board/BoardWriteFab.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { BoardWriteFab } from './BoardWriteFab';
+
+jest.mock('@/components/icons', () => ({
+  AddCircleOutlineIcon: () => null,
+}));
+
+jest.mock('@/stores/themeStore', () => ({
+  useThemeStore: (selector: (state: { isDarkMode: boolean }) => unknown) =>
+    selector({ isDarkMode: false }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+describe('BoardWriteFab', () => {
+  it('renders with the 글쓰기 accessibility label', () => {
+    const { getByLabelText } = render(<BoardWriteFab onPress={jest.fn()} />);
+    expect(getByLabelText('글쓰기')).toBeTruthy();
+  });
+
+  it('invokes onPress when tapped', () => {
+    const onPress = jest.fn();
+    const { getByLabelText } = render(<BoardWriteFab onPress={onPress} />);
+    fireEvent.press(getByLabelText('글쓰기'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/uniqn-mobile/src/components/board/BoardWriteFab.tsx
+++ b/uniqn-mobile/src/components/board/BoardWriteFab.tsx
@@ -1,0 +1,36 @@
+import { Pressable, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { AddCircleOutlineIcon } from '@/components/icons';
+import { useThemeStore } from '@/stores/themeStore';
+
+interface BoardWriteFabProps {
+  onPress: () => void;
+}
+
+/** 게시판 글쓰기 플로팅 액션 버튼 */
+export function BoardWriteFab({ onPress }: BoardWriteFabProps) {
+  const isDark = useThemeStore((s) => s.isDarkMode);
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View
+      pointerEvents="box-none"
+      style={{
+        position: 'absolute',
+        right: 16,
+        bottom: 16 + insets.bottom,
+      }}
+    >
+      <Pressable
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel="글쓰기"
+        className="h-12 w-12 items-center justify-center rounded-2xl bg-primary-500 shadow-lg active:opacity-70 dark:bg-primary-400"
+      >
+        <AddCircleOutlineIcon size={24} color={isDark ? '#000000' : '#FFFFFF'} />
+      </Pressable>
+    </View>
+  );
+}
+
+export default BoardWriteFab;

--- a/uniqn-mobile/src/components/board/PinnedNoticeBanner.test.tsx
+++ b/uniqn-mobile/src/components/board/PinnedNoticeBanner.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { PinnedNoticeBanner } from './PinnedNoticeBanner';
+import type { BoardPost } from '@/types/board';
+
+function makeNotice(id: string, title: string): BoardPost {
+  return {
+    id,
+    boardType: 'notice',
+    source: 'announcement',
+    title,
+    body: '',
+    authorId: 'admin',
+    authorName: '관리자',
+    authorRole: 'admin',
+    visibility: 'public',
+    status: 'active',
+    linkedJobPostingId: null,
+    isAutoCreated: true,
+    isLocked: false,
+    lockedBy: null,
+    lockedAt: null,
+    likeCount: 0,
+    dislikeCount: 0,
+    commentCount: 0,
+    viewCount: 0,
+    imageAttachments: [],
+    isPinned: true,
+    lastActivityAt: new Date('2026-04-14T00:00:00.000Z'),
+    createdAt: new Date('2026-04-14T00:00:00.000Z'),
+    updatedAt: new Date('2026-04-14T00:00:00.000Z'),
+  };
+}
+
+describe('PinnedNoticeBanner', () => {
+  it('returns null when notices is empty', () => {
+    const { toJSON } = render(<PinnedNoticeBanner notices={[]} onPress={jest.fn()} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders up to two pinned notices', () => {
+    const notices = [
+      makeNotice('n1', '첫 번째 공지'),
+      makeNotice('n2', '두 번째 공지'),
+      makeNotice('n3', '세 번째 공지'),
+    ];
+    const { getByText, queryByText } = render(
+      <PinnedNoticeBanner notices={notices} onPress={jest.fn()} />
+    );
+    expect(getByText('첫 번째 공지')).toBeTruthy();
+    expect(getByText('두 번째 공지')).toBeTruthy();
+    expect(queryByText('세 번째 공지')).toBeNull();
+  });
+
+  it('calls onPress with the tapped notice', () => {
+    const onPress = jest.fn();
+    const notice = makeNotice('n1', '공지 제목');
+    const { getByText } = render(<PinnedNoticeBanner notices={[notice]} onPress={onPress} />);
+    fireEvent.press(getByText('공지 제목'));
+    expect(onPress).toHaveBeenCalledWith(notice);
+  });
+});

--- a/uniqn-mobile/src/components/board/PinnedNoticeBanner.tsx
+++ b/uniqn-mobile/src/components/board/PinnedNoticeBanner.tsx
@@ -1,0 +1,43 @@
+import { Pressable, Text, View } from 'react-native';
+import { PinIcon } from '@/components/icons';
+import type { BoardPost } from '@/types/board';
+
+interface PinnedNoticeBannerProps {
+  notices: BoardPost[];
+  onPress: (notice: BoardPost) => void;
+}
+
+/** 홈 고정 공지 배너 */
+export function PinnedNoticeBanner({ notices, onPress }: PinnedNoticeBannerProps) {
+  const visible = notices.slice(0, 2);
+  if (visible.length === 0) return null;
+
+  return (
+    <View className="mb-4 rounded-md border-l-2 border-primary-500 bg-primary-50 px-3 py-2 dark:border-primary-400 dark:bg-surface-elevated">
+      <View className="mb-1 flex-row items-center gap-1">
+        <PinIcon size={12} color="#D4AF37" />
+        <Text className="text-xs font-sans-semibold text-primary-700 dark:text-primary-300">
+          고정 공지
+        </Text>
+      </View>
+      {visible.map((notice) => (
+        <Pressable
+          key={notice.id}
+          onPress={() => onPress(notice)}
+          accessibilityRole="button"
+          accessibilityLabel={`고정 공지: ${notice.title}`}
+          className="py-1 active:opacity-70"
+        >
+          <Text
+            numberOfLines={1}
+            className="text-sm font-sans text-content-primary dark:text-secondary-100"
+          >
+            {notice.title}
+          </Text>
+        </Pressable>
+      ))}
+    </View>
+  );
+}
+
+export default PinnedNoticeBanner;

--- a/uniqn-mobile/src/components/board/__tests__/BoardPostCard.test.tsx
+++ b/uniqn-mobile/src/components/board/__tests__/BoardPostCard.test.tsx
@@ -1,28 +1,15 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 import { BoardPostCard } from '../BoardPostCard';
 import type { BoardPost } from '@/types/board';
-
-jest.mock('@/components/ui', () => {
-  const ReactNative = jest.requireActual('react-native') as typeof import('react-native');
-
-  return {
-    Card: ({ children, onPress }: { children: React.ReactNode; onPress?: () => void }) => (
-      <ReactNative.Pressable onPress={onPress}>{children}</ReactNative.Pressable>
-    ),
-    Badge: ({ children }: { children: React.ReactNode }) => (
-      <ReactNative.Text>{children}</ReactNative.Text>
-    ),
-  };
-});
 
 function createMockPost(overrides: Partial<BoardPost> = {}): BoardPost {
   return {
     id: 'post-1',
     boardType: 'free',
     source: 'board',
-    title: '테스트 글',
-    body: '본문',
+    title: '테스트 글 제목',
+    body: '본문 내용은 더 이상 리스트에 표시되지 않습니다',
     authorId: 'user-1',
     authorName: '작성자',
     authorRole: 'staff',
@@ -33,39 +20,56 @@ function createMockPost(overrides: Partial<BoardPost> = {}): BoardPost {
     isLocked: false,
     lockedBy: null,
     lockedAt: null,
-    likeCount: 2222,
-    dislikeCount: 3333,
-    commentCount: 1111,
-    viewCount: 4444,
+    likeCount: 24,
+    dislikeCount: 3,
+    commentCount: 12,
+    viewCount: 340,
     imageAttachments: [],
-    lastActivityAt: new Date('2026-04-05T09:00:00.000Z'),
-    createdAt: new Date('2026-04-05T08:00:00.000Z'),
-    updatedAt: new Date('2026-04-05T08:30:00.000Z'),
+    lastActivityAt: new Date('2026-04-15T09:00:00.000Z'),
+    createdAt: new Date('2026-04-15T08:00:00.000Z'),
+    updatedAt: new Date('2026-04-15T08:30:00.000Z'),
     ...overrides,
   };
 }
 
 describe('BoardPostCard', () => {
-  it('hides engagement counters for notice posts', () => {
-    const { queryByText, getByText } = render(
-      <BoardPostCard
-        post={createMockPost({ boardType: 'notice', source: 'announcement' })}
-        onPress={jest.fn()}
-      />
+  it('renders title but not body preview (density mode)', () => {
+    const { getByText, queryByText } = render(
+      <BoardPostCard post={createMockPost()} onPress={jest.fn()} />
     );
-
-    expect(queryByText('1111')).toBeNull();
-    expect(queryByText('2222')).toBeNull();
-    expect(queryByText('3333')).toBeNull();
-    expect(getByText('4444')).toBeTruthy();
+    expect(getByText('테스트 글 제목')).toBeTruthy();
+    expect(queryByText('본문 내용은 더 이상 리스트에 표시되지 않습니다')).toBeNull();
   });
 
-  it('shows engagement counters for community posts', () => {
+  it('renders all four meta counts regardless of board type', () => {
     const { getByText } = render(<BoardPostCard post={createMockPost()} onPress={jest.fn()} />);
+    expect(getByText('12')).toBeTruthy();
+    expect(getByText('340')).toBeTruthy();
+    expect(getByText('24')).toBeTruthy();
+    expect(getByText('3')).toBeTruthy();
+  });
 
-    expect(getByText('1111')).toBeTruthy();
-    expect(getByText('2222')).toBeTruthy();
-    expect(getByText('3333')).toBeTruthy();
-    expect(getByText('4444')).toBeTruthy();
+  it('renders all four meta counts for notice posts as well', () => {
+    const post = createMockPost({ boardType: 'notice', source: 'announcement' });
+    const { getByText } = render(<BoardPostCard post={post} onPress={jest.fn()} />);
+    expect(getByText('12')).toBeTruthy();
+    expect(getByText('340')).toBeTruthy();
+    expect(getByText('24')).toBeTruthy();
+    expect(getByText('3')).toBeTruthy();
+  });
+
+  it('formats counts over 1000 using compact notation', () => {
+    const post = createMockPost({ viewCount: 1250, commentCount: 2100 });
+    const { getByText } = render(<BoardPostCard post={post} onPress={jest.fn()} />);
+    expect(getByText('1.3k')).toBeTruthy();
+    expect(getByText('2.1k')).toBeTruthy();
+  });
+
+  it('calls onPress with the post when tapped', () => {
+    const onPress = jest.fn();
+    const post = createMockPost();
+    const { getByRole } = render(<BoardPostCard post={post} onPress={onPress} />);
+    fireEvent.press(getByRole('button'));
+    expect(onPress).toHaveBeenCalledWith(post);
   });
 });

--- a/uniqn-mobile/src/components/employer/job-form/sections/SalarySection/SalarySection.tsx
+++ b/uniqn-mobile/src/components/employer/job-form/sections/SalarySection/SalarySection.tsx
@@ -6,17 +6,10 @@
  */
 
 import { SECONDARY_PALETTE } from '@/constants/colors';
-import React, { useCallback, useMemo, memo, useEffect } from 'react';
+import React, { useCallback, useMemo, memo } from 'react';
 import { View, Text, Switch } from 'react-native';
 import { useAllowances } from '@/hooks';
-import {
-  extractRolesFromPosting,
-  syncRolesWithExtracted,
-  parseCurrency,
-  calculateEstimatedCost,
-  calculateTotalCount,
-} from '@/utils/salary';
-import { shouldPreserveNonFixedDraftRoles } from '@/utils/job-posting/draftRoles';
+import { parseCurrency, calculateEstimatedCost, calculateTotalCount } from '@/utils/salary';
 import type { SalaryType, SalaryInfo, TaxSettings } from '@/types';
 import { TaxSettingsEditor } from '@/components/employer/settlement/TaxSettingsEditor';
 import { DEFAULT_TAX_SETTINGS } from '@/domains/settlement';
@@ -39,37 +32,8 @@ export const SalarySection = memo(function SalarySection({
   onUpdate,
   errors = {},
 }: SalarySectionProps) {
-  // ============================================================================
-  // 역할 추출 로직 (유틸리티 함수 사용)
-  // ============================================================================
-  const extractedRoles = useMemo(
-    () => extractRolesFromPosting(data.postingType, data.roles, data.dateSpecificRequirements),
-    [data.postingType, data.roles, data.dateSpecificRequirements]
-  );
-
-  // ============================================================================
-  // 역할 변경 시 data.roles 동기화
-  // ============================================================================
-  useEffect(() => {
-    // fixed 타입은 이미 data.roles를 직접 사용하므로 동기화 불필요
-    if (data.postingType === 'fixed') return;
-
-    if (extractedRoles.length === 0 && shouldPreserveNonFixedDraftRoles(data)) {
-      return;
-    }
-
-    const updatedRoles = syncRolesWithExtracted(
-      extractedRoles,
-      data.roles,
-      data.useSameSalary ?? false
-    );
-
-    if (updatedRoles) {
-      onUpdate({ roles: updatedRoles });
-    }
-  }, [extractedRoles, data, onUpdate]);
-
-  // 실제 표시할 역할 목록
+  // data.roles는 draftToFormData → buildDatedFormRoles 경로에서 timeSlots로부터 자동 파생되므로
+  // 이 컴포넌트에서 별도 sync effect를 돌리면 draft→formData→effect→patch→draft 무한 루프 발생.
   const roles = data.roles;
 
   // 전체 동일 급여 토글

--- a/uniqn-mobile/src/components/employer/posting/JobPostingCard.tsx
+++ b/uniqn-mobile/src/components/employer/posting/JobPostingCard.tsx
@@ -60,7 +60,7 @@ export const JobPostingCard = memo(function JobPostingCard({
                 <TournamentStatusBadge
                   status={posting.tournamentConfig.approvalStatus as TournamentApprovalStatus}
                   rejectionReason={posting.tournamentConfig.rejectionReason}
-                  postingId={posting.id}
+                  jobPostingId={posting.id}
                   size="sm"
                 />
               ) : null}

--- a/uniqn-mobile/src/components/jobs/ResubmitButton.tsx
+++ b/uniqn-mobile/src/components/jobs/ResubmitButton.tsx
@@ -17,7 +17,7 @@ import { useTournamentApproval } from '@/hooks/useTournamentApproval';
 
 interface ResubmitButtonProps {
   /** 공고 ID */
-  postingId: string;
+  jobPostingId: string;
   /** 버튼 크기 */
   size?: 'sm' | 'md' | 'lg';
   /** 전체 너비 사용 */
@@ -33,7 +33,7 @@ interface ResubmitButtonProps {
 // ============================================================================
 
 export function ResubmitButton({
-  postingId,
+  jobPostingId,
   size = 'md',
   fullWidth = false,
   onSuccess,
@@ -71,7 +71,7 @@ export function ResubmitButton({
   // 재제출 확인
   const handleConfirm = useCallback(() => {
     resubmit
-      .mutateAsync({ postingId })
+      .mutateAsync({ jobPostingId })
       .then(() => {
         setShowConfirmModal(false);
         onSuccess?.();
@@ -80,7 +80,7 @@ export function ResubmitButton({
         // 에러는 useTournamentApproval에서 토스트로 처리됨
         setShowConfirmModal(false);
       });
-  }, [postingId, resubmit, onSuccess]);
+  }, [jobPostingId, resubmit, onSuccess]);
 
   // 모달 닫기
   const handleClose = useCallback(() => {

--- a/uniqn-mobile/src/components/jobs/TournamentStatusBadge.tsx
+++ b/uniqn-mobile/src/components/jobs/TournamentStatusBadge.tsx
@@ -54,7 +54,7 @@ type TournamentStatusBadgeProps = (
   /** 추가 className */
   className?: string;
   /** 공고 ID (재제출 기능 활성화용) */
-  postingId?: string;
+  jobPostingId?: string;
   /** 재제출 성공 시 콜백 */
   onResubmitSuccess?: () => void;
 };
@@ -132,7 +132,7 @@ export const TournamentStatusBadge = memo(function TournamentStatusBadge(
     showRejectionReason = true,
     size = 'md',
     className = '',
-    postingId,
+    jobPostingId,
     onResubmitSuccess,
   } = props;
 
@@ -186,11 +186,11 @@ export const TournamentStatusBadge = memo(function TournamentStatusBadge(
 
   // 수정하기 버튼
   const handleEdit = useCallback(() => {
-    if (postingId) {
+    if (jobPostingId) {
       setShowModal(false);
-      router.push(`/(employer)/my-postings/${postingId}/edit`);
+      router.push(`/(employer)/my-postings/${jobPostingId}/edit`);
     }
-  }, [postingId]);
+  }, [jobPostingId]);
 
   // 재제출 버튼 클릭
   const handleResubmitPress = useCallback(() => {
@@ -199,10 +199,10 @@ export const TournamentStatusBadge = memo(function TournamentStatusBadge(
 
   // 재제출 확인
   const handleResubmitConfirm = useCallback(() => {
-    if (!postingId) return;
+    if (!jobPostingId) return;
 
     resubmit
-      .mutateAsync({ postingId })
+      .mutateAsync({ jobPostingId })
       .then(() => {
         setShowConfirmModal(false);
         setShowModal(false);
@@ -211,7 +211,7 @@ export const TournamentStatusBadge = memo(function TournamentStatusBadge(
       .catch(() => {
         setShowConfirmModal(false);
       });
-  }, [postingId, resubmit, onResubmitSuccess]);
+  }, [jobPostingId, resubmit, onResubmitSuccess]);
 
   // 재제출 확인 모달 닫기
   const handleConfirmClose = useCallback(() => {
@@ -278,8 +278,8 @@ export const TournamentStatusBadge = memo(function TournamentStatusBadge(
               공고 내용을 수정한 후 재제출하시면 다시 검토됩니다.
             </Text>
 
-            {/* 액션 버튼 (postingId가 있을 때만 표시) */}
-            {postingId && (
+            {/* 액션 버튼 (jobPostingId가 있을 때만 표시) */}
+            {jobPostingId && (
               <View className="flex-row">
                 <Pressable
                   onPress={handleEdit}

--- a/uniqn-mobile/src/hooks/useTournamentApproval.ts
+++ b/uniqn-mobile/src/hooks/useTournamentApproval.ts
@@ -44,22 +44,22 @@ interface UseTournamentApprovalReturn {
 
   // 승인 mutation
   approve: {
-    mutate: (postingId: string) => void;
-    mutateAsync: (data: { postingId: string }) => Promise<unknown>;
+    mutate: (jobPostingId: string) => void;
+    mutateAsync: (data: { jobPostingId: string }) => Promise<unknown>;
     isPending: boolean;
   };
 
   // 거부 mutation
   reject: {
-    mutate: (data: { postingId: string; reason: string }) => void;
-    mutateAsync: (data: { postingId: string; reason: string }) => Promise<unknown>;
+    mutate: (data: { jobPostingId: string; reason: string }) => void;
+    mutateAsync: (data: { jobPostingId: string; reason: string }) => Promise<unknown>;
     isPending: boolean;
   };
 
   // 재제출 mutation
   resubmit: {
-    mutate: (postingId: string) => void;
-    mutateAsync: (data: { postingId: string }) => Promise<unknown>;
+    mutate: (jobPostingId: string) => void;
+    mutateAsync: (data: { jobPostingId: string }) => Promise<unknown>;
     isPending: boolean;
   };
 
@@ -119,44 +119,44 @@ export function useTournamentApproval(
 
   // 승인 뮤테이션
   const approveMutation = useMutation({
-    mutationFn: (postingId: string) => tournamentApprovalService.approve({ postingId }),
-    onSuccess: (_, postingId) => {
+    mutationFn: (jobPostingId: string) => tournamentApprovalService.approve({ jobPostingId }),
+    onSuccess: (_, jobPostingId) => {
       toast.success('대회공고가 승인되었습니다');
       invalidateQueries.tournamentApproval();
-      logger.info('대회공고 승인 완료', { postingId });
+      logger.info('대회공고 승인 완료', { jobPostingId });
     },
-    onError: (error: Error, postingId) => {
+    onError: (error: Error, jobPostingId) => {
       toast.error(extractErrorMessage(error, '승인에 실패했습니다'));
-      logger.error('대회공고 승인 실패', error, { postingId });
+      logger.error('대회공고 승인 실패', error, { jobPostingId });
     },
   });
 
   // 거부 뮤테이션
   const rejectMutation = useMutation({
-    mutationFn: ({ postingId, reason }: { postingId: string; reason: string }) =>
-      tournamentApprovalService.reject({ postingId, reason }),
-    onSuccess: (_, { postingId }) => {
+    mutationFn: ({ jobPostingId, reason }: { jobPostingId: string; reason: string }) =>
+      tournamentApprovalService.reject({ jobPostingId, reason }),
+    onSuccess: (_, { jobPostingId }) => {
       toast.success('대회공고가 거부되었습니다');
       invalidateQueries.tournamentApproval();
-      logger.info('대회공고 거부 완료', { postingId });
+      logger.info('대회공고 거부 완료', { jobPostingId });
     },
-    onError: (error: Error, { postingId }) => {
+    onError: (error: Error, { jobPostingId }) => {
       toast.error(extractErrorMessage(error, '거부에 실패했습니다'));
-      logger.error('대회공고 거부 실패', error, { postingId });
+      logger.error('대회공고 거부 실패', error, { jobPostingId });
     },
   });
 
   // 재제출 뮤테이션
   const resubmitMutation = useMutation({
-    mutationFn: (postingId: string) => tournamentApprovalService.resubmit({ postingId }),
-    onSuccess: (_, postingId) => {
+    mutationFn: (jobPostingId: string) => tournamentApprovalService.resubmit({ jobPostingId }),
+    onSuccess: (_, jobPostingId) => {
       toast.success('대회공고가 재제출되었습니다');
       invalidateQueries.tournamentApproval();
-      logger.info('대회공고 재제출 완료', { postingId });
+      logger.info('대회공고 재제출 완료', { jobPostingId });
     },
-    onError: (error: Error, postingId) => {
+    onError: (error: Error, jobPostingId) => {
       toast.error(extractErrorMessage(error, '재제출에 실패했습니다'));
-      logger.error('대회공고 재제출 실패', error, { postingId });
+      logger.error('대회공고 재제출 실패', error, { jobPostingId });
     },
   });
 
@@ -165,22 +165,22 @@ export function useTournamentApproval(
   // ============================================================================
 
   const approve = useCallback(
-    (postingId: string) => {
-      approveMutation.mutate(postingId);
+    (jobPostingId: string) => {
+      approveMutation.mutate(jobPostingId);
     },
     [approveMutation]
   );
 
   const reject = useCallback(
-    (data: { postingId: string; reason: string }) => {
+    (data: { jobPostingId: string; reason: string }) => {
       rejectMutation.mutate(data);
     },
     [rejectMutation]
   );
 
   const resubmit = useCallback(
-    (postingId: string) => {
-      resubmitMutation.mutate(postingId);
+    (jobPostingId: string) => {
+      resubmitMutation.mutate(jobPostingId);
     },
     [resubmitMutation]
   );
@@ -205,8 +205,8 @@ export function useTournamentApproval(
     // 승인 mutation
     approve: {
       mutate: approve,
-      mutateAsync: async (data: { postingId: string }) => {
-        return approveMutation.mutateAsync(data.postingId);
+      mutateAsync: async (data: { jobPostingId: string }) => {
+        return approveMutation.mutateAsync(data.jobPostingId);
       },
       isPending: approveMutation.isPending,
     },
@@ -221,8 +221,8 @@ export function useTournamentApproval(
     // 재제출 mutation
     resubmit: {
       mutate: resubmit,
-      mutateAsync: async (data: { postingId: string }) => {
-        return resubmitMutation.mutateAsync(data.postingId);
+      mutateAsync: async (data: { jobPostingId: string }) => {
+        return resubmitMutation.mutateAsync(data.jobPostingId);
       },
       isPending: resubmitMutation.isPending,
     },

--- a/uniqn-mobile/src/schemas/tournament.schema.ts
+++ b/uniqn-mobile/src/schemas/tournament.schema.ts
@@ -48,7 +48,7 @@ export const rejectionReasonSchema = z
  * 승인 요청 스키마
  */
 export const approveTournamentSchema = z.object({
-  postingId: z.string().min(1, '공고 ID가 필요합니다'),
+  jobPostingId: z.string().min(1, '공고 ID가 필요합니다'),
 });
 
 export type ApproveTournamentData = z.infer<typeof approveTournamentSchema>;
@@ -57,7 +57,7 @@ export type ApproveTournamentData = z.infer<typeof approveTournamentSchema>;
  * 거부 요청 스키마
  */
 export const rejectTournamentSchema = z.object({
-  postingId: z.string().min(1, '공고 ID가 필요합니다'),
+  jobPostingId: z.string().min(1, '공고 ID가 필요합니다'),
   reason: rejectionReasonSchema,
 });
 
@@ -67,7 +67,7 @@ export type RejectTournamentData = z.infer<typeof rejectTournamentSchema>;
  * 재제출 요청 스키마
  */
 export const resubmitTournamentSchema = z.object({
-  postingId: z.string().min(1, '공고 ID가 필요합니다'),
+  jobPostingId: z.string().min(1, '공고 ID가 필요합니다'),
 });
 
 export type ResubmitTournamentData = z.infer<typeof resubmitTournamentSchema>;

--- a/uniqn-mobile/src/services/admin/__tests__/tournamentApprovalService.test.ts
+++ b/uniqn-mobile/src/services/admin/__tests__/tournamentApprovalService.test.ts
@@ -38,11 +38,15 @@ jest.mock('@/repositories', () => ({
 // ============================================================================
 
 const mockHttpsCallable = jest.fn();
+const mockGetSession = jest.fn();
 
 jest.mock('@/lib/supabase', () => ({
   supabase: {
     functions: {
       invoke: (...args: unknown[]) => mockHttpsCallable(...args),
+    },
+    auth: {
+      getSession: (...args: unknown[]) => mockGetSession(...args),
     },
     from: jest.fn(() => ({
       select: jest.fn().mockReturnThis(),
@@ -86,28 +90,34 @@ jest.mock('@/constants', () => ({
 describe('TournamentApprovalService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // 기본: 유효한 세션이 있다고 가정
+    mockGetSession.mockResolvedValue({
+      data: { session: { access_token: 'test-access-token' } },
+      error: null,
+    });
   });
 
   describe('approveTournamentPosting', () => {
-    const postingId = 'tournament-1';
+    const jobPostingId = 'tournament-1';
     const approvedBy = 'admin-1';
     const approvedAt = '2026-02-12T00:00:00.000Z';
 
     it('성공: 대회공고 승인', async () => {
       const mockResponse = {
         success: true,
-        postingId,
+        jobPostingId,
         approvedBy,
         approvedAt,
       };
 
       mockHttpsCallable.mockResolvedValue({ data: mockResponse });
 
-      const result = await approveTournamentPosting({ postingId });
+      const result = await approveTournamentPosting({ jobPostingId });
 
       expect(result).toEqual(mockResponse);
       expect(mockHttpsCallable).toHaveBeenCalledWith('approve-job-posting', {
-        body: { postingId },
+        body: { jobPostingId: jobPostingId },
+        headers: { Authorization: 'Bearer test-access-token' },
       });
     });
 
@@ -117,7 +127,9 @@ describe('TournamentApprovalService', () => {
         error: { message: 'Unauthenticated', context: { status: 401 } },
       });
 
-      await expect(approveTournamentPosting({ postingId })).rejects.toThrow('로그인이 필요합니다');
+      await expect(approveTournamentPosting({ jobPostingId })).rejects.toThrow(
+        '로그인이 필요합니다'
+      );
     });
 
     it('실패: 관리자 권한 없음 (403)', async () => {
@@ -126,7 +138,7 @@ describe('TournamentApprovalService', () => {
         error: { message: 'Permission denied', context: { status: 403 } },
       });
 
-      await expect(approveTournamentPosting({ postingId })).rejects.toThrow('권한이 없습니다');
+      await expect(approveTournamentPosting({ jobPostingId })).rejects.toThrow('권한이 없습니다');
     });
 
     it('실패: 공고를 찾을 수 없음 (404)', async () => {
@@ -135,7 +147,7 @@ describe('TournamentApprovalService', () => {
         error: { message: 'Document not found', context: { status: 404 } },
       });
 
-      await expect(approveTournamentPosting({ postingId })).rejects.toThrow(
+      await expect(approveTournamentPosting({ jobPostingId })).rejects.toThrow(
         '공고를 찾을 수 없습니다'
       );
     });
@@ -149,7 +161,7 @@ describe('TournamentApprovalService', () => {
         },
       });
 
-      await expect(approveTournamentPosting({ postingId })).rejects.toThrow('Already processed');
+      await expect(approveTournamentPosting({ jobPostingId })).rejects.toThrow('Already processed');
     });
 
     it('실패: 잘못된 요청 (422)', async () => {
@@ -161,18 +173,30 @@ describe('TournamentApprovalService', () => {
         },
       });
 
-      await expect(approveTournamentPosting({ postingId })).rejects.toThrow();
+      await expect(approveTournamentPosting({ jobPostingId })).rejects.toThrow();
     });
 
     it('실패: 네트워크 에러', async () => {
       mockHttpsCallable.mockRejectedValue(new Error('Network error'));
 
-      await expect(approveTournamentPosting({ postingId })).rejects.toThrow();
+      await expect(approveTournamentPosting({ jobPostingId })).rejects.toThrow();
+    });
+
+    it('실패: 세션 없음 (로그아웃 상태)', async () => {
+      mockGetSession.mockResolvedValue({
+        data: { session: null },
+        error: null,
+      });
+
+      await expect(approveTournamentPosting({ jobPostingId })).rejects.toThrow(
+        '로그인이 필요합니다'
+      );
+      expect(mockHttpsCallable).not.toHaveBeenCalled();
     });
   });
 
   describe('rejectTournamentPosting', () => {
-    const postingId = 'tournament-1';
+    const jobPostingId = 'tournament-1';
     const reason = '대회 정보가 부정확합니다. 재제출 시 참가 인원 및 일정을 확인해주세요.';
     const rejectedBy = 'admin-1';
     const rejectedAt = '2026-02-12T00:00:00.000Z';
@@ -180,7 +204,7 @@ describe('TournamentApprovalService', () => {
     it('성공: 대회공고 거부', async () => {
       const mockResponse = {
         success: true,
-        postingId,
+        jobPostingId,
         rejectedBy,
         rejectedAt,
         reason,
@@ -188,11 +212,12 @@ describe('TournamentApprovalService', () => {
 
       mockHttpsCallable.mockResolvedValue({ data: mockResponse });
 
-      const result = await rejectTournamentPosting({ postingId, reason });
+      const result = await rejectTournamentPosting({ jobPostingId, reason });
 
       expect(result).toEqual(mockResponse);
       expect(mockHttpsCallable).toHaveBeenCalledWith('reject-job-posting', {
-        body: { postingId, reason },
+        body: { jobPostingId: jobPostingId, reason },
+        headers: { Authorization: 'Bearer test-access-token' },
       });
     });
 
@@ -200,7 +225,7 @@ describe('TournamentApprovalService', () => {
       const longReason = '거부 사유 내용입니다. '.repeat(30);
       const mockResponse = {
         success: true,
-        postingId,
+        jobPostingId,
         rejectedBy,
         rejectedAt,
         reason: longReason,
@@ -208,7 +233,7 @@ describe('TournamentApprovalService', () => {
 
       mockHttpsCallable.mockResolvedValue({ data: mockResponse });
 
-      const result = await rejectTournamentPosting({ postingId, reason: longReason });
+      const result = await rejectTournamentPosting({ jobPostingId, reason: longReason });
 
       expect(result).toEqual(mockResponse);
     });
@@ -219,7 +244,7 @@ describe('TournamentApprovalService', () => {
         error: { message: 'Permission denied', context: { status: 403 } },
       });
 
-      await expect(rejectTournamentPosting({ postingId, reason })).rejects.toThrow(
+      await expect(rejectTournamentPosting({ jobPostingId, reason })).rejects.toThrow(
         '권한이 없습니다'
       );
     });
@@ -230,7 +255,7 @@ describe('TournamentApprovalService', () => {
         error: { message: 'Posting not found', context: { status: 404 } },
       });
 
-      await expect(rejectTournamentPosting({ postingId, reason })).rejects.toThrow(
+      await expect(rejectTournamentPosting({ jobPostingId, reason })).rejects.toThrow(
         '공고를 찾을 수 없습니다'
       );
     });
@@ -244,7 +269,7 @@ describe('TournamentApprovalService', () => {
         },
       });
 
-      await expect(rejectTournamentPosting({ postingId, reason })).rejects.toThrow(
+      await expect(rejectTournamentPosting({ jobPostingId, reason })).rejects.toThrow(
         'Already approved'
       );
     });
@@ -258,30 +283,33 @@ describe('TournamentApprovalService', () => {
         },
       });
 
-      await expect(rejectTournamentPosting({ postingId, reason: 'too short' })).rejects.toThrow();
+      await expect(
+        rejectTournamentPosting({ jobPostingId, reason: 'too short' })
+      ).rejects.toThrow();
     });
   });
 
   describe('resubmitTournamentPosting', () => {
-    const postingId = 'tournament-1';
+    const jobPostingId = 'tournament-1';
     const resubmittedBy = 'employer-1';
     const resubmittedAt = '2026-02-12T00:00:00.000Z';
 
     it('성공: 대회공고 재제출', async () => {
       const mockResponse = {
         success: true,
-        postingId,
+        jobPostingId,
         resubmittedBy,
         resubmittedAt,
       };
 
       mockHttpsCallable.mockResolvedValue({ data: mockResponse });
 
-      const result = await resubmitTournamentPosting({ postingId });
+      const result = await resubmitTournamentPosting({ jobPostingId });
 
       expect(result).toEqual(mockResponse);
       expect(mockHttpsCallable).toHaveBeenCalledWith('resubmit-job-posting', {
-        body: { postingId },
+        body: { jobPostingId: jobPostingId },
+        headers: { Authorization: 'Bearer test-access-token' },
       });
     });
 
@@ -291,7 +319,9 @@ describe('TournamentApprovalService', () => {
         error: { message: 'Unauthenticated', context: { status: 401 } },
       });
 
-      await expect(resubmitTournamentPosting({ postingId })).rejects.toThrow('로그인이 필요합니다');
+      await expect(resubmitTournamentPosting({ jobPostingId })).rejects.toThrow(
+        '로그인이 필요합니다'
+      );
     });
 
     it('실패: 권한 없음 (공고 소유자가 아님)', async () => {
@@ -300,7 +330,7 @@ describe('TournamentApprovalService', () => {
         error: { message: 'Not owner', context: { status: 403 } },
       });
 
-      await expect(resubmitTournamentPosting({ postingId })).rejects.toThrow('권한이 없습니다');
+      await expect(resubmitTournamentPosting({ jobPostingId })).rejects.toThrow('권한이 없습니다');
     });
 
     it('실패: 공고를 찾을 수 없음', async () => {
@@ -309,7 +339,7 @@ describe('TournamentApprovalService', () => {
         error: { message: 'Posting not found', context: { status: 404 } },
       });
 
-      await expect(resubmitTournamentPosting({ postingId })).rejects.toThrow(
+      await expect(resubmitTournamentPosting({ jobPostingId })).rejects.toThrow(
         '공고를 찾을 수 없습니다'
       );
     });
@@ -326,7 +356,7 @@ describe('TournamentApprovalService', () => {
         },
       });
 
-      await expect(resubmitTournamentPosting({ postingId })).rejects.toThrow(
+      await expect(resubmitTournamentPosting({ jobPostingId })).rejects.toThrow(
         'Not in rejected status'
       );
     });
@@ -340,7 +370,7 @@ describe('TournamentApprovalService', () => {
         },
       });
 
-      await expect(resubmitTournamentPosting({ postingId })).rejects.toThrow();
+      await expect(resubmitTournamentPosting({ jobPostingId })).rejects.toThrow();
     });
   });
 
@@ -581,11 +611,11 @@ describe('TournamentApprovalService', () => {
   });
 
   describe('getTournamentPostingById', () => {
-    const postingId = 'tournament-1';
+    const jobPostingId = 'tournament-1';
 
     it('성공: 대회공고 조회', async () => {
       const mockPosting: JobPosting = {
-        id: postingId,
+        id: jobPostingId,
         title: '서울 홀덤 토너먼트',
         postingType: 'tournament',
         tournamentConfig: { approvalStatus: 'pending' },
@@ -593,44 +623,44 @@ describe('TournamentApprovalService', () => {
 
       mockGetById.mockResolvedValue(mockPosting);
 
-      const result = await getTournamentPostingById(postingId);
+      const result = await getTournamentPostingById(jobPostingId);
 
       expect(result).toEqual(mockPosting);
-      expect(mockGetById).toHaveBeenCalledWith(postingId);
+      expect(mockGetById).toHaveBeenCalledWith(jobPostingId);
     });
 
     it('성공: 공고를 찾을 수 없음 (null 반환)', async () => {
       mockGetById.mockResolvedValue(null);
 
-      const result = await getTournamentPostingById(postingId);
+      const result = await getTournamentPostingById(jobPostingId);
 
       expect(result).toBeNull();
     });
 
     it('성공: 대회공고가 아닌 경우 (null 반환)', async () => {
       const mockPosting: JobPosting = {
-        id: postingId,
+        id: jobPostingId,
         title: '일반 공고',
         postingType: 'regular',
       } as JobPosting;
 
       mockGetById.mockResolvedValue(mockPosting);
 
-      const result = await getTournamentPostingById(postingId);
+      const result = await getTournamentPostingById(jobPostingId);
 
       expect(result).toBeNull();
     });
 
     it('성공: postingType이 undefined인 경우 (null 반환)', async () => {
       const mockPosting: JobPosting = {
-        id: postingId,
+        id: jobPostingId,
         title: '레거시 공고',
         postingType: undefined,
       } as JobPosting;
 
       mockGetById.mockResolvedValue(mockPosting);
 
-      const result = await getTournamentPostingById(postingId);
+      const result = await getTournamentPostingById(jobPostingId);
 
       expect(result).toBeNull();
     });
@@ -638,25 +668,25 @@ describe('TournamentApprovalService', () => {
     it('실패: Repository 에러', async () => {
       mockGetById.mockRejectedValue(new Error('Database error'));
 
-      await expect(getTournamentPostingById(postingId)).rejects.toThrow();
+      await expect(getTournamentPostingById(jobPostingId)).rejects.toThrow();
     });
   });
 
   describe('Edge Cases', () => {
-    it('approveTournamentPosting: 빈 postingId', async () => {
+    it('approveTournamentPosting: 빈 jobPostingId', async () => {
       mockHttpsCallable.mockRejectedValue({
         code: 'invalid-argument',
         message: 'Empty posting ID',
       });
 
-      await expect(approveTournamentPosting({ postingId: '' })).rejects.toThrow();
+      await expect(approveTournamentPosting({ jobPostingId: '' })).rejects.toThrow();
     });
 
     it('rejectTournamentPosting: 특수문자 포함 사유', async () => {
       const reason = '대회 내용에 <script> 태그가 포함되어 있습니다. 제거 후 재제출해주세요.';
       const mockResponse = {
         success: true,
-        postingId: 'tournament-1',
+        jobPostingId: 'tournament-1',
         rejectedBy: 'admin-1',
         rejectedAt: '2026-02-12T00:00:00.000Z',
         reason,
@@ -664,7 +694,7 @@ describe('TournamentApprovalService', () => {
 
       mockHttpsCallable.mockResolvedValue({ data: mockResponse });
 
-      const result = await rejectTournamentPosting({ postingId: 'tournament-1', reason });
+      const result = await rejectTournamentPosting({ jobPostingId: 'tournament-1', reason });
 
       expect(result.reason).toBe(reason);
     });

--- a/uniqn-mobile/src/services/admin/tournamentApprovalService.ts
+++ b/uniqn-mobile/src/services/admin/tournamentApprovalService.ts
@@ -44,7 +44,7 @@ import type {
  */
 interface ApprovalResponse {
   success: boolean;
-  postingId: string;
+  jobPostingId: string;
   approvedBy?: string;
   approvedAt?: string;
   rejectedBy?: string;
@@ -109,6 +109,28 @@ async function mapEdgeFunctionError(error: unknown): Promise<Error> {
 }
 
 // ============================================================================
+// Auth Helper
+// ============================================================================
+
+/**
+ * 현재 세션의 access token 획득
+ *
+ * @description Supabase JS v2의 FunctionsClient는 onAuthStateChange 시
+ * 자동으로 Authorization 헤더를 갱신하지 않아, 세션이 stale이면 anon key로
+ * 폴백되어 Edge Function이 401을 반환함. 명시적으로 세션 토큰을 꺼내 헤더에
+ * 주입해야 함. authCoreService.ts / portOneIdentityService.ts 참고.
+ */
+async function getAccessTokenOrThrow(): Promise<string> {
+  const { data, error } = await supabase.auth.getSession();
+  if (error || !data.session?.access_token) {
+    throw new AuthError(ERROR_CODES.AUTH_SESSION_EXPIRED, {
+      userMessage: '로그인이 필요합니다',
+    });
+  }
+  return data.session.access_token;
+}
+
+// ============================================================================
 // Approval Actions
 // ============================================================================
 
@@ -122,23 +144,27 @@ export async function approveTournamentPosting(
   data: ApproveTournamentData
 ): Promise<ApprovalResponse> {
   try {
-    logger.info('대회공고 승인 요청', { postingId: data.postingId });
+    logger.info('대회공고 승인 요청', { jobPostingId: data.jobPostingId });
 
+    const accessToken = await getAccessTokenOrThrow();
     const { data: result, error } = await supabase.functions.invoke<ApprovalResponse>(
       'approve-job-posting',
-      { body: data }
+      {
+        body: data,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      }
     );
     if (error) throw error;
 
     logger.info('대회공고 승인 완료', {
-      postingId: data.postingId,
+      jobPostingId: data.jobPostingId,
       approvedBy: result?.approvedBy,
     });
 
     return result!;
   } catch (error) {
     logger.error('대회공고 승인 실패', toError(error), {
-      postingId: data.postingId,
+      jobPostingId: data.jobPostingId,
     });
     throw await mapEdgeFunctionError(error);
   }
@@ -148,7 +174,7 @@ export async function approveTournamentPosting(
  * 대회공고 거부 (관리자 전용)
  *
  * @description Edge Function 'reject-job-posting' 호출
- * @param data.postingId - 공고 ID
+ * @param data.jobPostingId - 공고 ID
  * @param data.reason - 거부 사유 (최소 10자)
  * @throws BusinessError - 권한 없음, 공고 없음, 이미 처리됨, 사유 부족
  */
@@ -157,25 +183,29 @@ export async function rejectTournamentPosting(
 ): Promise<ApprovalResponse> {
   try {
     logger.info('대회공고 거부 요청', {
-      postingId: data.postingId,
+      jobPostingId: data.jobPostingId,
       reasonLength: data.reason.length,
     });
 
+    const accessToken = await getAccessTokenOrThrow();
     const { data: result, error } = await supabase.functions.invoke<ApprovalResponse>(
       'reject-job-posting',
-      { body: data }
+      {
+        body: data,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      }
     );
     if (error) throw error;
 
     logger.info('대회공고 거부 완료', {
-      postingId: data.postingId,
+      jobPostingId: data.jobPostingId,
       rejectedBy: result?.rejectedBy,
     });
 
     return result!;
   } catch (error) {
     logger.error('대회공고 거부 실패', toError(error), {
-      postingId: data.postingId,
+      jobPostingId: data.jobPostingId,
     });
     throw await mapEdgeFunctionError(error);
   }
@@ -185,30 +215,34 @@ export async function rejectTournamentPosting(
  * 대회공고 재제출 (구인자 전용)
  *
  * @description Edge Function 'resubmit-job-posting' 호출
- * @param data.postingId - 거부된 공고 ID
+ * @param data.jobPostingId - 거부된 공고 ID
  * @throws BusinessError - 권한 없음, 공고 없음, rejected 상태 아님
  */
 export async function resubmitTournamentPosting(
   data: ResubmitTournamentData
 ): Promise<ApprovalResponse> {
   try {
-    logger.info('대회공고 재제출 요청', { postingId: data.postingId });
+    logger.info('대회공고 재제출 요청', { jobPostingId: data.jobPostingId });
 
+    const accessToken = await getAccessTokenOrThrow();
     const { data: result, error } = await supabase.functions.invoke<ApprovalResponse>(
       'resubmit-job-posting',
-      { body: data }
+      {
+        body: data,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      }
     );
     if (error) throw error;
 
     logger.info('대회공고 재제출 완료', {
-      postingId: data.postingId,
+      jobPostingId: data.jobPostingId,
       resubmittedBy: result?.resubmittedBy,
     });
 
     return result!;
   } catch (error) {
     logger.error('대회공고 재제출 실패', toError(error), {
-      postingId: data.postingId,
+      jobPostingId: data.jobPostingId,
     });
     throw await mapEdgeFunctionError(error);
   }

--- a/uniqn-mobile/src/utils/formatCompactCount.test.ts
+++ b/uniqn-mobile/src/utils/formatCompactCount.test.ts
@@ -1,0 +1,26 @@
+import { formatCompactCount } from './formatCompactCount';
+
+describe('formatCompactCount', () => {
+  it('returns the number as-is when below 1000', () => {
+    expect(formatCompactCount(0)).toBe('0');
+    expect(formatCompactCount(1)).toBe('1');
+    expect(formatCompactCount(999)).toBe('999');
+  });
+
+  it('formats 1000+ as "1.2k" with single decimal', () => {
+    expect(formatCompactCount(1000)).toBe('1k');
+    expect(formatCompactCount(1200)).toBe('1.2k');
+    expect(formatCompactCount(1250)).toBe('1.3k');
+    expect(formatCompactCount(12345)).toBe('12.3k');
+    expect(formatCompactCount(999999)).toBe('1000k');
+  });
+
+  it('handles undefined and null safely', () => {
+    expect(formatCompactCount(undefined)).toBe('0');
+    expect(formatCompactCount(null)).toBe('0');
+  });
+
+  it('handles negative numbers as absolute value fallback to 0', () => {
+    expect(formatCompactCount(-5)).toBe('0');
+  });
+});

--- a/uniqn-mobile/src/utils/formatCompactCount.ts
+++ b/uniqn-mobile/src/utils/formatCompactCount.ts
@@ -1,0 +1,9 @@
+export function formatCompactCount(value: number | null | undefined): string {
+  if (value === null || value === undefined || value < 0) return '0';
+  if (value < 1000) return String(value);
+
+  const kValue = value / 1000;
+  const rounded = Math.round(kValue * 10) / 10;
+  if (rounded === Math.floor(rounded)) return `${Math.floor(rounded)}k`;
+  return `${rounded}k`;
+}

--- a/uniqn-mobile/src/utils/formatCompactCount.ts
+++ b/uniqn-mobile/src/utils/formatCompactCount.ts
@@ -1,3 +1,8 @@
+/**
+ * 1000 이상의 숫자를 compact notation으로 포맷 (1.2k)
+ * @param value - 포맷할 숫자 (null/undefined/음수는 '0'으로 처리)
+ * @returns compact 포맷된 문자열 ('999', '1.2k', '0')
+ */
 export function formatCompactCount(value: number | null | undefined): string {
   if (value === null || value === undefined || value < 0) return '0';
   if (value < 1000) return String(value);

--- a/uniqn-mobile/src/utils/job-posting/__tests__/draftAdapter.test.ts
+++ b/uniqn-mobile/src/utils/job-posting/__tests__/draftAdapter.test.ts
@@ -1,4 +1,4 @@
-import { draftToFormData } from '../draftAdapter';
+import { applyFormDataPatch, draftToFormData } from '../draftAdapter';
 import { INITIAL_JOB_POSTING_DRAFT, type JobPostingDraft } from '@/types/jobPostingDraft';
 
 function createDatedDraft(): JobPostingDraft {
@@ -107,6 +107,79 @@ describe('draftAdapter dated seed handling', () => {
         salary: { type: 'hourly', amount: 13000 },
       },
     ]);
+  });
+
+  it('surfaces a custom timeSlot role in formData.roles after a patch round-trip', () => {
+    const draft = createDatedDraft();
+    const currentFormData = draftToFormData(draft);
+    const requirement = currentFormData.dateSpecificRequirements?.[0];
+    if (!requirement) {
+      throw new Error('expected a dated requirement');
+    }
+
+    const nextRequirements = [
+      {
+        ...requirement,
+        timeSlots: requirement.timeSlots.map((slot) => ({
+          ...slot,
+          roles: [
+            ...slot.roles,
+            {
+              id: 'custom-manager',
+              role: 'other' as const,
+              customRole: '매니저',
+              headcount: 1,
+              filled: 0,
+            },
+          ],
+        })),
+      },
+      ...(currentFormData.dateSpecificRequirements ?? []).slice(1),
+    ];
+
+    const nextDraft = applyFormDataPatch(draft, { dateSpecificRequirements: nextRequirements });
+    const nextFormData = draftToFormData(nextDraft);
+
+    expect(nextFormData.roles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: '매니저', isCustom: true, count: 1 }),
+      ])
+    );
+  });
+
+  it('is idempotent when the same custom role patch is applied twice', () => {
+    const draft = createDatedDraft();
+    const formData = draftToFormData(draft);
+    const requirement = formData.dateSpecificRequirements?.[0];
+    if (!requirement) {
+      throw new Error('expected a dated requirement');
+    }
+
+    const patched = [
+      {
+        ...requirement,
+        timeSlots: requirement.timeSlots.map((slot) => ({
+          ...slot,
+          roles: [
+            ...slot.roles,
+            {
+              id: 'custom-manager',
+              role: 'other' as const,
+              customRole: '매니저',
+              headcount: 1,
+              filled: 0,
+            },
+          ],
+        })),
+      },
+    ];
+
+    const firstDraft = applyFormDataPatch(draft, { dateSpecificRequirements: patched });
+    const firstFormData = draftToFormData(firstDraft);
+    const secondDraft = applyFormDataPatch(firstDraft, { roles: firstFormData.roles });
+    const secondFormData = draftToFormData(secondDraft);
+
+    expect(secondFormData.roles).toEqual(firstFormData.roles);
   });
 
   it('falls back to template seed slots when dated requirements are removed', () => {


### PR DESCRIPTION
## Summary

- 홈 화면을 큐레이션 구조(고정공지 배너 + 🔥 인기글 + 🕒 내 일정 활동)로 재구성. 2×3 진입 카드 그리드 제거.
- 전 화면 공통 상단 탭 바(`홈/공지/일정/자유/TDA/대타`) 도입 — 어디서든 1 탭으로 다른 게시판으로 이동, `router.replace()`로 스택 누적 방지.
- `BoardPostCard`를 Card → Pressable 밀도형 리스트 아이템으로 개편. 제목 1줄 + 메타 4종(💬·👁·♥·✖) 단일 라인. 본문 미리보기 제거로 한 화면 7~8개 노출.
- 게시판 타입별 색상 뱃지(공지 파랑 / 일정 초록 / 자유 골드 / TDA 보라 / 대타 빨강)로 시각 구분.
- 자유/TDA에서 우하단 플로팅 FAB로 글쓰기 진입 추가.
- 게시글 상세에서 `반응` / `게시글 작업` 섹션을 나란히 배치(좁은 화면에서는 자동 wrap).

## What's included

- **신규 컴포넌트**: `BoardTabBar`, `BoardTypeBadge`, `BoardWriteFab`, `PinnedNoticeBanner`
- **신규 유틸**: `formatCompactCount` (1000+ 을 `1.2k` 포맷)
- **리팩터**: `BoardPostCard`, `board/index.tsx`, `board/[boardType].tsx`, `board/post/[postId].tsx`
- **테스트**: 23개 신규 유닛 테스트 + E2E 탭 바 persistence 테스트 추가
- **긴급 버그 픽스 2건 포함**: 대회공고 승인 401 수정 (`034782c3d`), 공고작성 커스텀 역할 무한 루프 수정 (`fc7c8f584`)

## Docs

- Spec: `docs/superpowers/specs/2026-04-16-board-ui-redesign-design.md`
- Plan: `docs/superpowers/plans/2026-04-16-board-ui-redesign.md`

## Test plan

- [x] `npm run quality` pass (type-check + lint + format)
- [x] 보드 모듈 테스트 35/35 pass
- [x] 스모크: 홈 → 탭으로 카테고리 이동 → 글 상세 진입
- [x] 스모크: 자유/TDA에서 FAB 표시, 공지/일정/대타에서 미표시
- [x] 스모크: 다크모드 토글 (새 컴포넌트 라이트/다크 모두 정상)
- [ ] CI E2E 실행 (로컬은 `.env.test` 미비로 skip)
- [ ] 배포 후 실기기 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)