### PR TITLE
feat(workspace): PR #1 — M1 schema + RLS + 인프라 함수

### DIFF
--- a/uniqn-mobile/__tests__/schema/workspaceSchema.test.ts
+++ b/uniqn-mobile/__tests__/schema/workspaceSchema.test.ts
@@ -1,0 +1,109 @@
+/**
+ * PR #1 — workspace 스키마 컴파일 시점 검증
+ *
+ * @description database.types.ts 에 workspace 3개 테이블 + is_workspace_member RPC 가
+ *              포함되어 있는지 컴파일 타임에 검증한다. 실제 DB RLS 통합 테스트는 PR #2
+ *              Repository 와 함께 진행된다 (mock 기반 프로젝트 관행).
+ *
+ * 본 테스트의 목적:
+ *  1. types regen 누락 방지 (Migration 적용했는데 types 갱신 잊은 경우)
+ *  2. enum / column / RPC signature 도메인 계약 고정
+ *  3. PR #5 owner_id rename 시 깨질 fixture 위치 식별
+ */
+
+import type { Database } from '@/lib/database.types';
+
+type PublicTables = Database['public']['Tables'];
+type PublicEnums = Database['public']['Enums'];
+type PublicFunctions = Database['public']['Functions'];
+
+describe('workspace schema (PR #1 — M1 migration)', () => {
+  it('workspaces 테이블 — Row 필수 컬럼 (id/name/owner_id/member_count/created_at/updated_at)', () => {
+    type Row = PublicTables['workspaces']['Row'];
+    const sample: Row = {
+      id: '00000000-0000-0000-0000-000000000000',
+      name: '테스트 워크스페이스',
+      owner_id: '00000000-0000-0000-0000-000000000001',
+      member_count: 0,
+      created_at: '2026-04-30T00:00:00.000Z',
+      updated_at: '2026-04-30T00:00:00.000Z',
+    };
+    expect(sample.member_count).toBe(0);
+    expect(sample.name.length).toBeGreaterThan(0);
+  });
+
+  it('workspaces 테이블 — Insert 시 member_count 옵셔널 (DEFAULT 0)', () => {
+    type Insert = PublicTables['workspaces']['Insert'];
+    const sample: Insert = {
+      name: '신규 워크스페이스',
+      owner_id: '00000000-0000-0000-0000-000000000001',
+    };
+    expect(sample).toBeDefined();
+  });
+
+  it('workspace_members 테이블 — composite PK (workspace_id, user_id) + role default editor', () => {
+    type Row = PublicTables['workspace_members']['Row'];
+    const sample: Row = {
+      workspace_id: '00000000-0000-0000-0000-000000000010',
+      user_id: '00000000-0000-0000-0000-000000000020',
+      role: 'editor',
+      invited_by: null,
+      joined_at: '2026-04-30T00:00:00.000Z',
+    };
+    expect(sample.role).toBe('editor');
+  });
+
+  it('workspace_invitations 테이블 — status 5종 + invitee_user_id 필수 (D1 invitee_email 제거됨)', () => {
+    type Row = PublicTables['workspace_invitations']['Row'];
+    const allowedStatuses = ['pending', 'accepted', 'rejected', 'revoked', 'expired'] as const;
+    const sample: Row = {
+      id: '00000000-0000-0000-0000-000000000030',
+      workspace_id: '00000000-0000-0000-0000-000000000010',
+      invitee_user_id: '00000000-0000-0000-0000-000000000020',
+      role: 'editor',
+      invited_by: '00000000-0000-0000-0000-000000000001',
+      status: 'pending',
+      expires_at: '2026-05-07T00:00:00.000Z',
+      created_at: '2026-04-30T00:00:00.000Z',
+      responded_at: null,
+    };
+    expect(allowedStatuses).toContain(sample.status);
+    // D1: invitee_email field must NOT exist
+    // @ts-expect-error — invitee_email 컬럼은 Phase 2 deferred (매직 링크 인프라)
+    const _shouldNotExist: string = sample.invitee_email;
+    expect(_shouldNotExist).toBeUndefined();
+  });
+
+  it('workspace_role enum — editor 단일 값 (D2: owner는 workspaces.owner_id 단독)', () => {
+    type Role = PublicEnums['workspace_role'];
+    const role: Role = 'editor';
+    // Compile-time guarantee: workspace_role only allows 'editor'
+    // @ts-expect-error — D2 결정: workspace_role 에 'owner' 값 없음, owner는 workspaces.owner_id 단독
+    const _invalidRole: Role = 'owner';
+    expect(role).toBe('editor');
+    expect(_invalidRole).toBeDefined();
+  });
+
+  it('is_workspace_member RPC — (workspace_id, user_id) → boolean signature', () => {
+    type Args = PublicFunctions['is_workspace_member']['Args'];
+    type Returns = PublicFunctions['is_workspace_member']['Returns'];
+    const args: Args = {
+      _workspace_id: '00000000-0000-0000-0000-000000000010',
+      _user_id: '00000000-0000-0000-0000-000000000020',
+    };
+    const returnsValid: Returns = true;
+    expect(args._workspace_id).toBeDefined();
+    expect(typeof returnsValid).toBe('boolean');
+  });
+
+  it('job_postings 테이블 — workspace_id 컬럼 추가 (nullable, PR #5 NOT NULL 전환 예정)', () => {
+    type Row = PublicTables['job_postings']['Row'];
+    // workspace_id nullable check — must accept null AND uuid
+    const withNullWorkspace: Pick<Row, 'workspace_id'> = { workspace_id: null };
+    const withWorkspace: Pick<Row, 'workspace_id'> = {
+      workspace_id: '00000000-0000-0000-0000-000000000010',
+    };
+    expect(withNullWorkspace.workspace_id).toBeNull();
+    expect(withWorkspace.workspace_id).toBeTruthy();
+  });
+});

