### PR TITLE
feat(job-posting): totalPositions 사람 단위 전환 (Phase 6-7)

### DIFF
--- a/docs/advisor-review-phase-6-7.md
+++ b/docs/advisor-review-phase-6-7.md
@@ -1,0 +1,32 @@
+# Codex 어드바이저 리뷰 — Phase 6-7 알고리즘 (2026-04-17)
+
+## 결론
+**YES** — `total_positions`를 "총 슬롯 수"가 아니라 "역할별로 재사용 가능한 최소 필요 고유 인원 수"로 **재정의**할 때만 의미가 일관됨.
+
+## 실무 엣지케이스 (3개)
+1. **업주가 "매일 다른 사람"을 원하는 경우**: 반복근무 허용 가정이 깨져 과소계산됨. 향후 isGrouped 플래그 확장 또는 "반복근무 가능" 체크박스 검토 필요.
+2. **같은 dealer라도 숙련도/게임종류/VIP 대응 차이로 대체 불가인 경우**: 역할 키가 거칠면 과소계산. 현재 정책은 "역할 단위 대체 가능"을 가정.
+3. **슬롯 겹침/연속근무 현실성**: 단순 MAX보다 실제 overlap/휴게 규칙 기반이 더 정확하나 비용 대비 효익 낮음. 추후 feedback 기반 재평가.
+
+## TS ⇔ SQL 의미 동등성 체크리스트
+
+| 항목 | TS (stats.ts) | SQL (migration) | 동등성 |
+|------|---------------|-----------------|--------|
+| role='other' + customRole 분리 | `other:${customRole}` | `'other:' \|\| COALESCE(customRole,'')` | ✅ |
+| role='other' + customRole 없음 | `other:` | `other:` | ✅ |
+| customRole trim/lowercase | 적용 안 함 | 적용 안 함 | ✅ |
+| count null/빈 문자열 | `role.count > previous` 비교에서 NaN → skip | `NULLIF('','')::int` → NULL → MAX 제외 | ✅ |
+| **role 필드 빈/누락** | **`!role.role` → skip** | **`COALESCE(..,'')` → `''` 키 집계 포함** | ❌ → **수정 필요** |
+| fixed + roleRequirements 없음 | `(?? []).reduce` → 0 | `LEFT JOIN LATERAL` + `COALESCE(SUM(..),0)` → 0 | ✅ |
+| dated + requirements 없음/빈 | 코드 구조상 forEach skip → 0 | 별도 UPDATE로 0 보정 | ✅ |
+
+## 수정 사항 (커밋)
+SQL WHERE 절에 `NULLIF(role_elem->>'role','') IS NOT NULL` 추가해 TS의 "빈 role 스킵" 규칙과 맞춤.
+
+## 업주 UX 커뮤니케이션 한 줄
+> "표시 기준이 총 슬롯 수에서 **최소 필요 인원 수**로 바뀌었습니다: 기존 30명 표시는 이제 반복근무 가능 기준으로 3명처럼 보일 수 있습니다."
+
+Phase 6-추가 UI 업데이트에서 이 문구를 안내문에 반영.
+
+## 출처
+`codex exec` 2026-04-17 (session 019d9bad-4976-7810-967d-cd48f9a9dc68), 22516 tokens.

