### PR TITLE
fix(applicant-stats): 멀티역할 지원자를 각 역할에 중복 카운트 (person basis)

### DIFF
--- a/uniqn-mobile/src/__tests__/hooks/useApplicantManagement.test.ts
+++ b/uniqn-mobile/src/__tests__/hooks/useApplicantManagement.test.ts
@@ -520,6 +520,47 @@ describe('useApplicantManagement Hooks', () => {
       expect(result.current.cancellationRequests[0].id).toBe('app-3');
     });
 
+    it('should count multi-role applicants under each role (deliberate overcount in role stats)', () => {
+      // 딜러+플로어 겸직 지원자 1명 확정 → dealer.confirmed=1 AND floor.confirmed=1
+      // overall confirmedCount=1 (사람 수), Σ statsByRole[role].confirmed=2 (역할별 합계)는 의도된 차이
+      mockData = createMockApplicantListResult([
+        createMockApplicantWithDetails({
+          id: 'app-multi',
+          status: 'confirmed',
+          assignments: [
+            { dates: ['2024-01-15'], timeSlot: '14:00~22:00', roleIds: ['dealer', 'floor'] },
+          ],
+        }),
+      ]);
+
+      const { result } = renderHook(() => useApplicantManagement('job-1'));
+
+      expect(result.current.confirmedCount).toBe(1);
+      expect(result.current.statsByRole.dealer.confirmed).toBe(1);
+      expect(result.current.statsByRole.floor.confirmed).toBe(1);
+      expect(result.current.statsByRole.dealer.total).toBe(1);
+      expect(result.current.statsByRole.floor.total).toBe(1);
+    });
+
+    it('should dedupe the same role across multiple assignments on a single application', () => {
+      // 같은 application이 서로 다른 assignment에서 'dealer' 역할을 2번 가져도 1번만 카운트
+      mockData = createMockApplicantListResult([
+        createMockApplicantWithDetails({
+          id: 'app-dupe-role',
+          status: 'confirmed',
+          assignments: [
+            { dates: ['2024-01-15'], timeSlot: '14:00~22:00', roleIds: ['dealer'] },
+            { dates: ['2024-01-16'], timeSlot: '14:00~22:00', roleIds: ['dealer'] },
+          ],
+        }),
+      ]);
+
+      const { result } = renderHook(() => useApplicantManagement('job-1'));
+
+      expect(result.current.statsByRole.dealer.confirmed).toBe(1);
+      expect(result.current.statsByRole.dealer.total).toBe(1);
+    });
+
     it('should filter and sort applicants', () => {
       mockData = createMockApplicantListResult([
         createMockApplicantWithDetails({

--- a/uniqn-mobile/src/hooks/applicant/index.ts
+++ b/uniqn-mobile/src/hooks/applicant/index.ts
@@ -11,7 +11,7 @@ import { STATUS } from '@/constants';
 import { STATUS_TO_STATS_KEY } from '@/constants/statusConfig';
 import { toDateValue } from '@/utils/date';
 import { useApplicantsByJobPosting } from './useApplicantsByJobPosting';
-import { getPrimaryRoleId } from './helpers';
+import { getPrimaryRoleId, getAllRoleIds } from './helpers';
 import {
   useConfirmApplication,
   useRejectApplication,
@@ -60,24 +60,39 @@ function createEmptyApplicationStats(): ApplicationStats {
   };
 }
 
+/**
+ * 지원자를 assignments의 **모든** 역할에 1씩 카운트한다.
+ * 멀티역할(딜러+플로어 겸직) 지원자는 각 역할 statsByRole에 1번씩 반영.
+ *
+ * 주의: Σ statsByRole[role].total > applicants.length 가능 (중복 카운트는 의도됨).
+ * 이유: "역할별 지원자 수" 카드는 각 역할 관점의 수요를 보여줘야 하고,
+ *       전체 합계는 별도 overall count(`confirmedCount` 등)에서 사람 단위로 제공.
+ */
 function buildStatsByRole(applicants: ApplicantWithDetails[]): Record<StaffRole, ApplicationStats> {
   const statsByRole: Record<string, ApplicationStats> = {};
 
   applicants.forEach((application) => {
-    const primaryRole = getPrimaryRoleId(application.assignments);
-    const effectiveRole =
-      primaryRole === 'other' && application.customRole ? application.customRole : primaryRole;
-
-    if (!statsByRole[effectiveRole]) {
-      statsByRole[effectiveRole] = createEmptyApplicationStats();
-    }
-
-    statsByRole[effectiveRole].total++;
+    const roleIds = getAllRoleIds(application.assignments);
+    const baseRoles = roleIds.length > 0 ? roleIds : ['other'];
+    const effectiveRoles = baseRoles.map((roleId) =>
+      roleId === 'other' && application.customRole ? application.customRole : roleId
+    );
+    // 같은 application이 다수 assignment에서 동일 역할을 가지면 1번만 카운트
+    const uniqueEffectiveRoles = Array.from(new Set(effectiveRoles));
 
     const statsKey = STATUS_TO_STATS_KEY[application.status];
-    if (statsKey && statsKey !== 'total') {
-      statsByRole[effectiveRole][statsKey]++;
-    }
+
+    uniqueEffectiveRoles.forEach((role) => {
+      if (!statsByRole[role]) {
+        statsByRole[role] = createEmptyApplicationStats();
+      }
+
+      statsByRole[role].total++;
+
+      if (statsKey && statsKey !== 'total') {
+        statsByRole[role][statsKey]++;
+      }
+    });
   });
 
   return statsByRole as Record<StaffRole, ApplicationStats>;

--- a/uniqn-mobile/supabase/migrations/20260418005000_person_basis_filled_positions.sql
+++ b/uniqn-mobile/supabase/migrations/20260418005000_person_basis_filled_positions.sql
@@ -1,0 +1,349 @@
+-- =============================================================================
+-- FIX: filled_positions 사람 기준(person basis) 정렬
+-- =============================================================================
+-- 증상(복합):
+--   1) confirm_application RPC가 jsonb_array_length(p_assignments)만큼 filled_positions 증가
+--      → 그룹일정(dates 여러 개) 1명 확정 시 +N → "사람 1명 = 슬롯 N개" 혼재 표시
+--   2) cancel_application_atomically RPC가 동일하게 assignment_count(슬롯) 단위로 감소
+--      → GREATEST(0, ...) clamp로 감소량이 의도치 않게 0에 걸릴 수 있음
+--   3) stats.filledPositions도 같이 슬롯 단위로 축적 → 집계 API 일관성 파괴
+--
+-- 정책 결정:
+--   filled_positions / stats.filledPositions = 확정된 지원서(사람) 수
+--   그룹일정, 멀티역할 여부와 무관하게 1 application = 1 filled_position
+--
+-- 수정:
+--   1. confirm_application: filled_positions += 1 (jsonb_array_length 제거)
+--   2. cancel_application_atomically: filled_positions -= 1 (slot 단위 감소 제거,
+--      assignment_count는 반환 JSON에 유지하여 backward-compat)
+--   3. 데이터 백필: filled_positions = COUNT(applications WHERE status IN
+--      ('confirmed','completed','cancellation_pending')) per posting
+--
+-- Related: docs/analysis/2026-04-17-confirmed-count-sync-root-cause.md
+-- =============================================================================
+
+-- =============================================================================
+-- 1. confirm_application — filled_positions += 1
+-- =============================================================================
+CREATE OR REPLACE FUNCTION public.confirm_application(
+  p_application_id uuid,
+  p_owner_id uuid,
+  p_assignments jsonb DEFAULT '[]'::jsonb,
+  p_original_application jsonb DEFAULT NULL::jsonb,
+  p_confirmation_history jsonb DEFAULT '[]'::jsonb,
+  p_notes text DEFAULT NULL::text,
+  p_is_fixed_posting boolean DEFAULT false,
+  p_assignments_v3 jsonb DEFAULT NULL::jsonb
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_app record;
+  v_job record;
+  v_work_log_ids uuid[] := '{}';
+  v_wl_id uuid;
+  v_assignment jsonb;
+  v_now timestamptz := now();
+BEGIN
+  -- is_active guard (T-E4-rest)
+  IF NOT EXISTS (
+    SELECT 1 FROM public.users
+    WHERE id = p_owner_id AND is_active = true
+  ) THEN
+    RAISE EXCEPTION 'ACCOUNT_DISABLED: owner account is disabled (%)', p_owner_id;
+  END IF;
+
+  SELECT * INTO v_app FROM applications WHERE id = p_application_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'APPLICATION_NOT_FOUND: %', p_application_id; END IF;
+  IF v_app.status != 'applied' THEN
+    RAISE EXCEPTION 'INVALID_STATUS: 현재 상태 %, applied만 확정 가능', v_app.status;
+  END IF;
+
+  SELECT * INTO v_job FROM job_postings WHERE id = v_app.job_posting_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'POSTING_NOT_FOUND: %', v_app.job_posting_id; END IF;
+  IF v_job.owner_id != p_owner_id THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED: 공고 소유자만 확정 가능';
+  END IF;
+
+  -- work_logs INSERT: flat 포맷(p_assignments) 사용 (슬롯 단위, 날짜×역할 1:1)
+  IF NOT p_is_fixed_posting AND jsonb_array_length(p_assignments) > 0 THEN
+    FOR v_assignment IN SELECT * FROM jsonb_array_elements(p_assignments)
+    LOOP
+      INSERT INTO work_logs (
+        staff_id, job_posting_id, application_id,
+        assignment_group_id, date, time_slot,
+        staff_name, staff_nickname, staff_photo_url,
+        role, custom_role, owner_id,
+        status, is_fixed_posting,
+        created_at, updated_at
+      ) VALUES (
+        v_app.applicant_id, v_app.job_posting_id, p_application_id,
+        v_assignment->>'groupId', v_assignment->>'date', v_assignment->>'timeSlot',
+        v_app.applicant_name, v_app.applicant_nickname, v_app.applicant_photo_url,
+        COALESCE((v_assignment->>'role')::staff_role, v_app.applicant_role, 'staff'),
+        v_assignment->>'customRole', p_owner_id,
+        'scheduled', false, v_now, v_now
+      ) RETURNING id INTO v_wl_id;
+      v_work_log_ids := array_append(v_work_log_ids, v_wl_id);
+    END LOOP;
+  END IF;
+
+  -- applications UPDATE: assignments 컬럼은 v3 canonical 사용 (덮어쓰기 버그 방지)
+  UPDATE applications SET
+    status = 'confirmed',
+    assignments = COALESCE(p_assignments_v3, assignments),
+    original_application = COALESCE(p_original_application, original_application),
+    confirmation_history = p_confirmation_history,
+    confirmed_at = v_now,
+    processed_by = p_owner_id::text,
+    processed_at = v_now,
+    notes = COALESCE(p_notes, notes),
+    updated_at = v_now
+  WHERE id = p_application_id;
+
+  -- job_postings filled_positions: 사람 단위(+1) ← CHANGED from jsonb_array_length(p_assignments)
+  UPDATE job_postings SET
+    filled_positions = filled_positions + 1,
+    stats = jsonb_set(
+      jsonb_set(
+        COALESCE(stats, '{}'::jsonb),
+        '{confirmedApplicants}',
+        to_jsonb(COALESCE((stats->>'confirmedApplicants')::int, 0) + 1)
+      ),
+      '{filledPositions}',
+      to_jsonb(COALESCE((stats->>'filledPositions')::int, 0) + 1)
+    ),
+    updated_at = v_now
+  WHERE id = v_app.job_posting_id;
+
+  RETURN jsonb_build_object(
+    'applicationId', p_application_id,
+    'workLogIds', to_jsonb(v_work_log_ids),
+    'assignmentCount', jsonb_array_length(p_assignments)
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.confirm_application(uuid, uuid, jsonb, jsonb, jsonb, text, boolean, jsonb) IS
+  '지원서 확정 RPC (person basis). applications.assignments=v3 canonical, work_logs=flat 전개, filled_positions += 1 (사람 단위).';
+
+-- =============================================================================
+-- 2. cancel_application_atomically — filled_positions -= 1 (사람 단위)
+-- =============================================================================
+CREATE OR REPLACE FUNCTION public.cancel_application_atomically(
+  p_application_id uuid,
+  p_actor_type text,
+  p_actor_id uuid,
+  p_cancel_reason text DEFAULT NULL::text,
+  p_rejection_reason text DEFAULT NULL::text
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_application applications%ROWTYPE;
+  v_job_posting job_postings%ROWTYPE;
+  v_active_confirmation_entry jsonb;
+  v_active_confirmation_index int;
+  v_confirmation_history jsonb := '[]'::jsonb;
+  v_deleted_work_log_count int := 0;
+  v_now text := to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"');
+  v_now_ts timestamptz := now();
+  v_assignment_count int := 0;
+  v_new_filled int;
+  v_new_status text;
+  v_updated_cancellation_request jsonb;
+BEGIN
+  -- 1. Lock application row
+  SELECT * INTO v_application FROM applications
+  WHERE id = p_application_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'application_not_found');
+  END IF;
+
+  -- is_active guard (T-E4-rest)
+  IF NOT EXISTS (
+    SELECT 1 FROM public.users
+    WHERE id = p_actor_id AND is_active = true
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'account_disabled');
+  END IF;
+
+  -- 2. Idempotency
+  IF p_actor_type = 'staff_initiates' AND v_application.status = 'applied' THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true);
+  END IF;
+  IF p_actor_type = 'staff_approves_cancel_request' AND v_application.status = 'cancelled' THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true);
+  END IF;
+
+  -- 3. State validation (actor-specific)
+  IF p_actor_type = 'staff_initiates' THEN
+    IF v_application.status != 'confirmed' THEN
+      RETURN jsonb_build_object('success', false, 'error', 'invalid_status_for_cancellation');
+    END IF;
+  ELSIF p_actor_type = 'staff_approves_cancel_request' THEN
+    IF v_application.status != 'cancellation_pending' THEN
+      RETURN jsonb_build_object('success', false, 'error', 'invalid_status_for_approval');
+    END IF;
+    IF (v_application.cancellation_request->>'status') != 'pending' THEN
+      RETURN jsonb_build_object('success', false, 'error', 'cancellation_request_not_pending');
+    END IF;
+  ELSE
+    RETURN jsonb_build_object('success', false, 'error', 'invalid_actor_type');
+  END IF;
+
+  -- 4. Lock job_posting
+  SELECT * INTO v_job_posting FROM job_postings
+  WHERE id = v_application.job_posting_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'job_posting_not_found');
+  END IF;
+
+  -- 5. Manual permission check
+  IF p_actor_type = 'staff_approves_cancel_request' THEN
+    IF v_job_posting.owner_id != p_actor_id THEN
+      RETURN jsonb_build_object('success', false, 'error', 'unauthorized');
+    END IF;
+  ELSIF p_actor_type = 'staff_initiates' THEN
+    IF v_application.applicant_id != p_actor_id THEN
+      RETURN jsonb_build_object('success', false, 'error', 'unauthorized');
+    END IF;
+  END IF;
+
+  -- 6. confirmation_history 갱신
+  v_confirmation_history := COALESCE(v_application.confirmation_history, '[]'::jsonb);
+  SELECT value, ordinality - 1
+  INTO v_active_confirmation_entry, v_active_confirmation_index
+  FROM jsonb_array_elements(v_confirmation_history) WITH ORDINALITY
+  WHERE (value->>'cancelled_at') IS NULL
+  LIMIT 1;
+
+  IF v_active_confirmation_entry IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'no_active_confirmation');
+  END IF;
+
+  v_confirmation_history := jsonb_set(v_confirmation_history,
+    ARRAY[v_active_confirmation_index::text, 'cancelled_at'], to_jsonb(v_now));
+  v_confirmation_history := jsonb_set(v_confirmation_history,
+    ARRAY[v_active_confirmation_index::text, 'cancelled_by'], to_jsonb(p_actor_id));
+  v_confirmation_history := jsonb_set(v_confirmation_history,
+    ARRAY[v_active_confirmation_index::text, 'cancellation_reason'],
+    COALESCE(to_jsonb(p_cancel_reason), 'null'::jsonb));
+
+  -- 7. New status + cancellation_request update
+  IF p_actor_type = 'staff_initiates' THEN
+    v_new_status := 'applied';
+  ELSE
+    v_new_status := 'cancelled';
+    v_updated_cancellation_request := v_application.cancellation_request
+      || jsonb_build_object('status', 'approved', 'reviewed_at', v_now, 'reviewed_by', p_actor_id);
+  END IF;
+
+  -- 8. Update applications
+  UPDATE applications SET
+    status = v_new_status::application_status,
+    confirmation_history = v_confirmation_history,
+    cancellation_request = COALESCE(v_updated_cancellation_request, cancellation_request),
+    cancelled_at = v_now_ts,
+    updated_at = v_now_ts
+  WHERE id = p_application_id;
+
+  -- 9. assignment_count는 backward-compat을 위해 계산 유지 (반환 JSON용)
+  SELECT COUNT(*)::int INTO v_assignment_count
+  FROM jsonb_array_elements(v_active_confirmation_entry->'assignments') a
+  CROSS JOIN LATERAL jsonb_array_elements((a->>'dates')::jsonb) d;
+
+  -- job_postings filled_positions: 사람 단위(-1) ← CHANGED from v_assignment_count
+  v_new_filled := GREATEST(0, v_job_posting.filled_positions - 1);
+
+  -- stats.filledPositions은 filled_positions 컬럼과 동기화, confirmedApplicants는 별도 관리 RPC에서 이미 감소됨
+  -- (staff_initiates: confirmed→applied / staff_approves_cancel_request: cancellation_pending→cancelled
+  --  둘 다 confirmedApplicants를 이 RPC에서 감소시킬지 여부는 request_cancellation RPC 동작과의 중복
+  --  리스크가 있어 본 마이그레이션에서는 손대지 않음. 백필로 초기 sync만 맞춤.)
+  UPDATE job_postings SET
+    filled_positions = v_new_filled,
+    stats = jsonb_set(
+      COALESCE(stats, '{}'::jsonb),
+      '{filledPositions}',
+      to_jsonb(v_new_filled)
+    ),
+    status = CASE
+      WHEN status = 'closed' AND v_new_filled < total_positions THEN 'active'::posting_status
+      ELSE status
+    END,
+    updated_at = v_now_ts
+  WHERE id = v_job_posting.id;
+
+  -- 10. work_logs DELETE (scheduled 상태만)
+  DELETE FROM work_logs
+  WHERE application_id = p_application_id
+    AND status = 'scheduled';
+  GET DIAGNOSTICS v_deleted_work_log_count = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'application_id', p_application_id,
+    'new_status', v_new_status,
+    'assignment_count', v_assignment_count,
+    'new_filled_positions', v_new_filled,
+    'deleted_work_log_count', v_deleted_work_log_count,
+    'cancelled_at', v_now
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.cancel_application_atomically(uuid, text, uuid, text, text) IS
+  '지원 취소 원자 RPC (person basis). filled_positions -= 1 (사람 단위, assignment_count는 반환 JSON에 유지).';
+
+-- =============================================================================
+-- 3. 데이터 백필 — 기존 filled_positions / stats.filledPositions 재계산
+-- =============================================================================
+-- 논리: 1 application(status=confirmed | completed | cancellation_pending) = 1 filled
+-- cancellation_pending은 "확정된 상태에서 취소 요청만 한 것"이므로 슬롯은 여전히 점유.
+-- =============================================================================
+UPDATE job_postings jp SET
+  filled_positions = sub.cnt,
+  stats = jsonb_set(
+    jsonb_set(
+      COALESCE(stats, '{}'::jsonb),
+      '{filledPositions}',
+      to_jsonb(sub.cnt)
+    ),
+    '{confirmedApplicants}',
+    to_jsonb(sub.confirmed_only_cnt)
+  ),
+  updated_at = now()
+FROM (
+  SELECT
+    jp2.id AS posting_id,
+    COALESCE(COUNT(a.id) FILTER (
+      WHERE a.status IN ('confirmed', 'completed', 'cancellation_pending')
+    ), 0)::int AS cnt,
+    COALESCE(COUNT(a.id) FILTER (
+      WHERE a.status = 'confirmed'
+    ), 0)::int AS confirmed_only_cnt
+  FROM job_postings jp2
+  LEFT JOIN applications a ON a.job_posting_id = jp2.id
+  GROUP BY jp2.id
+) sub
+WHERE jp.id = sub.posting_id
+  AND (
+    jp.filled_positions IS DISTINCT FROM sub.cnt
+    OR COALESCE((jp.stats->>'filledPositions')::int, -1) != sub.cnt
+    OR COALESCE((jp.stats->>'confirmedApplicants')::int, -1) != sub.confirmed_only_cnt
+  );
+
+-- 백필 결과 로그 (idempotent — 재실행 시 WHERE 조건으로 0행 업데이트)
+DO $$
+DECLARE
+  v_fixed_count int;
+BEGIN
+  GET DIAGNOSTICS v_fixed_count = ROW_COUNT;
+  RAISE NOTICE 'filled_positions 백필 완료: % rows', v_fixed_count;
+END $$;

--- a/uniqn-mobile/supabase/migrations/20260418010000_total_positions_person_basis.sql
+++ b/uniqn-mobile/supabase/migrations/20260418010000_total_positions_person_basis.sql
@@ -4,7 +4,7 @@
 -- ----------------------------------------------------------------------------
 -- 기존: total_positions = Σ slot.role.count (슬롯 단위, 3일×딜러2 = 6)
 -- 신규: total_positions = Σ_role MAX_{all timeslots}(count) (사람 단위)
--- 이유: 선행 마이그레이션(20260418000000_person_basis_filled_positions.sql)이
+-- 이유: 선행 마이그레이션(20260418005000_person_basis_filled_positions.sql)이
 --       filled_positions을 사람 단위로 전환 → total_positions과 의미 단위
 --       미스매치 → auto-close(filled >= total) 오동작. 본 마이그레이션으로 해소.
 --
@@ -33,9 +33,9 @@
 -- ============================================================================
 
 -- ----------------------------------------------------------------------------
--- Precondition: 선행 마이그레이션 20260418000000 이 적용되어야 함
+-- Precondition: 선행 마이그레이션 20260418005000 이 적용되어야 함
 -- ----------------------------------------------------------------------------
--- 20260418000000_person_basis_filled_positions은 filled_positions을 사람 단위로
+-- 20260418005000_person_basis_filled_positions은 filled_positions을 사람 단위로
 -- 전환한다. 본 마이그레이션이 단독 적용되면 total=사람, filled=슬롯 미스매치가
 -- 남아 auto-close 로직이 계속 오작동하므로 의존성을 강제한다.
 --
@@ -47,10 +47,10 @@ BEGIN
   IF NOT EXISTS (
     SELECT 1
     FROM supabase_migrations.schema_migrations
-    WHERE version = '20260418000000'
+    WHERE version = '20260418005000'
   ) THEN
     RAISE EXCEPTION
-      'MIGRATION_DEPENDENCY_MISSING: 20260418010000_total_positions_person_basis requires 20260418000000_person_basis_filled_positions to be applied first. Merge fix/confirmed-count-sync (worktree 1) before deploying this migration.';
+      'MIGRATION_DEPENDENCY_MISSING: 20260418010000_total_positions_person_basis requires 20260418005000_person_basis_filled_positions to be applied first. Merge fix/confirmed-count-sync (worktree 1) before deploying this migration.';
   END IF;
 END
 $precondition$;

--- a/uniqn-mobile/supabase/tests/person_basis_filled_positions.test.sql
+++ b/uniqn-mobile/supabase/tests/person_basis_filled_positions.test.sql
@@ -1,0 +1,228 @@
+-- ============================================================
+-- person basis filled_positions 회귀 테스트
+-- ============================================================
+-- 목적: 마이그레이션 20260418000000_person_basis_filled_positions.sql 적용 후
+--       confirm/cancel RPC가 filled_positions를 사람 단위로 증감하는지 검증.
+--
+-- 사용법:
+--   psql "$SUPABASE_DB_URL" -f supabase/tests/person_basis_filled_positions.test.sql
+--   기대: 마지막에 'PERSON_BASIS_TEST_PASSED' NOTICE, 에러 0건
+--
+-- 시나리오:
+--   S1. 그룹일정(dates=3) 1명 확정 → filled_positions=1 (slot 3 아님)
+--   S2. 단일일정(dates=1) 1명 확정 → filled_positions=2 (누적)
+--   S3. 그룹 확정자 취소 → filled_positions=1 (slot 3 감소 아님)
+--   S4. 백필 쿼리 idempotency (재실행 시 0 rows affected)
+-- ============================================================
+
+DO $$
+DECLARE
+  v_owner_id uuid := gen_random_uuid();
+  v_staff1_id uuid := gen_random_uuid();
+  v_staff2_id uuid := gen_random_uuid();
+  v_job_id uuid := gen_random_uuid();
+  v_app1_id uuid := gen_random_uuid();
+  v_app2_id uuid := gen_random_uuid();
+  v_assignment_v3_group jsonb;
+  v_assignment_v3_single jsonb;
+  v_flat_group jsonb;
+  v_flat_single jsonb;
+  v_history_group jsonb;
+  v_history_single jsonb;
+  v_result jsonb;
+  v_filled int;
+  v_stats_filled int;
+  v_stats_confirmed int;
+BEGIN
+  -- ============================================================
+  -- 0. auth.users seed (트리거가 public.users 자동 생성)
+  -- ============================================================
+  INSERT INTO auth.users (id, email, raw_app_meta_data, raw_user_meta_data, created_at, updated_at)
+  VALUES
+    (v_owner_id,  '__sql_fixture_pb_owner@test.local',  '{"role":"employer"}'::jsonb, '{"name":"PB_OWNER"}'::jsonb, now(), now()),
+    (v_staff1_id, '__sql_fixture_pb_staff1@test.local', '{"role":"staff"}'::jsonb,    '{"name":"PB_STAFF1"}'::jsonb, now(), now()),
+    (v_staff2_id, '__sql_fixture_pb_staff2@test.local', '{"role":"staff"}'::jsonb,    '{"name":"PB_STAFF2"}'::jsonb, now(), now());
+
+  INSERT INTO public.job_postings (
+    id, owner_id, title, total_positions, filled_positions, status, stats, created_at, updated_at
+  ) VALUES (
+    v_job_id, v_owner_id, '__sql_fixture: person basis', 10, 0, 'active',
+    '{"totalApplicants":0,"activeApplicants":0,"confirmedApplicants":0,"cancellationPendingApplicants":0,"filledPositions":0}'::jsonb,
+    now(), now()
+  );
+
+  -- v3 canonical 포맷 (confirm 후 applications.assignments에 저장될 형태)
+  v_assignment_v3_group := jsonb_build_array(jsonb_build_object(
+    'roleIds', jsonb_build_array('dealer'),
+    'dates', jsonb_build_array('2026-05-01', '2026-05-02', '2026-05-03'),
+    'isGrouped', true,
+    'timeSlot', '19:00',
+    'groupId', 'group-1'
+  ));
+
+  v_assignment_v3_single := jsonb_build_array(jsonb_build_object(
+    'roleIds', jsonb_build_array('floor'),
+    'dates', jsonb_build_array('2026-05-04'),
+    'isGrouped', false,
+    'timeSlot', '20:00',
+    'groupId', null
+  ));
+
+  -- flat 포맷 (work_logs 전개용, dates × roleIds 카테시안)
+  v_flat_group := jsonb_build_array(
+    jsonb_build_object('groupId', 'group-1', 'date', '2026-05-01', 'timeSlot', '19:00', 'role', 'dealer'),
+    jsonb_build_object('groupId', 'group-1', 'date', '2026-05-02', 'timeSlot', '19:00', 'role', 'dealer'),
+    jsonb_build_object('groupId', 'group-1', 'date', '2026-05-03', 'timeSlot', '19:00', 'role', 'dealer')
+  );
+
+  v_flat_single := jsonb_build_array(
+    jsonb_build_object('groupId', null, 'date', '2026-05-04', 'timeSlot', '20:00', 'role', 'floor')
+  );
+
+  -- confirmation_history (RPC가 요구; 신규 항목 1건, active 상태)
+  v_history_group := jsonb_build_array(jsonb_build_object(
+    'assignments', v_assignment_v3_group,
+    'confirmed_at', now()::text,
+    'cancelled_at', NULL
+  ));
+
+  v_history_single := jsonb_build_array(jsonb_build_object(
+    'assignments', v_assignment_v3_single,
+    'confirmed_at', now()::text,
+    'cancelled_at', NULL
+  ));
+
+  -- 두 application을 applied 상태로 생성
+  INSERT INTO public.applications (
+    id, job_posting_id, applicant_id, applicant_name, status, assignments, created_at, updated_at
+  )
+  VALUES
+    (v_app1_id, v_job_id, v_staff1_id, 'PB_STAFF1', 'applied', v_assignment_v3_group,  now(), now()),
+    (v_app2_id, v_job_id, v_staff2_id, 'PB_STAFF2', 'applied', v_assignment_v3_single, now(), now());
+
+  -- ============================================================
+  -- S1: 그룹일정(dates=3) 1명 확정 → filled_positions = 1 (NOT 3)
+  -- ============================================================
+  v_result := public.confirm_application(
+    v_app1_id, v_owner_id, v_flat_group, NULL, v_history_group, NULL, false, v_assignment_v3_group
+  );
+
+  SELECT filled_positions INTO v_filled FROM public.job_postings WHERE id = v_job_id;
+  IF v_filled != 1 THEN
+    RAISE EXCEPTION 'S1 FAIL: 그룹일정 1명 확정 후 filled_positions=%, 기대 1 (slot 3 아님)', v_filled;
+  END IF;
+
+  SELECT (stats->>'filledPositions')::int INTO v_stats_filled FROM public.job_postings WHERE id = v_job_id;
+  IF v_stats_filled != 1 THEN
+    RAISE EXCEPTION 'S1 FAIL: stats.filledPositions=%, 기대 1', v_stats_filled;
+  END IF;
+
+  SELECT (stats->>'confirmedApplicants')::int INTO v_stats_confirmed FROM public.job_postings WHERE id = v_job_id;
+  IF v_stats_confirmed != 1 THEN
+    RAISE EXCEPTION 'S1 FAIL: stats.confirmedApplicants=%, 기대 1', v_stats_confirmed;
+  END IF;
+
+  -- applications.assignments는 v3 canonical 유지 확인 (덮어쓰기 버그 재발 방지)
+  IF NOT ((SELECT assignments->0 FROM public.applications WHERE id = v_app1_id) ? 'roleIds') THEN
+    RAISE EXCEPTION 'S1 FAIL: applications.assignments가 v3 canonical 아님 (roleIds 키 없음)';
+  END IF;
+
+  -- work_logs는 slot 단위(3건) INSERT 확인
+  IF (SELECT COUNT(*) FROM public.work_logs WHERE application_id = v_app1_id) != 3 THEN
+    RAISE EXCEPTION 'S1 FAIL: work_logs=%, 기대 3 (슬롯 단위)', (SELECT COUNT(*) FROM public.work_logs WHERE application_id = v_app1_id);
+  END IF;
+
+  -- ============================================================
+  -- S2: 단일일정 1명 추가 확정 → filled_positions = 2
+  -- ============================================================
+  v_result := public.confirm_application(
+    v_app2_id, v_owner_id, v_flat_single, NULL, v_history_single, NULL, false, v_assignment_v3_single
+  );
+
+  SELECT filled_positions INTO v_filled FROM public.job_postings WHERE id = v_job_id;
+  IF v_filled != 2 THEN
+    RAISE EXCEPTION 'S2 FAIL: 단일 1명 추가 후 filled_positions=%, 기대 2', v_filled;
+  END IF;
+
+  -- ============================================================
+  -- S3: 그룹 확정자 취소(staff_initiates) → filled_positions = 1
+  --      slot 단위라면 filled_positions = GREATEST(0, 2-3) = 0 이 됐을 것
+  -- ============================================================
+  v_result := public.cancel_application_atomically(v_app1_id, 'staff_initiates', v_staff1_id, '개인 사정');
+
+  IF NOT ((v_result->>'success')::bool) THEN
+    RAISE EXCEPTION 'S3 FAIL: cancel RPC success=false: %', v_result;
+  END IF;
+
+  IF (v_result->>'new_filled_positions')::int != 1 THEN
+    RAISE EXCEPTION 'S3 FAIL: new_filled_positions=%, 기대 1', v_result->>'new_filled_positions';
+  END IF;
+
+  SELECT filled_positions INTO v_filled FROM public.job_postings WHERE id = v_job_id;
+  IF v_filled != 1 THEN
+    RAISE EXCEPTION 'S3 FAIL: 그룹 취소 후 filled_positions=%, 기대 1 (slot 3 감소 아님)', v_filled;
+  END IF;
+
+  SELECT (stats->>'filledPositions')::int INTO v_stats_filled FROM public.job_postings WHERE id = v_job_id;
+  IF v_stats_filled != 1 THEN
+    RAISE EXCEPTION 'S3 FAIL: stats.filledPositions=%, 기대 1 (filled_positions 컬럼과 동기)', v_stats_filled;
+  END IF;
+
+  -- stats.confirmedApplicants는 cancel RPC에서 손대지 않음 (request_cancellation 경로와 중복 우려).
+  -- 초기 sync는 백필로 맞추고, 이후 drift는 후속 PR에서 처리.
+
+  -- work_logs scheduled 3건은 모두 삭제되어야 함 (slot 레벨 기존 동작 유지)
+  IF (SELECT COUNT(*) FROM public.work_logs WHERE application_id = v_app1_id AND status = 'scheduled') != 0 THEN
+    RAISE EXCEPTION 'S3 FAIL: work_logs scheduled 건 남아있음';
+  END IF;
+
+  -- ============================================================
+  -- S4: 백필 쿼리 idempotency — 현재 상태에서 백필 재실행 시 0행
+  -- ============================================================
+  UPDATE public.job_postings jp SET
+    filled_positions = sub.cnt,
+    stats = jsonb_set(
+      jsonb_set(
+        COALESCE(stats, '{}'::jsonb),
+        '{filledPositions}',
+        to_jsonb(sub.cnt)
+      ),
+      '{confirmedApplicants}',
+      to_jsonb(sub.confirmed_only_cnt)
+    ),
+    updated_at = now()
+  FROM (
+    SELECT
+      jp2.id AS posting_id,
+      COALESCE(COUNT(a.id) FILTER (
+        WHERE a.status IN ('confirmed', 'completed', 'cancellation_pending')
+      ), 0)::int AS cnt,
+      COALESCE(COUNT(a.id) FILTER (
+        WHERE a.status = 'confirmed'
+      ), 0)::int AS confirmed_only_cnt
+    FROM public.job_postings jp2
+    LEFT JOIN public.applications a ON a.job_posting_id = jp2.id
+    WHERE jp2.id = v_job_id
+    GROUP BY jp2.id
+  ) sub
+  WHERE jp.id = sub.posting_id
+    AND (
+      jp.filled_positions IS DISTINCT FROM sub.cnt
+      OR COALESCE((jp.stats->>'filledPositions')::int, -1) != sub.cnt
+      OR COALESCE((jp.stats->>'confirmedApplicants')::int, -1) != sub.confirmed_only_cnt
+    );
+
+  IF FOUND THEN
+    RAISE EXCEPTION 'S4 FAIL: 백필 재실행 시 UPDATE 발생 (idempotent 아님)';
+  END IF;
+
+  -- ============================================================
+  -- 정리
+  -- ============================================================
+  DELETE FROM public.work_logs WHERE job_posting_id = v_job_id;
+  DELETE FROM public.applications WHERE id IN (v_app1_id, v_app2_id);
+  DELETE FROM public.job_postings WHERE id = v_job_id;
+  DELETE FROM auth.users WHERE id IN (v_owner_id, v_staff1_id, v_staff2_id);
+
+  RAISE NOTICE 'PERSON_BASIS_TEST_PASSED';
+END $$;


### PR DESCRIPTION
## Summary
- `buildStatsByRole` 가 `getPrimaryRoleId` (단일) → `getAllRoleIds` (멀티) 로 전환.
  멀티역할(딜러+플로어) 지원자가 각 역할의 statsByRole 카드에 1씩 반영된다.
  동일 application 내 같은 역할 중복은 dedupe.
- SQL 마이그레이션 `20260418005000_person_basis_filled_positions.sql`:
  그룹/단일 confirm/cancel 모두 사람 기준으로 filled_positions 동기화.
- PR #41 의 `20260418010000_total_positions_person_basis.sql` precondition check 가
  본 마이그레이션(20260418005000) 을 참조하도록 업데이트.

## Test plan
- [x] 로컬 `npm run quality` (type-check + lint + format:check) 그린
- [x] `useApplicantManagement` 테스트: 멀티역할 각 역할 카운트 / 동일 application 중복 역할 dedupe
- [x] `filledPositions.test.ts` / `stats.ts`: PR #41 master 상태 유지 (본 PR 이 superseded)
- [x] SQL 테스트 (`person_basis_filled_positions.test.sql`): group confirm(+1), 단일 confirm(+1), group cancel(-1), 백필 idempotent
- [ ] CI Quality / Tests / Bundle 그린 (post-push)

## Migration timestamp 충돌 해결
원래 `20260418000000_person_basis_filled_positions.sql` 로 예정되었으나
master 의 `20260418000000_confirm_application_propagate_blurhash.sql` (PR #42) 와 timestamp 충돌 →
`20260418005000` 으로 rename + PR #41 precondition check 동기 갱신.

🤖 Generated with [Claude Code](https://claude.com/claude-code)