--- a/uniqn-mobile/src/lib/database.types.ts
+++ b/uniqn-mobile/src/lib/database.types.ts
@@ -646,6 +646,39 @@ export type Database = {
           },
         ];
       };
+      diamond_products: {
+        Row: {
+          active: boolean;
+          bonus_diamonds: number;
+          created_at: string;
+          diamonds: number;
+          display_order: number;
+          price_krw: number;
+          product_id: string;
+          updated_at: string;
+        };
+        Insert: {
+          active?: boolean;
+          bonus_diamonds?: number;
+          created_at?: string;
+          diamonds: number;
+          display_order?: number;
+          price_krw: number;
+          product_id: string;
+          updated_at?: string;
+        };
+        Update: {
+          active?: boolean;
+          bonus_diamonds?: number;
+          created_at?: string;
+          diamonds?: number;
+          display_order?: number;
+          price_krw?: number;
+          product_id?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       employer_applications: {
         Row: {
           agreements_snapshot: Json;
@@ -802,6 +835,47 @@ export type Database = {
           },
         ];
       };
+      heart_lots: {
+        Row: {
+          amount_initial: number;
+          amount_remaining: number;
+          expires_at: string;
+          granted_at: string;
+          id: string;
+          source: Database['public']['Enums']['wallet_reason'];
+          source_ref_id: string | null;
+          user_id: string;
+        };
+        Insert: {
+          amount_initial: number;
+          amount_remaining: number;
+          expires_at: string;
+          granted_at?: string;
+          id?: string;
+          source: Database['public']['Enums']['wallet_reason'];
+          source_ref_id?: string | null;
+          user_id: string;
+        };
+        Update: {
+          amount_initial?: number;
+          amount_remaining?: number;
+          expires_at?: string;
+          granted_at?: string;
+          id?: string;
+          source?: Database['public']['Enums']['wallet_reason'];
+          source_ref_id?: string | null;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'heart_lots_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       inquiries: {
         Row: {
           attachments: Json | null;
@@ -941,6 +1015,7 @@ export type Database = {
           view_count: number | null;
           work_date: string | null;
           work_dates: string[] | null;
+          workspace_id: string | null;
         };
         Insert: {
           closed_at?: string | null;
@@ -977,6 +1052,7 @@ export type Database = {
           view_count?: number | null;
           work_date?: string | null;
           work_dates?: string[] | null;
+          workspace_id?: string | null;
         };
         Update: {
           closed_at?: string | null;
@@ -1013,6 +1089,7 @@ export type Database = {
           view_count?: number | null;
           work_date?: string | null;
           work_dates?: string[] | null;
+          workspace_id?: string | null;
         };
         Relationships: [
           {
@@ -1020,6 +1097,13 @@ export type Database = {
             columns: ['owner_id'];
             isOneToOne: false;
             referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'job_postings_workspace_id_fkey';
+            columns: ['workspace_id'];
+            isOneToOne: false;
+            referencedRelation: 'workspaces';
             referencedColumns: ['id'];
           },
         ];
@@ -1525,6 +1609,91 @@ export type Database = {
         };
         Relationships: [];
       };
+      wallet_ledger: {
+        Row: {
+          balance_after_diamond: number;
+          balance_after_heart: number;
+          created_at: string;
+          currency_type: Database['public']['Enums']['wallet_currency'];
+          delta: number;
+          id: string;
+          metadata: Json;
+          reason: Database['public']['Enums']['wallet_reason'];
+          ref_id: string | null;
+          ref_type: string | null;
+          revenuecat_transaction_id: string | null;
+          user_id: string;
+        };
+        Insert: {
+          balance_after_diamond: number;
+          balance_after_heart: number;
+          created_at?: string;
+          currency_type: Database['public']['Enums']['wallet_currency'];
+          delta: number;
+          id?: string;
+          metadata?: Json;
+          reason: Database['public']['Enums']['wallet_reason'];
+          ref_id?: string | null;
+          ref_type?: string | null;
+          revenuecat_transaction_id?: string | null;
+          user_id: string;
+        };
+        Update: {
+          balance_after_diamond?: number;
+          balance_after_heart?: number;
+          created_at?: string;
+          currency_type?: Database['public']['Enums']['wallet_currency'];
+          delta?: number;
+          id?: string;
+          metadata?: Json;
+          reason?: Database['public']['Enums']['wallet_reason'];
+          ref_id?: string | null;
+          ref_type?: string | null;
+          revenuecat_transaction_id?: string | null;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'wallet_ledger_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      wallets: {
+        Row: {
+          diamond_balance: number;
+          heart_balance: number;
+          lifetime_purchased_diamonds: number;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          diamond_balance?: number;
+          heart_balance?: number;
+          lifetime_purchased_diamonds?: number;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          diamond_balance?: number;
+          heart_balance?: number;
+          lifetime_purchased_diamonds?: number;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'wallets_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       work_logs: {
         Row: {
           application_id: string | null;
@@ -1668,6 +1837,145 @@ export type Database = {
           },
         ];
       };
+      workspace_invitations: {
+        Row: {
+          created_at: string;
+          expires_at: string;
+          id: string;
+          invited_by: string;
+          invitee_user_id: string;
+          responded_at: string | null;
+          role: Database['public']['Enums']['workspace_role'];
+          status: string;
+          workspace_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          expires_at?: string;
+          id?: string;
+          invited_by: string;
+          invitee_user_id: string;
+          responded_at?: string | null;
+          role?: Database['public']['Enums']['workspace_role'];
+          status?: string;
+          workspace_id: string;
+        };
+        Update: {
+          created_at?: string;
+          expires_at?: string;
+          id?: string;
+          invited_by?: string;
+          invitee_user_id?: string;
+          responded_at?: string | null;
+          role?: Database['public']['Enums']['workspace_role'];
+          status?: string;
+          workspace_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'workspace_invitations_invited_by_fkey';
+            columns: ['invited_by'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'workspace_invitations_invitee_user_id_fkey';
+            columns: ['invitee_user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'workspace_invitations_workspace_id_fkey';
+            columns: ['workspace_id'];
+            isOneToOne: false;
+            referencedRelation: 'workspaces';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      workspace_members: {
+        Row: {
+          invited_by: string | null;
+          joined_at: string;
+          role: Database['public']['Enums']['workspace_role'];
+          user_id: string;
+          workspace_id: string;
+        };
+        Insert: {
+          invited_by?: string | null;
+          joined_at?: string;
+          role?: Database['public']['Enums']['workspace_role'];
+          user_id: string;
+          workspace_id: string;
+        };
+        Update: {
+          invited_by?: string | null;
+          joined_at?: string;
+          role?: Database['public']['Enums']['workspace_role'];
+          user_id?: string;
+          workspace_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'workspace_members_invited_by_fkey';
+            columns: ['invited_by'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'workspace_members_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'workspace_members_workspace_id_fkey';
+            columns: ['workspace_id'];
+            isOneToOne: false;
+            referencedRelation: 'workspaces';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      workspaces: {
+        Row: {
+          created_at: string;
+          id: string;
+          member_count: number;
+          name: string;
+          owner_id: string;
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          member_count?: number;
+          name: string;
+          owner_id: string;
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          member_count?: number;
+          name?: string;
+          owner_id?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'workspaces_owner_id_fkey';
+            columns: ['owner_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
     };
     Views: {
       [_ in never]: never;
@@ -1747,6 +2055,7 @@ export type Database = {
         };
         Returns: Json;
       };
+      claim_daily_attendance: { Args: never; Returns: Json };
       confirm_application: {
         Args: {
           p_application_id: string;
@@ -1757,6 +2066,25 @@ export type Database = {
           p_notes?: string;
           p_original_application?: Json;
           p_owner_id: string;
+        };
+        Returns: Json;
+      };
+      consume_diamonds_atomically: {
+        Args: {
+          p_amount: number;
+          p_reason: Database['public']['Enums']['wallet_reason'];
+          p_ref_id: string;
+          p_ref_type: string;
+          p_user_id: string;
+        };
+        Returns: Json;
+      };
+      create_job_posting_with_payment_atomically: {
+        Args: {
+          p_cost_diamonds: number;
+          p_owner_id: string;
+          p_posting_payload: Json;
+          p_reason: Database['public']['Enums']['wallet_reason'];
         };
         Returns: Json;
       };
@@ -1778,6 +2106,15 @@ export type Database = {
         };
         Returns: Json;
       };
+      credit_diamonds_atomically: {
+        Args: {
+          p_diamonds: number;
+          p_product_id: string;
+          p_revenuecat_transaction_id: string;
+          p_user_id: string;
+        };
+        Returns: Json;
+      };
       decrement_unread_counter:
         | { Args: { p_notification_id: string }; Returns: undefined }
         | { Args: { p_delta?: number; p_user_id: string }; Returns: undefined };
@@ -1785,6 +2122,7 @@ export type Database = {
       fn_cleanup_rate_limits: { Args: never; Returns: number };
       fn_expire_by_last_work_date: { Args: never; Returns: number };
       fn_expire_fixed_postings_batch: { Args: never; Returns: number };
+      fn_expire_heart_lots: { Args: never; Returns: Json };
       fn_send_review_reminders: { Args: never; Returns: number };
       get_job_posting_stats: {
         Args: { p_owner_id: string };
@@ -1813,6 +2151,17 @@ export type Database = {
         Args: { p_user_id: string };
         Returns: number;
       };
+      get_wallet_summary: { Args: { p_user_id?: string }; Returns: Json };
+      grant_heart_atomically: {
+        Args: {
+          p_amount: number;
+          p_expires_in_days?: number;
+          p_reason: Database['public']['Enums']['wallet_reason'];
+          p_source_ref_id?: string;
+          p_user_id: string;
+        };
+        Returns: Json;
+      };
       increment_announcement_view_count: {
         Args: { p_announcement_id: string };
         Returns: undefined;
@@ -1828,6 +2177,10 @@ export type Database = {
       increment_view_count: { Args: { posting_id: string }; Returns: undefined };
       is_admin: { Args: never; Returns: boolean };
       is_employer_or_admin: { Args: never; Returns: boolean };
+      is_workspace_member: {
+        Args: { _user_id: string; _workspace_id: string };
+        Returns: boolean;
+      };
       permanently_delete_user: { Args: { p_user_id: string }; Returns: Json };
       process_qr_checkin_atomically: {
         Args: {
@@ -1838,6 +2191,10 @@ export type Database = {
           p_staff_id: string;
           p_work_log_id: string;
         };
+        Returns: Json;
+      };
+      refund_job_cancellation_atomically: {
+        Args: { p_owner_id: string; p_posting_id: string };
         Returns: Json;
       };
       register_as_employer: {
@@ -1912,6 +2269,22 @@ export type Database = {
       review_sentiment: 'positive' | 'neutral' | 'negative';
       staff_role: 'dealer' | 'floor' | 'serving' | 'manager' | 'staff' | 'other';
       user_role: 'admin' | 'employer' | 'staff';
+      wallet_currency: 'heart' | 'diamond';
+      wallet_reason:
+        | 'purchase'
+        | 'consume_job_posting'
+        | 'consume_job_extend'
+        | 'consume_job_upgrade'
+        | 'refund_purchase'
+        | 'refund_job_cancelled'
+        | 'grant_signup'
+        | 'grant_daily_attendance'
+        | 'grant_streak_7d'
+        | 'grant_review'
+        | 'grant_referral'
+        | 'grant_admin'
+        | 'grant_first_purchase_bonus'
+        | 'expire_heart';
       work_log_status:
         | 'scheduled'
         | 'checked_in'
@@ -1919,6 +2292,7 @@ export type Database = {
         | 'completed'
         | 'cancelled'
         | 'no_show';
+      workspace_role: 'editor';
     };
     CompositeTypes: {
       [_ in never]: never;
@@ -2081,6 +2455,23 @@ export const Constants = {
       review_sentiment: ['positive', 'neutral', 'negative'],
       staff_role: ['dealer', 'floor', 'serving', 'manager', 'staff', 'other'],
       user_role: ['admin', 'employer', 'staff'],
+      wallet_currency: ['heart', 'diamond'],
+      wallet_reason: [
+        'purchase',
+        'consume_job_posting',
+        'consume_job_extend',
+        'consume_job_upgrade',
+        'refund_purchase',
+        'refund_job_cancelled',
+        'grant_signup',
+        'grant_daily_attendance',
+        'grant_streak_7d',
+        'grant_review',
+        'grant_referral',
+        'grant_admin',
+        'grant_first_purchase_bonus',
+        'expire_heart',
+      ],
       work_log_status: [
         'scheduled',
         'checked_in',
@@ -2089,6 +2480,7 @@ export const Constants = {
         'cancelled',
         'no_show',
       ],
+      workspace_role: ['editor'],
     },
   },
 } as const;

--- a/uniqn-mobile/supabase/migrations/20260430010000_workspace_create_tables.sql
+++ b/uniqn-mobile/supabase/migrations/20260430010000_workspace_create_tables.sql
@@ -1,0 +1,88 @@
+-- 공고 워크스페이스 협업 편집 (M1.1) — 테이블 + enum
+-- Design: design/monetization-subscription doc (D2 owner SoT — owner_id 단독, members = editor only)
+-- 본 마이그레이션은 additive — 기존 데이터 영향 없음 (job_postings.workspace_id 추가는 별도 마이그레이션)
+
+-- 1. workspace_role enum (D2: owner는 workspaces.owner_id로 단독 표현, members는 editor만)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'workspace_role') THEN
+    CREATE TYPE public.workspace_role AS ENUM ('editor');
+  END IF;
+END$$;
+
+-- 2. workspaces — 단일 owner + denormalized member_count (trigger 동기화)
+CREATE TABLE IF NOT EXISTS public.workspaces (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  owner_id uuid NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  member_count integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT workspaces_name_length CHECK (char_length(name) BETWEEN 1 AND 50),
+  CONSTRAINT workspaces_member_count_nonneg CHECK (member_count >= 0)
+);
+
+COMMENT ON TABLE public.workspaces IS '공고 워크스페이스 — owner 단독 + editor 멤버. job_postings.workspace_id로 연결.';
+COMMENT ON COLUMN public.workspaces.member_count IS 'editor 수 (owner 제외). trigger 동기화. UI에서 owner+1 표시.';
+
+ALTER TABLE public.workspaces ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.workspaces FORCE ROW LEVEL SECURITY;
+
+-- 3. workspace_members — editor 전용 (D2)
+CREATE TABLE IF NOT EXISTS public.workspace_members (
+  workspace_id uuid NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  role public.workspace_role NOT NULL DEFAULT 'editor',
+  invited_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  joined_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (workspace_id, user_id)
+);
+
+COMMENT ON TABLE public.workspace_members IS 'editor 멤버만 저장. owner는 workspaces.owner_id 단독 (D2 — drift 0).';
+
+ALTER TABLE public.workspace_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.workspace_members FORCE ROW LEVEL SECURITY;
+
+-- 4. workspace_invitations — D1 invitee_email 컬럼 제거됨 (Phase 2 매직 링크)
+CREATE TABLE IF NOT EXISTS public.workspace_invitations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
+  invitee_user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  role public.workspace_role NOT NULL DEFAULT 'editor',
+  invited_by uuid NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  status text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending','accepted','rejected','revoked','expired')),
+  expires_at timestamptz NOT NULL DEFAULT (now() + interval '7 days'),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  responded_at timestamptz
+);
+
+COMMENT ON TABLE public.workspace_invitations IS '인앱 초대 (invitee_user_id 필수). 외부 이메일 초대는 Phase 2.';
+COMMENT ON COLUMN public.workspace_invitations.status IS 'pending → accepted/rejected/revoked/expired. 만료 정리는 pg_cron (PR #2).';
+
+-- pending 중복 방지 — 동일 (workspace, invitee) pending 1개만 허용
+-- rejected/expired/revoked/accepted 다중 row 허용 (재초대 가능)
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_workspace_invitations_pending
+  ON public.workspace_invitations (workspace_id, invitee_user_id)
+  WHERE status = 'pending';
+
+ALTER TABLE public.workspace_invitations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.workspace_invitations FORCE ROW LEVEL SECURITY;
+
+-- 5. updated_at 자동 갱신 trigger (workspaces 전용 — workspace_members는 joined_at만)
+CREATE OR REPLACE FUNCTION public.fn_workspaces_set_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_workspaces_set_updated_at ON public.workspaces;
+CREATE TRIGGER trg_workspaces_set_updated_at
+  BEFORE UPDATE ON public.workspaces
+  FOR EACH ROW EXECUTE FUNCTION public.fn_workspaces_set_updated_at();

--- a/uniqn-mobile/supabase/migrations/20260430010100_workspace_indexes.sql
+++ b/uniqn-mobile/supabase/migrations/20260430010100_workspace_indexes.sql
@@ -1,0 +1,25 @@
+-- 공고 워크스페이스 협업 편집 (M1.2) — 인덱스 5개 (Performance Review P1)
+-- 모두 추가형. 기존 인덱스 영향 없음.
+
+-- "내가 owner인 워크스페이스" 조회 — workspaces_select_owner_or_member RLS 핫패스
+CREATE INDEX IF NOT EXISTS idx_workspaces_owner_id
+  ON public.workspaces(owner_id);
+
+-- "내가 멤버인 워크스페이스" 조회 — is_workspace_member 함수 핫패스
+CREATE INDEX IF NOT EXISTS idx_workspace_members_user_id
+  ON public.workspace_members(user_id);
+
+-- "내가 받은 pending 초대" 조회 — 알림/홈 화면 핫패스
+-- partial index: pending status만 인덱스에 들어감 (size 절약 + selectivity)
+CREATE INDEX IF NOT EXISTS idx_workspace_invitations_invitee_pending
+  ON public.workspace_invitations(invitee_user_id)
+  WHERE status = 'pending';
+
+-- "워크스페이스 초대 목록" 조회 — owner 화면에서 status별 필터링
+CREATE INDEX IF NOT EXISTS idx_workspace_invitations_workspace_status
+  ON public.workspace_invitations(workspace_id, status);
+
+-- 만료 정리 cron 핫패스 (PR #2 pg_cron 작업) — pending 만료 row 빠른 추출
+CREATE INDEX IF NOT EXISTS idx_workspace_invitations_expires_pending
+  ON public.workspace_invitations(expires_at)
+  WHERE status = 'pending';

--- a/uniqn-mobile/supabase/migrations/20260430010200_workspace_member_count_trigger.sql
+++ b/uniqn-mobile/supabase/migrations/20260430010200_workspace_member_count_trigger.sql
@@ -1,0 +1,35 @@
+-- 공고 워크스페이스 협업 편집 (M1.3) — member_count 동기화 trigger
+-- Pattern: denormalized counter trigger (memory: pitfall_denormalized_counter_drift, EJ-001/ST-001 표준)
+-- INSERT/DELETE 시 workspaces.member_count 자동 ±1, GREATEST(0, ...) 가드
+
+CREATE OR REPLACE FUNCTION public.fn_sync_workspace_member_count()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE public.workspaces
+      SET member_count = member_count + 1,
+          updated_at = now()
+      WHERE id = NEW.workspace_id;
+
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE public.workspaces
+      SET member_count = GREATEST(member_count - 1, 0),
+          updated_at = now()
+      WHERE id = OLD.workspace_id;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_sync_workspace_member_count IS
+  'workspace_members INSERT/DELETE 시 workspaces.member_count ±1. owner 제외 editor 수.';
+
+DROP TRIGGER IF EXISTS trg_sync_workspace_member_count ON public.workspace_members;
+CREATE TRIGGER trg_sync_workspace_member_count
+  AFTER INSERT OR DELETE ON public.workspace_members
+  FOR EACH ROW EXECUTE FUNCTION public.fn_sync_workspace_member_count();

--- a/uniqn-mobile/supabase/migrations/20260430010300_workspace_membership_function.sql
+++ b/uniqn-mobile/supabase/migrations/20260430010300_workspace_membership_function.sql
@@ -1,0 +1,24 @@
+-- 공고 워크스페이스 협업 편집 (M1.4) — is_workspace_member SECURITY DEFINER
+-- Architecture A2: RLS 순환 회피 + 단일 멤버십 진실 (owner UNION editor)
+-- D2: owner는 workspaces.owner_id 단독, editor는 workspace_members row → UNION으로 통합
+
+CREATE OR REPLACE FUNCTION public.is_workspace_member(_workspace_id uuid, _user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+STABLE
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.workspaces
+      WHERE id = _workspace_id AND owner_id = _user_id
+    UNION ALL
+    SELECT 1 FROM public.workspace_members
+      WHERE workspace_id = _workspace_id AND user_id = _user_id
+  );
+$$;
+
+COMMENT ON FUNCTION public.is_workspace_member IS
+  '워크스페이스 멤버십 단일 진실 — owner OR editor. RLS 정책 핫패스.';
+
+GRANT EXECUTE ON FUNCTION public.is_workspace_member(uuid, uuid) TO authenticated;

--- a/uniqn-mobile/supabase/migrations/20260430010400_workspace_rls_policies.sql
+++ b/uniqn-mobile/supabase/migrations/20260430010400_workspace_rls_policies.sql
@@ -1,0 +1,101 @@
+-- 공고 워크스페이스 협업 편집 (M1.5) — RLS 정책 7개
+-- D2 owner SoT + A4 cap 10 + Architecture A2 (is_workspace_member SECURITY DEFINER)
+-- 기존 jp_update / jp_delete RLS와 함께 OR로 결합 (additive — 기존 owner 권한 유지)
+-- workspace_members / workspace_invitations 의 INSERT/UPDATE/DELETE는 PR #2 SECURITY DEFINER RPC 전용
+
+-- ========================================
+-- workspaces (3 정책)
+-- ========================================
+
+-- 1. SELECT — owner이거나 멤버이거나 admin
+DROP POLICY IF EXISTS workspaces_select_owner_or_member ON public.workspaces;
+CREATE POLICY workspaces_select_owner_or_member
+  ON public.workspaces FOR SELECT TO authenticated
+  USING (
+    public.is_workspace_member(id, (SELECT auth.uid()))
+    OR (SELECT public.is_admin())
+  );
+
+-- 2. INSERT — employer/admin + 사용자당 최대 10개 cap (Architecture A4)
+--   본인이 owner_id 인 경우만, employer/admin 역할만, cap 미도달
+DROP POLICY IF EXISTS workspaces_insert_employer_with_cap ON public.workspaces;
+CREATE POLICY workspaces_insert_employer_with_cap
+  ON public.workspaces FOR INSERT TO authenticated
+  WITH CHECK (
+    owner_id = (SELECT auth.uid())
+    AND (SELECT public.get_my_role()) = ANY (ARRAY['employer','admin'])
+    AND (SELECT count(*) FROM public.workspaces WHERE owner_id = (SELECT auth.uid())) < 10
+  );
+
+-- 3. UPDATE — owner만 (이름 변경 등)
+DROP POLICY IF EXISTS workspaces_update_owner ON public.workspaces;
+CREATE POLICY workspaces_update_owner
+  ON public.workspaces FOR UPDATE TO authenticated
+  USING (owner_id = (SELECT auth.uid()) OR (SELECT public.is_admin()))
+  WITH CHECK (owner_id = (SELECT auth.uid()) OR (SELECT public.is_admin()));
+
+-- (DELETE 정책 없음 — 워크스페이스 삭제는 Phase 2 deferred)
+
+-- ========================================
+-- workspace_members (1 정책 — SELECT만)
+-- ========================================
+-- INSERT/UPDATE/DELETE는 SECURITY DEFINER RPC 전용 (PR #2)
+
+-- 4. SELECT — 본인 row OR 같은 워크스페이스 멤버 (멤버 목록 화면)
+DROP POLICY IF EXISTS workspace_members_select_self_or_workspace ON public.workspace_members;
+CREATE POLICY workspace_members_select_self_or_workspace
+  ON public.workspace_members FOR SELECT TO authenticated
+  USING (
+    user_id = (SELECT auth.uid())
+    OR public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+    OR (SELECT public.is_admin())
+  );
+
+-- ========================================
+-- workspace_invitations (1 정책 — SELECT만)
+-- ========================================
+-- INSERT/UPDATE/DELETE는 SECURITY DEFINER RPC 전용 (PR #2 invite/accept/reject/revoke)
+
+-- 5. SELECT — 본인이 받은 초대 OR 본인이 owner인 워크스페이스 초대
+DROP POLICY IF EXISTS workspace_invitations_select_relevant ON public.workspace_invitations;
+CREATE POLICY workspace_invitations_select_relevant
+  ON public.workspace_invitations FOR SELECT TO authenticated
+  USING (
+    invitee_user_id = (SELECT auth.uid())
+    OR workspace_id IN (
+      SELECT id FROM public.workspaces WHERE owner_id = (SELECT auth.uid())
+    )
+    OR (SELECT public.is_admin())
+  );
+
+-- ========================================
+-- job_postings (2 정책 추가 — 기존 jp_update/jp_delete 와 OR 결합)
+-- ========================================
+-- 기존 jp_update: owner_id = auth.uid() OR admin
+-- 기존 jp_delete: admin only
+-- 본 마이그레이션은 위 둘에 워크스페이스 멤버 / 워크스페이스 owner 경로 추가
+-- PR #5 owner_id → created_by rename 시 기존 정책 정리 예정
+
+-- 6. UPDATE — 워크스페이스 멤버 (owner OR editor)
+DROP POLICY IF EXISTS jp_update_workspace_member ON public.job_postings;
+CREATE POLICY jp_update_workspace_member
+  ON public.job_postings FOR UPDATE TO authenticated
+  USING (
+    workspace_id IS NOT NULL
+    AND public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+  )
+  WITH CHECK (
+    workspace_id IS NOT NULL
+    AND public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+  );
+
+-- 7. DELETE — 워크스페이스 owner만 (editor는 삭제 불가)
+DROP POLICY IF EXISTS jp_delete_workspace_owner ON public.job_postings;
+CREATE POLICY jp_delete_workspace_owner
+  ON public.job_postings FOR DELETE TO authenticated
+  USING (
+    workspace_id IS NOT NULL
+    AND workspace_id IN (
+      SELECT id FROM public.workspaces WHERE owner_id = (SELECT auth.uid())
+    )
+  );

--- a/uniqn-mobile/supabase/migrations/20260430010500_job_postings_add_workspace_id.sql
+++ b/uniqn-mobile/supabase/migrations/20260430010500_job_postings_add_workspace_id.sql
@@ -1,0 +1,14 @@
+-- 공고 워크스페이스 협업 편집 (M1.6) — job_postings.workspace_id 추가 (nullable)
+-- 백필은 PR #4 (M2). NOT NULL 전환은 PR #5 (M3).
+-- 본 마이그레이션 시점: workspace_id IS NULL이 정상 (병행 동작).
+
+ALTER TABLE public.job_postings
+  ADD COLUMN IF NOT EXISTS workspace_id uuid REFERENCES public.workspaces(id) ON DELETE RESTRICT;
+
+COMMENT ON COLUMN public.job_postings.workspace_id IS
+  '연결된 워크스페이스. PR #4(백필) 후 NOT NULL 전환 (PR #5). NULL 동안 owner_id 권한 사용.';
+
+-- "워크스페이스의 공고 목록" 조회 핫패스 (RLS + employer 화면)
+CREATE INDEX IF NOT EXISTS idx_job_postings_workspace_id
+  ON public.job_postings(workspace_id)
+  WHERE workspace_id IS NOT NULL;

--- a/uniqn-mobile/supabase/migrations/20260430010600_workspace_add_invited_by_indexes.sql
+++ b/uniqn-mobile/supabase/migrations/20260430010600_workspace_add_invited_by_indexes.sql
@@ -1,0 +1,9 @@
+-- 공고 워크스페이스 협업 편집 (M1.7) — invited_by FK 커버 인덱스
+-- supabase advisors performance lint(0001_unindexed_foreign_keys) 해소
+
+CREATE INDEX IF NOT EXISTS idx_workspace_invitations_invited_by
+  ON public.workspace_invitations(invited_by);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_members_invited_by
+  ON public.workspace_members(invited_by)
+  WHERE invited_by IS NOT NULL;

--- a/uniqn-mobile/supabase/migrations/20260430010700_workspace_revoke_anon_execute.sql
+++ b/uniqn-mobile/supabase/migrations/20260430010700_workspace_revoke_anon_execute.sql
@@ -1,0 +1,11 @@
+-- 공고 워크스페이스 협업 편집 (M1.8) — 신규 SECURITY DEFINER 함수 anon 노출 차단
+-- supabase advisors security lint(0028_anon_security_definer_function_executable) 해소
+-- 트리거 함수 2개는 외부 RPC 호출 자체를 차단, is_workspace_member는 anon만 차단
+
+-- 1. 트리거 전용 함수 — RPC로 부를 일 없으므로 PUBLIC/anon/authenticated 모두 EXECUTE 회수
+REVOKE EXECUTE ON FUNCTION public.fn_workspaces_set_updated_at() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.fn_sync_workspace_member_count() FROM PUBLIC, anon, authenticated;
+
+-- 2. is_workspace_member — RLS 평가 시 authenticated 가 호출, anon 만 차단
+REVOKE EXECUTE ON FUNCTION public.is_workspace_member(uuid, uuid) FROM PUBLIC, anon;
+-- (authenticated GRANT 는 M1.4 에서 부여됨)


### PR DESCRIPTION
## Summary

공고 워크스페이스 협업 편집 (5 PR 시리즈) **PR #1 — DB 인프라 (M1)**.

- 8 마이그레이션 (모두 additive, staging 적용 완료)
- workspaces / workspace_members / workspace_invitations + workspace_role enum
- `is_workspace_member` SECURITY DEFINER 헬퍼 (UNION owner OR editor)
- `fn_sync_workspace_member_count` trigger (denormalized counter pattern)
- RLS 7 정책 (workspaces 3 + members 1 + invitations 1 + job_postings 2 additive)
- `job_postings.workspace_id` nullable 컬럼 + partial index
- types regen + 컴파일 시점 스키마 계약 테스트 7건

## 설계 근거

- 설계 doc: ENG_REVIEW_APPROVED, D1/D2/D3 모두 A 채택
- D1: `invitee_email` 제외 → Phase 2 매직 링크
- D2: owner 단일 진실 = `workspaces.owner_id`. members 는 `editor` 만
- D3: PR #5 에서 `owner_id` → `created_by` rename

## 디자인 결정 (인라인)

- design doc 의 `UNIQUE(workspace_id, invitee_user_id, status) DEFERRABLE` 대신 partial unique index `WHERE status = 'pending'` 채택
- 신규 SECURITY DEFINER 함수 anon EXECUTE 회수 (advisors lint 0028 해소)

## Test plan

- [x] MCP apply_migration 8건 성공
- [x] DB 레벨 smoke test (member_count ±1, is_workspace_member UNION) 통과
- [x] 신규 컴파일 시점 스키마 테스트 7/7 통과
- [x] npm run quality 통과 (typecheck + lint 0 errors + format clean)
- [x] 전체 Jest 3896/3898 통과 (실패 2건은 master 의 사전 결함, 본 PR 무관)
- [x] supabase advisors performance/security 신규 critical 0건
- [ ] PR #2 Repository + Service 작성 시 RLS 4 personas × 5 정책 = 20 통합 테스트 추가

## Advisors 잔여 항목 (의도적 / 사전 존재)

- multiple_permissive_policies on job_postings UPDATE/DELETE — 의도적 OR 결합, PR #5에서 통합
- 신규 인덱스 5건 unused_index INFO — workspace row 0 시점이라 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)