--- a/uniqn-mobile/app/(employer)/my-postings/[id]/edit.tsx
+++ b/uniqn-mobile/app/(employer)/my-postings/[id]/edit.tsx
@@ -251,6 +251,17 @@ export default function EditJobPostingScreen() {
           keyboardShouldPersistTaps="handled"
           showsVerticalScrollIndicator={false}
         >
+          <View className="mb-4 rounded-lg border border-primary-200 bg-primary-50 p-3 dark:border-primary-800 dark:bg-primary-900/20">
+            <Text className="text-sm font-sans-bold text-primary-700 dark:text-primary-300">
+              모집 인원 표시 기준 변경 안내
+            </Text>
+            <Text className="mt-1 text-sm text-primary-700 dark:text-primary-300 font-sans">
+              2026-04-17부터 &quot;모집 인원&quot;이 슬롯 합계가 아닌 실제 필요 인원 수(역할별 최대
+              동시 필요 인원의 합)로 표시됩니다. 기존 공고의 숫자는 자동 재계산되어 과거보다 작게
+              보일 수 있습니다.
+            </Text>
+          </View>
+
           {hasConfirmedApplicants && (
             <View className="mb-4 rounded-lg border border-amber-200 bg-warning-50 p-3 dark:border-amber-800 dark:bg-warning-900/20">
               <Text className="text-sm text-warning-700 dark:text-warning-300 font-sans">

--- a/uniqn-mobile/src/domains/job-posting/__tests__/totalPositions.test.ts
+++ b/uniqn-mobile/src/domains/job-posting/__tests__/totalPositions.test.ts
@@ -1,0 +1,299 @@
+import { calculateTotalPositionsFromSchedule } from '@/domains/job-posting/stats';
+import type { PostingSchedule } from '@/types/jobPosting';
+
+// HANDOFF 알고리즘: 같은 사람이 여러 슬롯·날짜에 돌아가며 근무 가능하다고 가정하여
+// 역할별 peak(여러 슬롯/날짜 중 최대 필요 인원)의 합으로 totalPositions를 산출한다.
+
+describe('calculateTotalPositionsFromSchedule', () => {
+  describe('fixed schedule', () => {
+    it('sums roleRequirements counts (dealer 2 + floor 1 = 3)', () => {
+      const schedule: PostingSchedule = {
+        kind: 'fixed',
+        roleRequirements: [
+          { role: 'dealer', count: 2 },
+          { role: 'floor', count: 1 },
+        ],
+      };
+
+      expect(calculateTotalPositionsFromSchedule(schedule)).toBe(3);
+    });
+
+    it('returns 0 when roleRequirements is empty', () => {
+      const schedule: PostingSchedule = {
+        kind: 'fixed',
+        roleRequirements: [],
+      };
+
+      expect(calculateTotalPositionsFromSchedule(schedule)).toBe(0);
+    });
+
+    it('returns 0 when roleRequirements is undefined', () => {
+      const schedule: PostingSchedule = {
+        kind: 'fixed',
+      };
+
+      expect(calculateTotalPositionsFromSchedule(schedule)).toBe(0);
+    });
+  });
+
+  describe('dated schedule', () => {
+    it('returns 0 when requirements array is empty', () => {
+      const schedule: PostingSchedule = {
+        kind: 'dated',
+        primaryDate: '2025-05-01',
+        allDates: [],
+        requirements: [],
+      };
+
+      expect(calculateTotalPositionsFromSchedule(schedule)).toBe(0);
+    });
+
+    it('grouped 3-day dealer x2 every day -> max 2', () => {
+      const schedule: PostingSchedule = {
+        kind: 'dated',
+        primaryDate: '2025-05-01',
+        allDates: ['2025-05-01', '2025-05-02', '2025-05-03'],
+        requirements: [
+          {
+            date: '2025-05-01',
+            isGrouped: true,
+            timeSlots: [{ startTime: '10:00', roles: [{ role: 'dealer', count: 2 }] }],
+          },
+          {
+            date: '2025-05-02',
+            isGrouped: true,
+            timeSlots: [{ startTime: '10:00', roles: [{ role: 'dealer', count: 2 }] }],
+          },
+          {
+            date: '2025-05-03',
+            isGrouped: true,
+            timeSlots: [{ startTime: '10:00', roles: [{ role: 'dealer', count: 2 }] }],
+          },
+        ],
+      };
+
+      expect(calculateTotalPositionsFromSchedule(schedule)).toBe(2);
+    });
+
+    it('non-grouped 3-day dealer x2 -> max 2', () => {
+      const schedule: PostingSchedule = {
+        kind: 'dated',
+        primaryDate: '2025-05-01',
+        allDates: ['2025-05-01', '2025-05-02', '2025-05-03'],
+        requirements: [
+          {
+            date: '2025-05-01',
+            timeSlots: [{ startTime: '10:00', roles: [{ role: 'dealer', count: 2 }] }],
+          },
+          {
+            date: '2025-05-02',
+            timeSlots: [{ startTime: '10:00', roles: [{ role: 'dealer', count: 2 }] }],
+          },
+          {
+            date: '2025-05-03',
+            timeSlots: [{ startTime: '10:00', roles: [{ role: 'dealer', count: 2 }] }],
+          },
+        ],
+      };
+
+      expect(calculateTotalPositionsFromSchedule(schedule)).toBe(2);
+    });
+
+    it('mixed counts across dates: d1,d2 dealer x2 + d3 dealer x3 -> 3', () => {
+      const schedule: PostingSchedule = {
+        kind: 'dated',
+        primaryDate: '2025-05-01',
+        allDates: ['2025-05-01', '2025-05-02', '2025-05-03'],
+        requirements: [
+          {
+            date: '2025-05-01',
+            timeSlots: [{ startTime: '10:00', roles: [{ role: 'dealer', count: 2 }] }],
+          },
+          {
+            date: '2025-05-02',
+            timeSlots: [{ startTime: '10:00', roles: [{ role: 'dealer', count: 2 }] }],
+          },
+          {
+            date: '2025-05-03',
+            timeSlots: [{ startTime: '10:00', roles: [{ role: 'dealer', count: 3 }] }],
+          },
+        ],
+      };
+
+      expect(calculateTotalPositionsFromSchedule(schedule)).toBe(3);
+    });
+
+    it('multi-role peak sum: dealer x2 + floor x1 + serving x1 across 2 days -> 4', () => {
+      const schedule: PostingSchedule = {
+        kind: 'dated',
+        primaryDate: '2025-05-01',
+        allDates: ['2025-05-01', '2025-05-02'],
+        requirements: [
+          {
+            date: '2025-05-01',
+            timeSlots: [
+              {
+                startTime: '10:00',
+                roles: [
+                  { role: 'dealer', count: 2 },
+                  { role: 'floor', count: 1 },
+                  { role: 'serving', count: 1 },
+                ],
+              },
+            ],
+          },
+          {
+            date: '2025-05-02',
+            timeSlots: [
+              {
+                startTime: '10:00',
+                roles: [
+                  { role: 'dealer', count: 2 },
+                  { role: 'floor', count: 1 },
+                  { role: 'serving', count: 1 },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(calculateTotalPositionsFromSchedule(schedule)).toBe(4);
+    });
+
+    it('role=other with customRole "translator" keeps separate key from plain other', () => {
+      const schedule: PostingSchedule = {
+        kind: 'dated',
+        primaryDate: '2025-05-01',
+        allDates: ['2025-05-01', '2025-05-02'],
+        requirements: [
+          {
+            date: '2025-05-01',
+            timeSlots: [
+              {
+                startTime: '10:00',
+                roles: [
+                  { role: 'other', customRole: 'translator', count: 2 },
+                  { role: 'other', customRole: 'security', count: 1 },
+                ],
+              },
+            ],
+          },
+          {
+            date: '2025-05-02',
+            timeSlots: [
+              {
+                startTime: '10:00',
+                roles: [
+                  { role: 'other', customRole: 'translator', count: 3 },
+                  { role: 'other', customRole: 'security', count: 1 },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      // translator max 3 + security max 1 = 4
+      expect(calculateTotalPositionsFromSchedule(schedule)).toBe(4);
+    });
+
+    it('role=other without customRole groups under a single key safely', () => {
+      const schedule: PostingSchedule = {
+        kind: 'dated',
+        primaryDate: '2025-05-01',
+        allDates: ['2025-05-01', '2025-05-02'],
+        requirements: [
+          {
+            date: '2025-05-01',
+            timeSlots: [
+              {
+                startTime: '10:00',
+                roles: [{ role: 'other', count: 2 }],
+              },
+            ],
+          },
+          {
+            date: '2025-05-02',
+            timeSlots: [
+              {
+                startTime: '10:00',
+                roles: [{ role: 'other', count: 3 }],
+              },
+            ],
+          },
+        ],
+      };
+
+      // other(무customRole) 하나의 키로 묶여 max=3
+      expect(calculateTotalPositionsFromSchedule(schedule)).toBe(3);
+    });
+
+    it('same role in two timeSlots within one date (dealer x2 morning + dealer x3 evening) -> 3', () => {
+      const schedule: PostingSchedule = {
+        kind: 'dated',
+        primaryDate: '2025-05-01',
+        allDates: ['2025-05-01'],
+        requirements: [
+          {
+            date: '2025-05-01',
+            timeSlots: [
+              { startTime: '10:00', roles: [{ role: 'dealer', count: 2 }] },
+              { startTime: '18:00', roles: [{ role: 'dealer', count: 3 }] },
+            ],
+          },
+        ],
+      };
+
+      expect(calculateTotalPositionsFromSchedule(schedule)).toBe(3);
+    });
+
+    it('safely ignores slots with empty roles array', () => {
+      const schedule: PostingSchedule = {
+        kind: 'dated',
+        primaryDate: '2025-05-01',
+        allDates: ['2025-05-01'],
+        requirements: [
+          {
+            date: '2025-05-01',
+            timeSlots: [
+              { startTime: '10:00', roles: [] },
+              { startTime: '14:00', roles: [{ role: 'dealer', count: 2 }] },
+            ],
+          },
+        ],
+      };
+
+      expect(calculateTotalPositionsFromSchedule(schedule)).toBe(2);
+    });
+
+    it('safely handles roles with count 0 and missing role field', () => {
+      const schedule: PostingSchedule = {
+        kind: 'dated',
+        primaryDate: '2025-05-01',
+        allDates: ['2025-05-01'],
+        requirements: [
+          {
+            date: '2025-05-01',
+            timeSlots: [
+              {
+                startTime: '10:00',
+                roles: [
+                  { role: 'dealer', count: 0 },
+                  { role: 'floor', count: 1 },
+                  // role 필드 없음: 안전하게 스킵
+                  { count: 5 } as never,
+                  // 빈 문자열 role: 안전하게 스킵
+                  { role: '' as never, count: 7 },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      // dealer=0, floor=1, 나머지는 스킵 → 합 1
+      expect(calculateTotalPositionsFromSchedule(schedule)).toBe(1);
+    });
+  });
+});

--- a/uniqn-mobile/src/domains/job-posting/serialization.ts
+++ b/uniqn-mobile/src/domains/job-posting/serialization.ts
@@ -191,40 +191,14 @@ function buildPostingLocation(input: CreateJobPostingInput): JobPostingDocumentV
 
 function calculateTotalsFromSchedule(schedule: PostingSchedule): {
   totalPositions: number;
-  filledPositions: number;
   workDate: string;
   workDates?: string[];
 } {
-  if (schedule.kind === 'fixed') {
-    const totalPositions = calculateTotalPositionsFromSchedule(schedule);
-    const filledPositions = (schedule.roleRequirements ?? []).reduce(
-      (sum, role) => sum + (role.filled ?? 0),
-      0
-    );
-
-    return {
-      totalPositions,
-      filledPositions,
-      ...deriveWorkDateFieldsFromSchedule(schedule),
-    };
-  }
-
-  // totalPositions는 사람 단위 peak 합(HANDOFF Phase 6), filledPositions는 worktree 1 책임으로 기존 슬롯 합산 유지
-  const totalPositions = calculateTotalPositionsFromSchedule(schedule);
-
-  const filledPositions = schedule.requirements.reduce(
-    (dateSum, requirement) =>
-      dateSum +
-      requirement.timeSlots.reduce(
-        (slotSum, slot) => slotSum + slot.roles.reduce((sum, role) => sum + (role.filled ?? 0), 0),
-        0
-      ),
-    0
-  );
-
+  // filledPositions는 RPC(confirm/cancel)가 job_postings.filled_positions 컬럼에
+  // 직접 쓰는 사람 단위 진실원이다. schedule의 slot-level role.filled는 dead counter라
+  // 추론하지 않는다. 신규 공고의 filledPositions는 serializeJobPostingV3에서 0으로 초기화.
   return {
-    totalPositions,
-    filledPositions,
+    totalPositions: calculateTotalPositionsFromSchedule(schedule),
     ...deriveWorkDateFieldsFromSchedule(schedule),
   };
 }
@@ -239,7 +213,8 @@ export function serializeJobPostingV3(
   const schedule = normalizeSchedule(input.schedule);
   const compensation = normalizeCompensation(input.compensation);
   const totals = calculateTotalsFromSchedule(schedule);
-  const authoritativeFilledPositions = current?.filledPositions ?? totals.filledPositions;
+  // 신규 공고는 0, 편집 공고는 DB(RPC 관리)에서 온 값 그대로. schedule 추론 금지.
+  const authoritativeFilledPositions = current?.filledPositions ?? 0;
   const stats = normalizePostingAggregateStats(current?.stats, schedule, {
     authoritativeFilledPositions,
   });

--- a/uniqn-mobile/src/domains/job-posting/serialization.ts
+++ b/uniqn-mobile/src/domains/job-posting/serialization.ts
@@ -13,7 +13,7 @@ import type {
   UpdateJobPostingInput,
 } from '@/types/jobPosting';
 import { JOB_POSTING_SCHEMA_VERSION } from '@/types/jobPosting';
-import { normalizePostingAggregateStats } from './stats';
+import { calculateTotalPositionsFromSchedule, normalizePostingAggregateStats } from './stats';
 
 interface SerializeJobPostingV3Options {
   ownerId: string;
@@ -196,10 +196,7 @@ function calculateTotalsFromSchedule(schedule: PostingSchedule): {
   workDates?: string[];
 } {
   if (schedule.kind === 'fixed') {
-    const totalPositions = (schedule.roleRequirements ?? []).reduce(
-      (sum, role) => sum + role.count,
-      0
-    );
+    const totalPositions = calculateTotalPositionsFromSchedule(schedule);
     const filledPositions = (schedule.roleRequirements ?? []).reduce(
       (sum, role) => sum + (role.filled ?? 0),
       0
@@ -212,15 +209,8 @@ function calculateTotalsFromSchedule(schedule: PostingSchedule): {
     };
   }
 
-  const totalPositions = schedule.requirements.reduce(
-    (dateSum, requirement) =>
-      dateSum +
-      requirement.timeSlots.reduce(
-        (slotSum, slot) => slotSum + slot.roles.reduce((sum, role) => sum + role.count, 0),
-        0
-      ),
-    0
-  );
+  // totalPositions는 사람 단위 peak 합(HANDOFF Phase 6), filledPositions는 worktree 1 책임으로 기존 슬롯 합산 유지
+  const totalPositions = calculateTotalPositionsFromSchedule(schedule);
 
   const filledPositions = schedule.requirements.reduce(
     (dateSum, requirement) =>

--- a/uniqn-mobile/src/domains/job-posting/stats.ts
+++ b/uniqn-mobile/src/domains/job-posting/stats.ts
@@ -25,6 +25,55 @@ export function calculateFilledPositionsFromSchedule(schedule: PostingSchedule):
   }, 0);
 }
 
+function getRoleKey(role: { role?: string; customRole?: string }): string | null {
+  // 빈 role 필드는 키 충돌·무의미 집계를 막기 위해 스킵
+  if (!role.role) {
+    return null;
+  }
+
+  if (role.role === 'other') {
+    return role.customRole ? `other:${role.customRole}` : 'other:';
+  }
+
+  return role.role;
+}
+
+/**
+ * 사람 단위(person basis) 모집 인원 계산.
+ * 같은 역할은 여러 슬롯/날짜에서 "같은 사람이 돌아가며 근무 가능"하다고 가정하여
+ * 역할별 최대 동시 필요 인원(peak)의 합으로 totalPositions를 구한다.
+ * (HANDOFF.md Phase 6 알고리즘 결정)
+ */
+export function calculateTotalPositionsFromSchedule(schedule: PostingSchedule): number {
+  if (schedule.kind === 'fixed') {
+    return (schedule.roleRequirements ?? []).reduce((sum, role) => sum + role.count, 0);
+  }
+
+  const peakByRole = new Map<string, number>();
+
+  schedule.requirements.forEach((requirement) => {
+    requirement.timeSlots.forEach((slot) => {
+      slot.roles.forEach((role) => {
+        const key = getRoleKey(role);
+        if (key === null) {
+          return;
+        }
+        const previous = peakByRole.get(key) ?? 0;
+        if (role.count > previous) {
+          peakByRole.set(key, role.count);
+        }
+      });
+    });
+  });
+
+  let total = 0;
+  peakByRole.forEach((count) => {
+    total += count;
+  });
+
+  return total;
+}
+
 export function createInitialPostingStats(schedule: PostingSchedule): JobPostingAggregateStats {
   return {
     totalApplicants: 0,

--- a/uniqn-mobile/src/utils/job-posting/__tests__/dateUtils.test.ts
+++ b/uniqn-mobile/src/utils/job-posting/__tests__/dateUtils.test.ts
@@ -483,4 +483,105 @@ describe('getClosingStatus', () => {
     expect(result.total).toBe(0);
     expect(result.filled).toBe(0);
   });
+
+  // Phase 6 리뷰 C3: schedule 경로는 사람 단위(person basis)로 total 계산.
+  // filled는 DB 컬럼(filledPositions)만 신뢰.
+  it('schedule.kind=dated인 경우 역할별 peak 합으로 total 계산 (사람 단위)', () => {
+    const jobData = {
+      schedule: {
+        kind: 'dated' as const,
+        primaryDate: '2025-01-10',
+        allDates: ['2025-01-10', '2025-01-11', '2025-01-12'],
+        requirements: [
+          {
+            date: '2025-01-10',
+            timeSlots: [{ roles: [{ role: 'dealer' as const, count: 2, filled: 1 }] }],
+          },
+          {
+            date: '2025-01-11',
+            timeSlots: [{ roles: [{ role: 'dealer' as const, count: 2, filled: 1 }] }],
+          },
+          {
+            date: '2025-01-12',
+            timeSlots: [{ roles: [{ role: 'dealer' as const, count: 2, filled: 1 }] }],
+          },
+        ],
+      },
+      filledPositions: 1,
+    };
+
+    const result = getClosingStatus(jobData);
+    // 슬롯 단위라면 6, 사람 단위(peak) 기준 2
+    expect(result.total).toBe(2);
+    expect(result.filled).toBe(1);
+    expect(result.isClosed).toBe(false);
+  });
+
+  it('schedule.kind=dated + filled >= total이면 isClosed: true', () => {
+    const jobData = {
+      schedule: {
+        kind: 'dated' as const,
+        primaryDate: '2025-01-10',
+        allDates: ['2025-01-10'],
+        requirements: [
+          {
+            date: '2025-01-10',
+            timeSlots: [
+              {
+                roles: [
+                  { role: 'dealer' as const, count: 2, filled: 2 },
+                  { role: 'floor' as const, count: 1, filled: 1 },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      filledPositions: 3,
+    };
+
+    const result = getClosingStatus(jobData);
+    expect(result.total).toBe(3);
+    expect(result.filled).toBe(3);
+    expect(result.isClosed).toBe(true);
+  });
+
+  it('schedule.kind=fixed인 경우 roleRequirements 합으로 total 계산', () => {
+    const jobData = {
+      schedule: {
+        kind: 'fixed' as const,
+        roleRequirements: [
+          { role: 'dealer' as const, count: 2, filled: 0 },
+          { role: 'floor' as const, count: 1, filled: 0 },
+        ],
+      },
+      filledPositions: 0,
+    };
+
+    const result = getClosingStatus(jobData);
+    expect(result.total).toBe(3);
+    expect(result.filled).toBe(0);
+    expect(result.isClosed).toBe(false);
+  });
+
+  it('schedule이 있지만 filledPositions이 undefined이면 filled=0으로 처리', () => {
+    const jobData = {
+      schedule: {
+        kind: 'dated' as const,
+        primaryDate: '2025-01-10',
+        allDates: ['2025-01-10'],
+        requirements: [
+          {
+            date: '2025-01-10',
+            timeSlots: [{ roles: [{ role: 'dealer' as const, count: 2 }] }],
+          },
+        ],
+      },
+    };
+
+    const result = getClosingStatus(jobData);
+    expect(result.total).toBe(2);
+    expect(result.filled).toBe(0);
+    expect(result.isClosed).toBe(false);
+  });
 });

--- a/uniqn-mobile/src/utils/job-posting/dateUtils.ts
+++ b/uniqn-mobile/src/utils/job-posting/dateUtils.ts
@@ -8,6 +8,7 @@
 import { toISODateString, generateId as generateIdBase } from '../date/core';
 import { formatDateWithDay } from '../date/formatting';
 import { groupConsecutiveDates as groupConsecutiveDatesBase } from '../date/grouping';
+import { calculateTotalPositionsFromSchedule } from '@/domains/job-posting/stats';
 import type { PostingSchedule } from '@/types/jobPosting';
 
 // Re-export from date/ for backward compatibility
@@ -222,43 +223,12 @@ export function getClosingStatus(jobData: {
   totalPositions?: number;
   filledPositions?: number;
 }): { total: number; filled: number; isClosed: boolean } {
-  if (jobData.schedule?.kind === 'fixed') {
-    const total = (jobData.schedule.roleRequirements ?? []).reduce(
-      (sum, role) => sum + role.count,
-      0
-    );
-    const filled = (jobData.schedule.roleRequirements ?? []).reduce(
-      (sum, role) => sum + (role.filled ?? 0),
-      0
-    );
-
-    return {
-      total,
-      filled,
-      isClosed: total > 0 && filled >= total,
-    };
-  }
-
-  if (jobData.schedule?.kind === 'dated') {
-    const total = jobData.schedule.requirements.reduce(
-      (dateSum, requirement) =>
-        dateSum +
-        requirement.timeSlots.reduce(
-          (slotSum, slot) => slotSum + slot.roles.reduce((sum, role) => sum + role.count, 0),
-          0
-        ),
-      0
-    );
-    const filled = jobData.schedule.requirements.reduce(
-      (dateSum, requirement) =>
-        dateSum +
-        requirement.timeSlots.reduce(
-          (slotSum, slot) =>
-            slotSum + slot.roles.reduce((sum, role) => sum + (role.filled ?? 0), 0),
-          0
-        ),
-      0
-    );
+  // schedule이 있으면 사람 단위(person basis)로 total/filled 계산.
+  // total: stats.ts의 calculateTotalPositionsFromSchedule과 의미 동등 (역할별 peak의 합).
+  // filled: RPC가 관리하는 job_postings.filled_positions 컬럼을 단일 진실원으로 사용.
+  if (jobData.schedule?.kind === 'fixed' || jobData.schedule?.kind === 'dated') {
+    const total = calculateTotalPositionsFromSchedule(jobData.schedule);
+    const filled = jobData.filledPositions ?? 0;
 
     return {
       total,

--- a/uniqn-mobile/supabase/migrations/20260418010000_total_positions_person_basis.sql
+++ b/uniqn-mobile/supabase/migrations/20260418010000_total_positions_person_basis.sql
@@ -46,6 +46,8 @@ WITH role_max AS (
   WHERE jp.schedule->>'kind' IS DISTINCT FROM 'fixed'
     AND jp.schedule ? 'requirements'
     AND jsonb_typeof(jp.schedule->'requirements') = 'array'
+    -- TS getRoleKey와 동일하게 role 필드가 비어있으면 스킵 (Codex advisor review)
+    AND NULLIF(role_elem->>'role', '') IS NOT NULL
   GROUP BY jp.id, role_key
 ),
 dated_totals AS (

--- a/uniqn-mobile/supabase/migrations/20260418010000_total_positions_person_basis.sql
+++ b/uniqn-mobile/supabase/migrations/20260418010000_total_positions_person_basis.sql
@@ -1,0 +1,111 @@
+-- ============================================================================
+-- total_positions 사람 단위(person basis) 백필
+-- Phase 7 of "confirmed-count-sync" 시리즈
+-- ----------------------------------------------------------------------------
+-- 기존: total_positions = Σ slot.role.count (슬롯 단위, 3일×딜러2 = 6)
+-- 신규: total_positions = Σ_role MAX_{all timeslots}(count) (사람 단위)
+-- 이유: 선행 마이그레이션(20260418000000_person_basis_filled_positions.sql)이
+--       filled_positions을 사람 단위로 전환 → total_positions과 의미 단위
+--       미스매치 → auto-close(filled >= total) 오동작. 본 마이그레이션으로 해소.
+--
+-- 알고리즘 (Phase 6 TS calculateTotalPositionsFromSchedule와 의미 동등):
+--   schedule.kind = 'fixed':
+--     total = SUM(roleRequirements[].count)
+--
+--   schedule.kind != 'fixed' (regular/tournament/urgent, dated):
+--     역할별로 모든 timeSlots[].roles[]의 count MAX → 역할별 MAX의 SUM
+--     role 키: role = 'other' → 'other:<customRole>' (분리 카운트)
+--              그 외 → role 그대로
+--
+--   빈 케이스:
+--     fixed + roleRequirements 없음/빈 배열 → 0
+--     dated + requirements 없음/빈 배열 → 0
+--
+-- Related:
+--   - docs/analysis/2026-04-17-confirmed-count-sync-root-cause.md
+--   - src/domains/job-posting/stats.ts (TS 영역 동일 알고리즘)
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1) dated/fixed 각각 posting별 사람 단위 total 계산 후 UPDATE
+-- ----------------------------------------------------------------------------
+WITH role_max AS (
+  -- dated posting: (posting, role_key)별 count MAX
+  SELECT
+    jp.id AS posting_id,
+    CASE
+      WHEN role_elem->>'role' = 'other'
+        THEN 'other:' || COALESCE(role_elem->>'customRole', '')
+      ELSE COALESCE(role_elem->>'role', '')
+    END AS role_key,
+    MAX(NULLIF(role_elem->>'count', '')::int) AS max_count
+  FROM public.job_postings jp
+  CROSS JOIN LATERAL jsonb_array_elements(jp.schedule->'requirements') AS req
+  CROSS JOIN LATERAL jsonb_array_elements(req->'timeSlots') AS slot
+  CROSS JOIN LATERAL jsonb_array_elements(slot->'roles') AS role_elem
+  WHERE jp.schedule->>'kind' IS DISTINCT FROM 'fixed'
+    AND jp.schedule ? 'requirements'
+    AND jsonb_typeof(jp.schedule->'requirements') = 'array'
+  GROUP BY jp.id, role_key
+),
+dated_totals AS (
+  SELECT posting_id, COALESCE(SUM(max_count), 0)::int AS total
+  FROM role_max
+  GROUP BY posting_id
+),
+fixed_totals AS (
+  SELECT
+    jp.id AS posting_id,
+    COALESCE(SUM(NULLIF(r->>'count', '')::int), 0)::int AS total
+  FROM public.job_postings jp
+  LEFT JOIN LATERAL jsonb_array_elements(jp.schedule->'roleRequirements') AS r ON TRUE
+  WHERE jp.schedule->>'kind' = 'fixed'
+  GROUP BY jp.id
+),
+posting_totals AS (
+  SELECT posting_id, total FROM dated_totals
+  UNION ALL
+  SELECT posting_id, total FROM fixed_totals
+)
+UPDATE public.job_postings jp
+SET
+  total_positions = pt.total,
+  updated_at = now()
+FROM posting_totals pt
+WHERE jp.id = pt.posting_id
+  AND jp.total_positions IS DISTINCT FROM pt.total;
+
+-- ----------------------------------------------------------------------------
+-- 2) 빈 dated 케이스: requirements 없음/빈 배열 → 0
+--    (role_max에 row 없음 → dated_totals에 posting 누락 → 위 UPDATE 미적용)
+-- ----------------------------------------------------------------------------
+UPDATE public.job_postings
+SET
+  total_positions = 0,
+  updated_at = now()
+WHERE schedule->>'kind' IS DISTINCT FROM 'fixed'
+  AND (
+    schedule->'requirements' IS NULL
+    OR jsonb_typeof(schedule->'requirements') != 'array'
+    OR jsonb_array_length(schedule->'requirements') = 0
+  )
+  AND total_positions IS DISTINCT FROM 0;
+
+-- ----------------------------------------------------------------------------
+-- 3) 백필 결과 로그 (idempotent — 재실행 시 WHERE 조건으로 0행 업데이트)
+-- ----------------------------------------------------------------------------
+DO $$
+DECLARE
+  v_dated_count int;
+  v_fixed_count int;
+BEGIN
+  SELECT COUNT(*) INTO v_dated_count
+  FROM public.job_postings
+  WHERE schedule->>'kind' IS DISTINCT FROM 'fixed';
+
+  SELECT COUNT(*) INTO v_fixed_count
+  FROM public.job_postings
+  WHERE schedule->>'kind' = 'fixed';
+
+  RAISE NOTICE 'total_positions 사람 단위 백필 완료 (dated=% fixed=%)', v_dated_count, v_fixed_count;
+END $$;

--- a/uniqn-mobile/supabase/migrations/20260418010000_total_positions_person_basis.sql
+++ b/uniqn-mobile/supabase/migrations/20260418010000_total_positions_person_basis.sql
@@ -32,6 +32,29 @@
 --   - src/domains/job-posting/stats.ts (TS 영역 동일 알고리즘)
 -- ============================================================================
 
+-- ----------------------------------------------------------------------------
+-- Precondition: 선행 마이그레이션 20260418000000 이 적용되어야 함
+-- ----------------------------------------------------------------------------
+-- 20260418000000_person_basis_filled_positions은 filled_positions을 사람 단위로
+-- 전환한다. 본 마이그레이션이 단독 적용되면 total=사람, filled=슬롯 미스매치가
+-- 남아 auto-close 로직이 계속 오작동하므로 의존성을 강제한다.
+--
+-- 단독 배포(worktree 1 미머지)를 가드: Supabase가 적용 이력을 저장하는
+-- supabase_migrations.schema_migrations에 선행 버전이 없으면 RAISE EXCEPTION.
+-- ----------------------------------------------------------------------------
+DO $precondition$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM supabase_migrations.schema_migrations
+    WHERE version = '20260418000000'
+  ) THEN
+    RAISE EXCEPTION
+      'MIGRATION_DEPENDENCY_MISSING: 20260418010000_total_positions_person_basis requires 20260418000000_person_basis_filled_positions to be applied first. Merge fix/confirmed-count-sync (worktree 1) before deploying this migration.';
+  END IF;
+END
+$precondition$;
+
 DO $$
 DECLARE
   v_updated_main int;

--- a/uniqn-mobile/supabase/migrations/20260418010000_total_positions_person_basis.sql
+++ b/uniqn-mobile/supabase/migrations/20260418010000_total_positions_person_basis.sql
@@ -21,93 +21,144 @@
 --     fixed + roleRequirements 없음/빈 배열 → 0
 --     dated + requirements 없음/빈 배열 → 0
 --
+-- 방어적 처리 (Codex adversarial review 2026-04-17 반영):
+--   - 중첩 jsonb_array_elements 호출 전 jsonb_typeof = 'array' 가드(CASE)로
+--     scalar/object timeSlots/roles에서 에러 발생 방지.
+--   - count 문자열은 정규식(`^-?[0-9]+$`) 통과한 것만 정수 캐스팅하여
+--     `' '`/`'abc'`/`'null'` 등 dirty data에서 InvalidTextRepresentation 차단.
+--
 -- Related:
---   - docs/analysis/2026-04-17-confirmed-count-sync-root-cause.md
+--   - docs/advisor-review-phase-6-7.md (Codex advisor 1차 리뷰)
 --   - src/domains/job-posting/stats.ts (TS 영역 동일 알고리즘)
 -- ============================================================================
 
--- ----------------------------------------------------------------------------
--- 1) dated/fixed 각각 posting별 사람 단위 total 계산 후 UPDATE
--- ----------------------------------------------------------------------------
-WITH role_max AS (
-  -- dated posting: (posting, role_key)별 count MAX
-  SELECT
-    jp.id AS posting_id,
-    CASE
-      WHEN role_elem->>'role' = 'other'
-        THEN 'other:' || COALESCE(role_elem->>'customRole', '')
-      ELSE COALESCE(role_elem->>'role', '')
-    END AS role_key,
-    MAX(NULLIF(role_elem->>'count', '')::int) AS max_count
-  FROM public.job_postings jp
-  CROSS JOIN LATERAL jsonb_array_elements(jp.schedule->'requirements') AS req
-  CROSS JOIN LATERAL jsonb_array_elements(req->'timeSlots') AS slot
-  CROSS JOIN LATERAL jsonb_array_elements(slot->'roles') AS role_elem
-  WHERE jp.schedule->>'kind' IS DISTINCT FROM 'fixed'
-    AND jp.schedule ? 'requirements'
-    AND jsonb_typeof(jp.schedule->'requirements') = 'array'
-    -- TS getRoleKey와 동일하게 role 필드가 비어있으면 스킵 (Codex advisor review)
-    AND NULLIF(role_elem->>'role', '') IS NOT NULL
-  GROUP BY jp.id, role_key
-),
-dated_totals AS (
-  SELECT posting_id, COALESCE(SUM(max_count), 0)::int AS total
-  FROM role_max
-  GROUP BY posting_id
-),
-fixed_totals AS (
-  SELECT
-    jp.id AS posting_id,
-    COALESCE(SUM(NULLIF(r->>'count', '')::int), 0)::int AS total
-  FROM public.job_postings jp
-  LEFT JOIN LATERAL jsonb_array_elements(jp.schedule->'roleRequirements') AS r ON TRUE
-  WHERE jp.schedule->>'kind' = 'fixed'
-  GROUP BY jp.id
-),
-posting_totals AS (
-  SELECT posting_id, total FROM dated_totals
-  UNION ALL
-  SELECT posting_id, total FROM fixed_totals
-)
-UPDATE public.job_postings jp
-SET
-  total_positions = pt.total,
-  updated_at = now()
-FROM posting_totals pt
-WHERE jp.id = pt.posting_id
-  AND jp.total_positions IS DISTINCT FROM pt.total;
-
--- ----------------------------------------------------------------------------
--- 2) 빈 dated 케이스: requirements 없음/빈 배열 → 0
---    (role_max에 row 없음 → dated_totals에 posting 누락 → 위 UPDATE 미적용)
--- ----------------------------------------------------------------------------
-UPDATE public.job_postings
-SET
-  total_positions = 0,
-  updated_at = now()
-WHERE schedule->>'kind' IS DISTINCT FROM 'fixed'
-  AND (
-    schedule->'requirements' IS NULL
-    OR jsonb_typeof(schedule->'requirements') != 'array'
-    OR jsonb_array_length(schedule->'requirements') = 0
-  )
-  AND total_positions IS DISTINCT FROM 0;
-
--- ----------------------------------------------------------------------------
--- 3) 백필 결과 로그 (idempotent — 재실행 시 WHERE 조건으로 0행 업데이트)
--- ----------------------------------------------------------------------------
 DO $$
 DECLARE
-  v_dated_count int;
-  v_fixed_count int;
+  v_updated_main int;
+  v_updated_zero int;
+  v_total_dated int;
+  v_total_fixed int;
 BEGIN
-  SELECT COUNT(*) INTO v_dated_count
+  -- ----------------------------------------------------------------------------
+  -- 1) dated/fixed 각각 posting별 사람 단위 total 계산 후 UPDATE
+  -- ----------------------------------------------------------------------------
+  WITH role_max AS (
+    -- dated posting: (posting, role_key)별 count MAX
+    SELECT
+      jp.id AS posting_id,
+      CASE
+        WHEN role_elem->>'role' = 'other'
+          THEN 'other:' || COALESCE(role_elem->>'customRole', '')
+        ELSE COALESCE(role_elem->>'role', '')
+      END AS role_key,
+      MAX(
+        CASE
+          WHEN (role_elem->>'count') ~ '^-?[0-9]+$'
+            THEN (role_elem->>'count')::int
+          ELSE NULL
+        END
+      ) AS max_count
+    FROM public.job_postings jp
+    CROSS JOIN LATERAL jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(jp.schedule->'requirements') = 'array'
+          THEN jp.schedule->'requirements'
+        ELSE '[]'::jsonb
+      END
+    ) AS req
+    CROSS JOIN LATERAL jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(req->'timeSlots') = 'array'
+          THEN req->'timeSlots'
+        ELSE '[]'::jsonb
+      END
+    ) AS slot
+    CROSS JOIN LATERAL jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(slot->'roles') = 'array'
+          THEN slot->'roles'
+        ELSE '[]'::jsonb
+      END
+    ) AS role_elem
+    WHERE jp.schedule->>'kind' IS DISTINCT FROM 'fixed'
+      -- TS getRoleKey와 동일하게 role 필드가 비어있으면 스킵
+      AND NULLIF(role_elem->>'role', '') IS NOT NULL
+    GROUP BY jp.id, role_key
+  ),
+  dated_totals AS (
+    SELECT posting_id, COALESCE(SUM(max_count), 0)::int AS total
+    FROM role_max
+    GROUP BY posting_id
+  ),
+  fixed_totals AS (
+    SELECT
+      jp.id AS posting_id,
+      COALESCE(
+        SUM(
+          CASE
+            WHEN (r->>'count') ~ '^-?[0-9]+$'
+              THEN (r->>'count')::int
+            ELSE 0
+          END
+        ),
+        0
+      )::int AS total
+    FROM public.job_postings jp
+    LEFT JOIN LATERAL jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(jp.schedule->'roleRequirements') = 'array'
+          THEN jp.schedule->'roleRequirements'
+        ELSE '[]'::jsonb
+      END
+    ) AS r ON TRUE
+    WHERE jp.schedule->>'kind' = 'fixed'
+    GROUP BY jp.id
+  ),
+  posting_totals AS (
+    SELECT posting_id, total FROM dated_totals
+    UNION ALL
+    SELECT posting_id, total FROM fixed_totals
+  )
+  UPDATE public.job_postings jp
+  SET
+    total_positions = pt.total,
+    updated_at = now()
+  FROM posting_totals pt
+  WHERE jp.id = pt.posting_id
+    AND jp.total_positions IS DISTINCT FROM pt.total;
+
+  GET DIAGNOSTICS v_updated_main = ROW_COUNT;
+
+  -- ----------------------------------------------------------------------------
+  -- 2) 빈 dated 케이스: requirements 없음/빈 배열 → 0
+  --    (role_max에 row 없음 → dated_totals에 posting 누락 → 위 UPDATE 미적용)
+  -- ----------------------------------------------------------------------------
+  UPDATE public.job_postings
+  SET
+    total_positions = 0,
+    updated_at = now()
+  WHERE schedule->>'kind' IS DISTINCT FROM 'fixed'
+    AND (
+      schedule->'requirements' IS NULL
+      OR jsonb_typeof(schedule->'requirements') != 'array'
+      OR jsonb_array_length(schedule->'requirements') = 0
+    )
+    AND total_positions IS DISTINCT FROM 0;
+
+  GET DIAGNOSTICS v_updated_zero = ROW_COUNT;
+
+  -- ----------------------------------------------------------------------------
+  -- 3) 백필 결과 로그 (실제 영향 row 수 포함)
+  -- ----------------------------------------------------------------------------
+  SELECT COUNT(*) INTO v_total_dated
   FROM public.job_postings
   WHERE schedule->>'kind' IS DISTINCT FROM 'fixed';
 
-  SELECT COUNT(*) INTO v_fixed_count
+  SELECT COUNT(*) INTO v_total_fixed
   FROM public.job_postings
   WHERE schedule->>'kind' = 'fixed';
 
-  RAISE NOTICE 'total_positions 사람 단위 백필 완료 (dated=% fixed=%)', v_dated_count, v_fixed_count;
+  RAISE NOTICE
+    'total_positions 사람 단위 백필 완료 (영향 row: 메인=% 빈dated=% / 전체: dated=% fixed=%)',
+    v_updated_main, v_updated_zero, v_total_dated, v_total_fixed;
 END $$;

--- a/uniqn-mobile/supabase/tests/total_positions_backfill.test.sql
+++ b/uniqn-mobile/supabase/tests/total_positions_backfill.test.sql
@@ -208,14 +208,37 @@ BEGIN
           THEN 'other:' || COALESCE(role_elem->>'customRole', '')
         ELSE COALESCE(role_elem->>'role', '')
       END AS role_key,
-      MAX(NULLIF(role_elem->>'count', '')::int) AS max_count
+      MAX(
+        CASE
+          WHEN (role_elem->>'count') ~ '^-?[0-9]+$'
+            THEN (role_elem->>'count')::int
+          ELSE NULL
+        END
+      ) AS max_count
     FROM public.job_postings jp
-    CROSS JOIN LATERAL jsonb_array_elements(jp.schedule->'requirements') AS req
-    CROSS JOIN LATERAL jsonb_array_elements(req->'timeSlots') AS slot
-    CROSS JOIN LATERAL jsonb_array_elements(slot->'roles') AS role_elem
+    CROSS JOIN LATERAL jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(jp.schedule->'requirements') = 'array'
+          THEN jp.schedule->'requirements'
+        ELSE '[]'::jsonb
+      END
+    ) AS req
+    CROSS JOIN LATERAL jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(req->'timeSlots') = 'array'
+          THEN req->'timeSlots'
+        ELSE '[]'::jsonb
+      END
+    ) AS slot
+    CROSS JOIN LATERAL jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(slot->'roles') = 'array'
+          THEN slot->'roles'
+        ELSE '[]'::jsonb
+      END
+    ) AS role_elem
     WHERE jp.schedule->>'kind' IS DISTINCT FROM 'fixed'
-      AND jp.schedule ? 'requirements'
-      AND jsonb_typeof(jp.schedule->'requirements') = 'array'
+      AND NULLIF(role_elem->>'role', '') IS NOT NULL
       AND jp.id IN (v_t1, v_t2, v_t3, v_t4, v_t7)
     GROUP BY jp.id, role_key
   ),
@@ -227,9 +250,24 @@ BEGIN
   fixed_totals AS (
     SELECT
       jp.id AS posting_id,
-      COALESCE(SUM(NULLIF(r->>'count', '')::int), 0)::int AS total
+      COALESCE(
+        SUM(
+          CASE
+            WHEN (r->>'count') ~ '^-?[0-9]+$'
+              THEN (r->>'count')::int
+            ELSE 0
+          END
+        ),
+        0
+      )::int AS total
     FROM public.job_postings jp
-    LEFT JOIN LATERAL jsonb_array_elements(jp.schedule->'roleRequirements') AS r ON TRUE
+    LEFT JOIN LATERAL jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(jp.schedule->'roleRequirements') = 'array'
+          THEN jp.schedule->'roleRequirements'
+        ELSE '[]'::jsonb
+      END
+    ) AS r ON TRUE
     WHERE jp.schedule->>'kind' = 'fixed'
       AND jp.id = v_t5
     GROUP BY jp.id

--- a/uniqn-mobile/supabase/tests/total_positions_backfill.test.sql
+++ b/uniqn-mobile/supabase/tests/total_positions_backfill.test.sql
@@ -1,0 +1,305 @@
+-- ============================================================
+-- Phase 7: total_positions 사람 단위 백필 회귀 테스트
+-- ============================================================
+-- 목적: 20260418010000_total_positions_person_basis.sql의 CTE 로직을
+--       고정된 JSON schedule 케이스에 적용했을 때 사람 단위 total이
+--       정확히 계산되는지 검증.
+--
+-- 사용법:
+--   psql "$SUPABASE_DB_URL" -f supabase/tests/total_positions_backfill.test.sql
+--   기대 결과: 마지막에 'TOTAL_POSITIONS_BACKFILL_TEST_PASSED' 1행 반환, 에러 0건
+--
+-- 안전장치:
+--   - BEGIN ... ROLLBACK 블록으로 감싸 production에서도 영속 변경 없음
+--   - 마커 이메일(__sql_fixture_total_*@test.local) + 임시 uuid 사용
+--   - auth.users INSERT 시 handle_new_user 트리거가 public.users 자동 생성
+--
+-- 시나리오:
+--   T1. grouped 3일 동안 dealer×2 + floor×1 → total = 3
+--   T2. 비그룹 3일 각각 dealer×2 → total = 2
+--   T3. 혼합 (그룹 dealer×2 + 독립 dealer×3) → total = 3
+--   T4. 멀티역할 (dealer×2 + floor×1 + serving×1) → total = 4
+--   T5. fixed [dealer×2, floor×1] → total = 3
+--   T6. dated + requirements=[] → total = 0
+--   T7. role='other' customRole='translator' + dealer → 분리 카운트 (translator=1, dealer=2 → total=3)
+-- ============================================================
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_owner_id uuid := gen_random_uuid();
+  v_t1 uuid := gen_random_uuid();  -- grouped 3일 dealer×2 + floor×1 → 3
+  v_t2 uuid := gen_random_uuid();  -- 비그룹 3일 각 dealer×2 → 2
+  v_t3 uuid := gen_random_uuid();  -- 혼합 dealer×2 + dealer×3 → 3
+  v_t4 uuid := gen_random_uuid();  -- 멀티역할 → 4
+  v_t5 uuid := gen_random_uuid();  -- fixed [dealer×2, floor×1] → 3
+  v_t6 uuid := gen_random_uuid();  -- dated + requirements=[] → 0
+  v_t7 uuid := gen_random_uuid();  -- role='other' customRole 분리 → 3
+  v_got int;
+BEGIN
+  -- owner seed (auth.users → trigger → public.users)
+  INSERT INTO auth.users (id, email, raw_app_meta_data, raw_user_meta_data, created_at, updated_at)
+  VALUES (
+    v_owner_id, '__sql_fixture_total_owner@test.local',
+    '{"role":"employer"}'::jsonb, '{"name":"TOTAL_OWNER"}'::jsonb,
+    now(), now()
+  );
+
+  -- ============================================================
+  -- T1: grouped 3일, 각 timeSlot에 dealer×2 + floor×1 (3일 반복)
+  --     역할별 MAX: dealer=2, floor=1 → SUM = 3
+  -- ============================================================
+  INSERT INTO public.job_postings (id, owner_id, title, status, total_positions, filled_positions, schedule)
+  VALUES (
+    v_t1, v_owner_id, '__sql_fixture_total_t1', 'draft', 999, 0,
+    jsonb_build_object(
+      'kind', 'dated',
+      'requirements', jsonb_build_array(
+        jsonb_build_object('date', '2026-05-01', 'timeSlots', jsonb_build_array(
+          jsonb_build_object('roles', jsonb_build_array(
+            jsonb_build_object('role', 'dealer', 'count', 2, 'customRole', NULL),
+            jsonb_build_object('role', 'floor',  'count', 1, 'customRole', NULL)
+          ))
+        )),
+        jsonb_build_object('date', '2026-05-02', 'timeSlots', jsonb_build_array(
+          jsonb_build_object('roles', jsonb_build_array(
+            jsonb_build_object('role', 'dealer', 'count', 2, 'customRole', NULL),
+            jsonb_build_object('role', 'floor',  'count', 1, 'customRole', NULL)
+          ))
+        )),
+        jsonb_build_object('date', '2026-05-03', 'timeSlots', jsonb_build_array(
+          jsonb_build_object('roles', jsonb_build_array(
+            jsonb_build_object('role', 'dealer', 'count', 2, 'customRole', NULL),
+            jsonb_build_object('role', 'floor',  'count', 1, 'customRole', NULL)
+          ))
+        ))
+      )
+    )
+  );
+
+  -- ============================================================
+  -- T2: 비그룹 3일, 각 dealer×2 (동일 역할, 날짜만 다름)
+  --     역할별 MAX: dealer=2 → SUM = 2
+  -- ============================================================
+  INSERT INTO public.job_postings (id, owner_id, title, status, total_positions, filled_positions, schedule)
+  VALUES (
+    v_t2, v_owner_id, '__sql_fixture_total_t2', 'draft', 999, 0,
+    jsonb_build_object(
+      'kind', 'dated',
+      'requirements', jsonb_build_array(
+        jsonb_build_object('date', '2026-05-01', 'timeSlots', jsonb_build_array(
+          jsonb_build_object('roles', jsonb_build_array(
+            jsonb_build_object('role', 'dealer', 'count', 2, 'customRole', NULL)
+          ))
+        )),
+        jsonb_build_object('date', '2026-05-02', 'timeSlots', jsonb_build_array(
+          jsonb_build_object('roles', jsonb_build_array(
+            jsonb_build_object('role', 'dealer', 'count', 2, 'customRole', NULL)
+          ))
+        )),
+        jsonb_build_object('date', '2026-05-03', 'timeSlots', jsonb_build_array(
+          jsonb_build_object('roles', jsonb_build_array(
+            jsonb_build_object('role', 'dealer', 'count', 2, 'customRole', NULL)
+          ))
+        ))
+      )
+    )
+  );
+
+  -- ============================================================
+  -- T3: 혼합 — day1 dealer×2, day2 dealer×3
+  --     dealer MAX = 3 → SUM = 3
+  -- ============================================================
+  INSERT INTO public.job_postings (id, owner_id, title, status, total_positions, filled_positions, schedule)
+  VALUES (
+    v_t3, v_owner_id, '__sql_fixture_total_t3', 'draft', 999, 0,
+    jsonb_build_object(
+      'kind', 'dated',
+      'requirements', jsonb_build_array(
+        jsonb_build_object('date', '2026-05-01', 'timeSlots', jsonb_build_array(
+          jsonb_build_object('roles', jsonb_build_array(
+            jsonb_build_object('role', 'dealer', 'count', 2, 'customRole', NULL)
+          ))
+        )),
+        jsonb_build_object('date', '2026-05-02', 'timeSlots', jsonb_build_array(
+          jsonb_build_object('roles', jsonb_build_array(
+            jsonb_build_object('role', 'dealer', 'count', 3, 'customRole', NULL)
+          ))
+        ))
+      )
+    )
+  );
+
+  -- ============================================================
+  -- T4: 멀티역할 단일 날짜 — dealer×2 + floor×1 + serving×1
+  --     → SUM = 4
+  -- ============================================================
+  INSERT INTO public.job_postings (id, owner_id, title, status, total_positions, filled_positions, schedule)
+  VALUES (
+    v_t4, v_owner_id, '__sql_fixture_total_t4', 'draft', 999, 0,
+    jsonb_build_object(
+      'kind', 'dated',
+      'requirements', jsonb_build_array(
+        jsonb_build_object('date', '2026-05-01', 'timeSlots', jsonb_build_array(
+          jsonb_build_object('roles', jsonb_build_array(
+            jsonb_build_object('role', 'dealer',  'count', 2, 'customRole', NULL),
+            jsonb_build_object('role', 'floor',   'count', 1, 'customRole', NULL),
+            jsonb_build_object('role', 'serving', 'count', 1, 'customRole', NULL)
+          ))
+        ))
+      )
+    )
+  );
+
+  -- ============================================================
+  -- T5: fixed roleRequirements [dealer×2, floor×1] → SUM = 3
+  -- ============================================================
+  INSERT INTO public.job_postings (id, owner_id, title, status, total_positions, filled_positions, schedule)
+  VALUES (
+    v_t5, v_owner_id, '__sql_fixture_total_t5', 'draft', 999, 0,
+    jsonb_build_object(
+      'kind', 'fixed',
+      'roleRequirements', jsonb_build_array(
+        jsonb_build_object('role', 'dealer', 'count', 2),
+        jsonb_build_object('role', 'floor',  'count', 1)
+      )
+    )
+  );
+
+  -- ============================================================
+  -- T6: dated + requirements=[] → 0
+  -- ============================================================
+  INSERT INTO public.job_postings (id, owner_id, title, status, total_positions, filled_positions, schedule)
+  VALUES (
+    v_t6, v_owner_id, '__sql_fixture_total_t6', 'draft', 999, 0,
+    jsonb_build_object('kind', 'dated', 'requirements', '[]'::jsonb)
+  );
+
+  -- ============================================================
+  -- T7: role='other' customRole='translator' + dealer×2
+  --     translator MAX = 1, dealer MAX = 2 → SUM = 3
+  -- ============================================================
+  INSERT INTO public.job_postings (id, owner_id, title, status, total_positions, filled_positions, schedule)
+  VALUES (
+    v_t7, v_owner_id, '__sql_fixture_total_t7', 'draft', 999, 0,
+    jsonb_build_object(
+      'kind', 'dated',
+      'requirements', jsonb_build_array(
+        jsonb_build_object('date', '2026-05-01', 'timeSlots', jsonb_build_array(
+          jsonb_build_object('roles', jsonb_build_array(
+            jsonb_build_object('role', 'other',  'count', 1, 'customRole', 'translator'),
+            jsonb_build_object('role', 'dealer', 'count', 2, 'customRole', NULL)
+          ))
+        ))
+      )
+    )
+  );
+
+  -- ============================================================
+  -- 백필 CTE 실행 (마이그레이션 본체와 동일 로직, 테스트 대상 postings만 한정 X
+  -- → idempotent UPDATE이므로 다른 postings에도 안전하지만, BEGIN/ROLLBACK으로 보호)
+  -- ============================================================
+  WITH role_max AS (
+    SELECT
+      jp.id AS posting_id,
+      CASE
+        WHEN role_elem->>'role' = 'other'
+          THEN 'other:' || COALESCE(role_elem->>'customRole', '')
+        ELSE COALESCE(role_elem->>'role', '')
+      END AS role_key,
+      MAX(NULLIF(role_elem->>'count', '')::int) AS max_count
+    FROM public.job_postings jp
+    CROSS JOIN LATERAL jsonb_array_elements(jp.schedule->'requirements') AS req
+    CROSS JOIN LATERAL jsonb_array_elements(req->'timeSlots') AS slot
+    CROSS JOIN LATERAL jsonb_array_elements(slot->'roles') AS role_elem
+    WHERE jp.schedule->>'kind' IS DISTINCT FROM 'fixed'
+      AND jp.schedule ? 'requirements'
+      AND jsonb_typeof(jp.schedule->'requirements') = 'array'
+      AND jp.id IN (v_t1, v_t2, v_t3, v_t4, v_t7)
+    GROUP BY jp.id, role_key
+  ),
+  dated_totals AS (
+    SELECT posting_id, COALESCE(SUM(max_count), 0)::int AS total
+    FROM role_max
+    GROUP BY posting_id
+  ),
+  fixed_totals AS (
+    SELECT
+      jp.id AS posting_id,
+      COALESCE(SUM(NULLIF(r->>'count', '')::int), 0)::int AS total
+    FROM public.job_postings jp
+    LEFT JOIN LATERAL jsonb_array_elements(jp.schedule->'roleRequirements') AS r ON TRUE
+    WHERE jp.schedule->>'kind' = 'fixed'
+      AND jp.id = v_t5
+    GROUP BY jp.id
+  ),
+  posting_totals AS (
+    SELECT posting_id, total FROM dated_totals
+    UNION ALL
+    SELECT posting_id, total FROM fixed_totals
+  )
+  UPDATE public.job_postings jp
+  SET total_positions = pt.total, updated_at = now()
+  FROM posting_totals pt
+  WHERE jp.id = pt.posting_id;
+
+  -- 빈 dated 케이스 보정
+  UPDATE public.job_postings
+  SET total_positions = 0, updated_at = now()
+  WHERE id = v_t6
+    AND schedule->>'kind' IS DISTINCT FROM 'fixed'
+    AND (
+      schedule->'requirements' IS NULL
+      OR jsonb_typeof(schedule->'requirements') != 'array'
+      OR jsonb_array_length(schedule->'requirements') = 0
+    );
+
+  -- ============================================================
+  -- 검증
+  -- ============================================================
+  SELECT total_positions INTO v_got FROM public.job_postings WHERE id = v_t1;
+  IF v_got IS DISTINCT FROM 3 THEN
+    RAISE EXCEPTION 'T1 fail: grouped 3days dealer×2+floor×1 expected total=3, got %', v_got;
+  END IF;
+
+  SELECT total_positions INTO v_got FROM public.job_postings WHERE id = v_t2;
+  IF v_got IS DISTINCT FROM 2 THEN
+    RAISE EXCEPTION 'T2 fail: 3days dealer×2 expected total=2 (person basis), got %', v_got;
+  END IF;
+
+  SELECT total_positions INTO v_got FROM public.job_postings WHERE id = v_t3;
+  IF v_got IS DISTINCT FROM 3 THEN
+    RAISE EXCEPTION 'T3 fail: mixed dealer×2 + dealer×3 expected total=3, got %', v_got;
+  END IF;
+
+  SELECT total_positions INTO v_got FROM public.job_postings WHERE id = v_t4;
+  IF v_got IS DISTINCT FROM 4 THEN
+    RAISE EXCEPTION 'T4 fail: multi-role dealer×2+floor×1+serving×1 expected total=4, got %', v_got;
+  END IF;
+
+  SELECT total_positions INTO v_got FROM public.job_postings WHERE id = v_t5;
+  IF v_got IS DISTINCT FROM 3 THEN
+    RAISE EXCEPTION 'T5 fail: fixed [dealer×2, floor×1] expected total=3, got %', v_got;
+  END IF;
+
+  SELECT total_positions INTO v_got FROM public.job_postings WHERE id = v_t6;
+  IF v_got IS DISTINCT FROM 0 THEN
+    RAISE EXCEPTION 'T6 fail: dated + requirements=[] expected total=0, got %', v_got;
+  END IF;
+
+  SELECT total_positions INTO v_got FROM public.job_postings WHERE id = v_t7;
+  IF v_got IS DISTINCT FROM 3 THEN
+    RAISE EXCEPTION 'T7 fail: other:translator(1) + dealer(2) expected total=3, got %', v_got;
+  END IF;
+
+  -- ============================================================
+  -- Cleanup (ROLLBACK이 모든 변경을 되돌리지만, 명시적으로도 삭제)
+  -- ============================================================
+  DELETE FROM public.job_postings WHERE id IN (v_t1, v_t2, v_t3, v_t4, v_t5, v_t6, v_t7);
+  DELETE FROM auth.users WHERE id = v_owner_id;
+END $$;
+
+ROLLBACK;
+
+SELECT 'TOTAL_POSITIONS_BACKFILL_TEST_PASSED' AS result;


### PR DESCRIPTION
## Summary

`job_postings.total_positions`를 **슬롯 단위(3일×딜러2=6)**에서 **사람 단위(역할별 peak 합=2)**로 전환합니다. 선행 PR(#TBD, `fix/confirmed-count-sync`)의 `filled_positions` 사람 단위화와 짝을 이루어 의미 단위 미스매치로 인한 auto-close 오작동을 해소합니다.

## ⚠️ 머지 순서 (필수)

**이 PR은 `fix/confirmed-count-sync` (worktree 1) 머지 후에만 머지 가능합니다.**

- 본 마이그레이션(`20260418010000`)은 선행 마이그레이션(`20260418000000_person_basis_filled_positions`)의 존재를 `supabase_migrations.schema_migrations`에서 precondition 체크하며, 없으면 `RAISE EXCEPTION`으로 배포 실패시킵니다.
- 단독 머지 시 `total=사람 / filled=슬롯` 의미 역전으로 auto-close가 계속 오작동합니다.

## Changes

### Phase 6 — TS 사람 단위 계산 함수 (`446961c7e`, `8161cee81`)
- `src/domains/job-posting/stats.ts`: `calculateTotalPositionsFromSchedule` 신규 export
  - `fixed`: `sum(roleRequirements[].count)`
  - `dated`: 역할별 `MAX(count)` across all timeSlots → 역할별 MAX의 SUM
  - role 키: `role === 'other'` → `other:<customRole>`, 그 외 → `role`
  - 빈 role 스킵 (null 반환)
- `serialization.ts`: 기존 `calculateTotalsFromSchedule` 내부 교체
- `__tests__/totalPositions.test.ts`: **13 케이스 TDD** (그룹/비그룹/혼합/멀티역할/other/경계)

### Phase 7 — 백필 마이그레이션 (`dc52d9f23`)
- `supabase/migrations/20260418010000_total_positions_person_basis.sql`: 기존 데이터 재계산
- `supabase/tests/total_positions_backfill.test.sql`: **7 회귀 케이스** (BEGIN/ROLLBACK)

### Phase 6-추가 — UI 안내 배너 (`aa09355d5`)
- `app/(employer)/my-postings/[id]/edit.tsx`: 업주가 편집 진입 시 "표시 기준이 최소 필요 인원 수로 바뀌어 숫자가 작아 보일 수 있음" 안내 배너

### 리뷰 반영 (Claude + Codex adversarial, 4 CRITICAL + 1 INFO)
- **C1** (`fef319cf7`): SQL 중첩 `jsonb_array_elements` 호출 전 `jsonb_typeof = 'array'` CASE 가드 → dirty schedule에서 마이그레이션 abort 방지
- **C2** (`fef319cf7`): count 문자열 정규식(`^-?[0-9]+$`) 통과한 것만 int 캐스팅 → `'abc'`/`' '`/`'null'` InvalidTextRepresentation 차단
- **C3** (`13e15b3d3`): `dateUtils.getClosingStatus` dated/fixed 분기 → `calculateTotalPositionsFromSchedule` + DB `filledPositions` 직접 사용. `ApplicationValidator`·apply 가드 third-site 버그 해소
- **C4** (`ab8d4f31e`): `serialization.ts`에서 `filledPositions` schedule 추론 제거. RPC가 관리하는 DB 컬럼을 단일 진실원으로
- **I3** (`9189903ab`): 마이그레이션에 선행 버전 precondition 가드
- **I4** (`fef319cf7`): `GET DIAGNOSTICS ROW_COUNT`로 실제 영향 row 수 로깅

## Test plan

- [x] `npx jest --testPathPattern "(totalPositions|filledPositions|dateUtils|ApplicationValidator)"` → **106/106 pass**
- [x] `npm run quality` (tsc + eslint + prettier) → clean
- [ ] 스테이징 DB에서 `supabase db push` 후 precondition 가드 동작 확인 (선행 마이그 없이 실행 시 실패해야 함)
- [ ] 스테이징에서 dated/fixed/혼합 포스팅 대상 백필 전후 `total_positions` 값 비교
- [ ] 편집 화면에서 안내 배너 렌더링 확인 (다크모드 포함)
- [ ] 백필 후 auto-close 실제 동작 확인 (`filled_positions >= total_positions` 트리거되는지)

## 배포 주의사항

- **머지 순서**: `fix/confirmed-count-sync` 먼저 머지/배포 → 본 PR 머지/배포
- **realtime trigger**: 백필 UPDATE는 `WHERE total_positions IS DISTINCT FROM pt.total`로 실제 변화 row만 갱신하나, `updated_at=now()`가 찍히므로 board/realtime 채널이 해당 row를 재전송할 수 있음. 배포 직후 채널 부하 모니터링 권고
- **업주 UX**: 백필 후 기존 "30명" 표시가 "3명"처럼 작아질 수 있음. 편집 화면 배너로 안내 중이며, 릴리즈 노트 공지 권고

## 관련 문서

- `docs/advisor-review-phase-6-7.md` — Codex advisor 1차 리뷰 (알고리즘 검증)
- HANDOFF.md (untracked, 로컬 세션 핸드오프 용도)

---
Generated with [Claude Code](https://claude.com/claude-code)