### PR TITLE
feat(workspace): PR #2 — Repository + Service + Hook + atomic RPC

### DIFF
--- a/uniqn-mobile/src/components/notifications/NotificationIcon.tsx
+++ b/uniqn-mobile/src/components/notifications/NotificationIcon.tsx
@@ -94,6 +94,9 @@ const typeIcons: Partial<Record<NotificationType, IconComponent>> = {
   [NotificationType.REVIEW_REQUEST]: ChatBubbleLeftIcon,
   [NotificationType.REVIEW_RECEIVED]: CheckCircleIcon,
   [NotificationType.REVIEW_REMINDER]: ClockIcon,
+
+  // 워크스페이스 협업 (PR #2)
+  [NotificationType.WORKSPACE_INVITATION]: BriefcaseIcon,
 };
 
 // 카테고리별 색상 (Black & Gold v3.0)

--- a/uniqn-mobile/src/constants/notificationTemplates.ts
+++ b/uniqn-mobile/src/constants/notificationTemplates.ts
@@ -370,6 +370,14 @@ export const NotificationTemplates: Record<NotificationType, NotificationTemplat
     link: (d) => `/reviews/${d.workLogId}`,
     icon: '⏰',
   },
+
+  // 워크스페이스 협업 (PR #2)
+  [NotificationType.WORKSPACE_INVITATION]: {
+    title: (d) => `${d.inviterName ?? '누군가'}님이 워크스페이스에 초대했어요`,
+    body: (d) => `${d.workspaceName ?? '워크스페이스'} · 편집자 권한`,
+    link: () => `/workspace/invitations`,
+    icon: '🤝',
+  },
 };
 
 // ============================================================================

--- a/uniqn-mobile/src/errors/__tests__/workspace.test.ts
+++ b/uniqn-mobile/src/errors/__tests__/workspace.test.ts
@@ -1,0 +1,90 @@
+/**
+ * PR #2 — workspace RPC 에러 매핑 테스트
+ */
+
+import { mapWorkspaceRpcError, WORKSPACE_ERROR_CODES } from '@/errors/workspace';
+import { isAuthError, isPermissionError, isBusinessError, isValidationError } from '@/errors';
+
+describe('mapWorkspaceRpcError (PR #2)', () => {
+  it('AUTH_REQUIRED → AuthError', () => {
+    const err = mapWorkspaceRpcError({ message: 'AUTH_REQUIRED' });
+    expect(err).not.toBeNull();
+    expect(isAuthError(err!)).toBe(true);
+  });
+
+  it('PERMISSION_DENIED → PermissionError + 권한 회수 메시지', () => {
+    const err = mapWorkspaceRpcError({ message: 'PERMISSION_DENIED' });
+    expect(err).not.toBeNull();
+    expect(isPermissionError(err!)).toBe(true);
+    expect(err!.userMessage).toContain('권한이 회수');
+  });
+
+  it('SELF_INVITE_FORBIDDEN → ValidationError', () => {
+    const err = mapWorkspaceRpcError({ message: 'SELF_INVITE_FORBIDDEN' });
+    expect(err).not.toBeNull();
+    expect(isValidationError(err!)).toBe(true);
+    expect(err!.code).toBe(WORKSPACE_ERROR_CODES.WORKSPACE_SELF_INVITE);
+  });
+
+  it('CANNOT_REMOVE_OWNER → ValidationError', () => {
+    const err = mapWorkspaceRpcError({ message: 'CANNOT_REMOVE_OWNER' });
+    expect(err).not.toBeNull();
+    expect(isValidationError(err!)).toBe(true);
+  });
+
+  it('ALREADY_MEMBER → BusinessError', () => {
+    const err = mapWorkspaceRpcError({ message: 'ALREADY_MEMBER' });
+    expect(err).not.toBeNull();
+    expect(isBusinessError(err!)).toBe(true);
+    expect(err!.code).toBe(WORKSPACE_ERROR_CODES.WORKSPACE_ALREADY_MEMBER);
+  });
+
+  it('ALREADY_INVITED → BusinessError', () => {
+    const err = mapWorkspaceRpcError({ message: 'ALREADY_INVITED' });
+    expect(err).not.toBeNull();
+    expect(err!.code).toBe(WORKSPACE_ERROR_CODES.WORKSPACE_ALREADY_INVITED);
+  });
+
+  it('INVITATION_EXPIRED → BusinessError + 만료 메시지', () => {
+    const err = mapWorkspaceRpcError({ message: 'INVITATION_EXPIRED' });
+    expect(err).not.toBeNull();
+    expect(err!.code).toBe(WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_EXPIRED);
+    expect(err!.userMessage).toContain('만료된 초대');
+  });
+
+  it('INVITATION_REJECTED / REVOKED / ACCEPTED 각각 별도 코드', () => {
+    expect(mapWorkspaceRpcError({ message: 'INVITATION_REJECTED' })?.code).toBe(
+      WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_REJECTED
+    );
+    expect(mapWorkspaceRpcError({ message: 'INVITATION_REVOKED' })?.code).toBe(
+      WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_REVOKED
+    );
+    expect(mapWorkspaceRpcError({ message: 'INVITATION_ACCEPTED' })?.code).toBe(
+      WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_ACCEPTED
+    );
+  });
+
+  it('INVITATION_NOT_FOUND / WORKSPACE_NOT_FOUND', () => {
+    expect(mapWorkspaceRpcError({ message: 'INVITATION_NOT_FOUND' })?.code).toBe(
+      WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_NOT_FOUND
+    );
+    expect(mapWorkspaceRpcError({ message: 'WORKSPACE_NOT_FOUND' })?.code).toBe(
+      WORKSPACE_ERROR_CODES.WORKSPACE_NOT_FOUND
+    );
+  });
+
+  it('RLS cap 도달 → CAP_REACHED', () => {
+    const err = mapWorkspaceRpcError({
+      message: 'new row violates row-level security policy',
+    });
+    expect(err).not.toBeNull();
+    expect(err!.code).toBe(WORKSPACE_ERROR_CODES.WORKSPACE_CAP_REACHED);
+    expect(err!.userMessage).toContain('10개');
+  });
+
+  it('알 수 없는 에러 → null (호출자가 일반 처리)', () => {
+    expect(mapWorkspaceRpcError({ message: 'SOME_RANDOM_ERROR' })).toBeNull();
+    expect(mapWorkspaceRpcError(null)).toBeNull();
+    expect(mapWorkspaceRpcError({})).toBeNull();
+  });
+});

--- a/uniqn-mobile/src/errors/workspace.ts
+++ b/uniqn-mobile/src/errors/workspace.ts
@@ -1,0 +1,130 @@
+/**
+ * UNIQN Mobile - 워크스페이스 RPC 에러 매핑
+ *
+ * @description PR #2 — invite/accept/reject/revoke RPC 에러 → AppError 변환.
+ *              DB 함수가 RAISE EXCEPTION 'CODE_NAME' 으로 던진 에러를 잡아 도메인 에러로 변환.
+ * @version 1.0.0
+ */
+
+import {
+  AuthError,
+  BusinessError,
+  PermissionError,
+  ValidationError,
+  ERROR_CODES,
+  AppError,
+} from './AppError';
+
+/**
+ * 워크스페이스 도메인 에러 코드 (E6 비즈니스)
+ */
+export const WORKSPACE_ERROR_CODES = {
+  WORKSPACE_NOT_FOUND: 'E6080',
+  WORKSPACE_INVITATION_NOT_FOUND: 'E6081',
+  WORKSPACE_ALREADY_MEMBER: 'E6082',
+  WORKSPACE_ALREADY_INVITED: 'E6083',
+  WORKSPACE_INVITATION_EXPIRED: 'E6084',
+  WORKSPACE_INVITATION_REJECTED: 'E6085',
+  WORKSPACE_INVITATION_REVOKED: 'E6086',
+  WORKSPACE_INVITATION_ACCEPTED: 'E6087',
+  WORKSPACE_SELF_INVITE: 'E6088',
+  WORKSPACE_CANNOT_REMOVE_OWNER: 'E6089',
+  WORKSPACE_CAP_REACHED: 'E6090',
+} as const;
+
+const WORKSPACE_ERROR_USER_MESSAGES: Record<string, string> = {
+  [WORKSPACE_ERROR_CODES.WORKSPACE_NOT_FOUND]: '워크스페이스를 찾을 수 없습니다.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_NOT_FOUND]: '초대를 찾을 수 없습니다.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_ALREADY_MEMBER]: '이미 워크스페이스 멤버입니다.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_ALREADY_INVITED]:
+    '이미 초대 보류 중입니다. 상대방의 응답을 기다려주세요.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_EXPIRED]:
+    '만료된 초대예요. 워크스페이스 소유자에게 다시 초대를 요청해주세요.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_REJECTED]: '이미 거절한 초대입니다.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_REVOKED]: '회수된 초대입니다.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_ACCEPTED]: '이미 수락된 초대입니다.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_SELF_INVITE]: '본인은 초대할 수 없습니다.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_CANNOT_REMOVE_OWNER]:
+    '워크스페이스 소유자는 멤버에서 제외할 수 없습니다.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_CAP_REACHED]:
+    '워크스페이스는 사용자당 최대 10개까지 만들 수 있어요. 사용하지 않는 워크스페이스를 정리해주세요.',
+};
+
+function makeWorkspaceError(code: string): AppError {
+  const userMessage = WORKSPACE_ERROR_USER_MESSAGES[code];
+  switch (code) {
+    case WORKSPACE_ERROR_CODES.WORKSPACE_SELF_INVITE:
+      return new ValidationError(code, { userMessage });
+    case WORKSPACE_ERROR_CODES.WORKSPACE_CANNOT_REMOVE_OWNER:
+      return new ValidationError(code, { userMessage });
+    default:
+      return new BusinessError(code, { userMessage });
+  }
+}
+
+/**
+ * Postgres / supabase-js 에러 메시지를 AppError 로 매핑.
+ * RPC 가 RAISE EXCEPTION 'CODE_NAME' 으로 던진 토큰을 인식.
+ *
+ * @param error supabase rpc().error 또는 catch 한 unknown
+ * @returns 매핑된 AppError, 매핑 실패 시 null (호출자가 일반 BusinessError 처리)
+ */
+export function mapWorkspaceRpcError(error: unknown): AppError | null {
+  if (!error || typeof error !== 'object') return null;
+  const message = (error as { message?: string }).message;
+  if (typeof message !== 'string') return null;
+
+  // RAISE EXCEPTION 'CODE' → "CODE" 또는 "P0001: CODE" 패턴 모두 처리
+  const upper = message.toUpperCase();
+
+  if (upper.includes('AUTH_REQUIRED'))
+    return new AuthError(ERROR_CODES.AUTH_REQUIRED, {
+      userMessage: '로그인이 필요합니다.',
+    });
+
+  if (upper.includes('PERMISSION_DENIED'))
+    return new PermissionError(ERROR_CODES.INFRA_PERMISSION_DENIED, {
+      userMessage: '워크스페이스 편집 권한이 회수되었어요. 다시 로그인하면 최신 상태가 적용됩니다.',
+    });
+
+  if (upper.includes('SELF_INVITE_FORBIDDEN'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_SELF_INVITE);
+
+  if (upper.includes('CANNOT_REMOVE_OWNER'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_CANNOT_REMOVE_OWNER);
+
+  if (upper.includes('ALREADY_MEMBER'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_ALREADY_MEMBER);
+
+  if (upper.includes('ALREADY_INVITED'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_ALREADY_INVITED);
+
+  // INVITATION_* 매핑 (순서 중요 — 더 구체적인 패턴 먼저)
+  if (upper.includes('INVITATION_EXPIRED'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_EXPIRED);
+
+  if (upper.includes('INVITATION_REJECTED'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_REJECTED);
+
+  if (upper.includes('INVITATION_REVOKED'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_REVOKED);
+
+  if (upper.includes('INVITATION_ACCEPTED'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_ACCEPTED);
+
+  if (upper.includes('INVITATION_NOT_FOUND'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_NOT_FOUND);
+
+  if (upper.includes('WORKSPACE_NOT_FOUND'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_NOT_FOUND);
+
+  // RLS 위반 패턴 — INSERT 정책 거절 (cap 도달 등)
+  if (upper.includes('NEW ROW VIOLATES ROW-LEVEL SECURITY POLICY')) {
+    return new BusinessError(WORKSPACE_ERROR_CODES.WORKSPACE_CAP_REACHED, {
+      userMessage:
+        WORKSPACE_ERROR_USER_MESSAGES[WORKSPACE_ERROR_CODES.WORKSPACE_CAP_REACHED] ?? '권한 부족',
+    });
+  }
+
+  return null;
+}

--- a/uniqn-mobile/src/hooks/workspace/index.ts
+++ b/uniqn-mobile/src/hooks/workspace/index.ts
@@ -1,0 +1,23 @@
+/**
+ * UNIQN Mobile - Workspace Hooks Barrel
+ *
+ * @description 공고 워크스페이스 협업 편집 (PR #2)
+ */
+
+export {
+  useWorkspaces,
+  useWorkspaceMembers,
+  useReceivedWorkspaceInvitations,
+  useWorkspaceInvitationsSent,
+  useInviteWorkspaceMember,
+  useAcceptWorkspaceInvitation,
+  useRejectWorkspaceInvitation,
+  useRevokeWorkspaceInvitation,
+  useRemoveWorkspaceMember,
+  useCreateWorkspace,
+  useUpdateWorkspaceName,
+  type UseWorkspacesResult,
+  type UseWorkspaceMembersResult,
+  type UseReceivedInvitationsResult,
+  type UseSentInvitationsResult,
+} from './useWorkspaces';

--- a/uniqn-mobile/src/hooks/workspace/useWorkspaces.ts
+++ b/uniqn-mobile/src/hooks/workspace/useWorkspaces.ts
@@ -1,0 +1,279 @@
+/**
+ * UNIQN Mobile - useWorkspaces / useWorkspaceMembers / useWorkspaceInvitations Hooks
+ *
+ * @description 워크스페이스 협업 (PR #2) — TanStack Query 기반.
+ *              권한 단일 진실은 DB RLS. UI 분기는 데이터 형태로 구분.
+ * @version 1.0.0
+ */
+
+import { useMemo } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryKeys, cachingPolicies } from '@/lib/queryClient';
+import { useAuthStore } from '@/stores/authStore';
+import { workspaceService, workspaceInvitationService } from '@/services/workspace';
+import type {
+  Workspace,
+  WorkspaceMemberWithUser,
+  ReceivedWorkspaceInvitation,
+  WorkspaceInvitation,
+} from '@/types/workspace';
+
+// ============================================================================
+// useWorkspaces — 사용자가 속한 모든 워크스페이스
+// ============================================================================
+
+export interface UseWorkspacesResult {
+  workspaces: Workspace[];
+  ownedWorkspaces: Workspace[];
+  memberWorkspaces: Workspace[];
+  isLoading: boolean;
+  error: unknown;
+  refetch: () => void;
+}
+
+export function useWorkspaces(): UseWorkspacesResult {
+  const { user } = useAuthStore();
+  const userId = user?.uid;
+
+  const query = useQuery({
+    queryKey: userId
+      ? queryKeys.workspaces.listForUser(userId)
+      : [...queryKeys.workspaces.all, 'list', 'anonymous'],
+    queryFn: () => workspaceService.listWorkspacesForUser(userId!),
+    enabled: !!userId,
+    staleTime: cachingPolicies.frequent,
+  });
+
+  const ownedWorkspaces = useMemo(
+    () => (query.data ?? []).filter((w) => w.ownerId === userId),
+    [query.data, userId]
+  );
+  const memberWorkspaces = useMemo(
+    () => (query.data ?? []).filter((w) => w.ownerId !== userId),
+    [query.data, userId]
+  );
+
+  return {
+    workspaces: query.data ?? [],
+    ownedWorkspaces,
+    memberWorkspaces,
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}
+
+// ============================================================================
+// useWorkspaceMembers — editor 멤버 목록 + 사용자 정보
+// ============================================================================
+
+export interface UseWorkspaceMembersResult {
+  members: WorkspaceMemberWithUser[];
+  isLoading: boolean;
+  error: unknown;
+  /** 현재 사용자가 owner 인지 (UI 분기용 — RLS 가 진짜 게이트) */
+  isOwner: boolean;
+}
+
+export function useWorkspaceMembers(
+  workspaceId: string | undefined,
+  ownerId: string | undefined
+): UseWorkspaceMembersResult {
+  const { user } = useAuthStore();
+
+  const query = useQuery({
+    queryKey: workspaceId
+      ? queryKeys.workspaces.members(workspaceId)
+      : [...queryKeys.workspaces.all, 'members', 'none'],
+    queryFn: () => workspaceService.listMembers(workspaceId!),
+    enabled: !!workspaceId,
+    staleTime: cachingPolicies.frequent,
+  });
+
+  return {
+    members: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+    isOwner: Boolean(ownerId && user?.uid && ownerId === user.uid),
+  };
+}
+
+// ============================================================================
+// useReceivedWorkspaceInvitations — 본인이 받은 pending 초대
+// ============================================================================
+
+export interface UseReceivedInvitationsResult {
+  invitations: ReceivedWorkspaceInvitation[];
+  isLoading: boolean;
+  error: unknown;
+  refetch: () => void;
+}
+
+export function useReceivedWorkspaceInvitations(): UseReceivedInvitationsResult {
+  const { user } = useAuthStore();
+  const userId = user?.uid;
+
+  const query = useQuery({
+    queryKey: userId
+      ? queryKeys.workspaces.invitationsReceived(userId)
+      : [...queryKeys.workspaces.all, 'invitations', 'received', 'anonymous'],
+    queryFn: () => workspaceInvitationService.listPendingForUser(userId!),
+    enabled: !!userId,
+    staleTime: cachingPolicies.frequent,
+  });
+
+  return {
+    invitations: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}
+
+// ============================================================================
+// useWorkspaceInvitationsSent — owner 가 보낸 초대 목록
+// ============================================================================
+
+export interface UseSentInvitationsResult {
+  invitations: WorkspaceInvitation[];
+  isLoading: boolean;
+  error: unknown;
+}
+
+export function useWorkspaceInvitationsSent(
+  workspaceId: string | undefined
+): UseSentInvitationsResult {
+  const query = useQuery({
+    queryKey: workspaceId
+      ? queryKeys.workspaces.invitationsSent(workspaceId)
+      : [...queryKeys.workspaces.all, 'invitations', 'sent', 'none'],
+    queryFn: () => workspaceInvitationService.listByWorkspace(workspaceId!),
+    enabled: !!workspaceId,
+    staleTime: cachingPolicies.frequent,
+  });
+
+  return {
+    invitations: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+  };
+}
+
+// ============================================================================
+// Mutations — invite / accept / reject / revoke / removeMember
+// ============================================================================
+
+export function useInviteWorkspaceMember() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { workspaceId: string; inviteeUserId: string }) =>
+      workspaceInvitationService.invite(input),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.workspaces.invitationsSent(vars.workspaceId),
+      });
+    },
+  });
+}
+
+export function useAcceptWorkspaceInvitation() {
+  const queryClient = useQueryClient();
+  const { user } = useAuthStore();
+  return useMutation({
+    mutationFn: (invitationId: string) => workspaceInvitationService.accept({ invitationId }),
+    onSuccess: () => {
+      // 받은 초대 + 워크스페이스 목록 둘 다 갱신
+      if (user?.uid) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.invitationsReceived(user.uid),
+        });
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.listForUser(user.uid),
+        });
+      }
+    },
+  });
+}
+
+export function useRejectWorkspaceInvitation() {
+  const queryClient = useQueryClient();
+  const { user } = useAuthStore();
+  return useMutation({
+    mutationFn: (invitationId: string) => workspaceInvitationService.reject({ invitationId }),
+    onSuccess: () => {
+      if (user?.uid) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.invitationsReceived(user.uid),
+        });
+      }
+    },
+  });
+}
+
+export function useRevokeWorkspaceInvitation(workspaceId: string | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (invitationId: string) => workspaceInvitationService.revoke({ invitationId }),
+    onSuccess: () => {
+      if (workspaceId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.invitationsSent(workspaceId),
+        });
+      }
+    },
+  });
+}
+
+export function useRemoveWorkspaceMember(workspaceId: string | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (userId: string) =>
+      workspaceService.removeMember({ workspaceId: workspaceId!, userId }),
+    onSuccess: () => {
+      if (workspaceId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.members(workspaceId),
+        });
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.detail(workspaceId),
+        });
+      }
+    },
+  });
+}
+
+export function useCreateWorkspace() {
+  const queryClient = useQueryClient();
+  const { user } = useAuthStore();
+  return useMutation({
+    mutationFn: (name: string) => workspaceService.createWorkspace({ name, ownerId: user!.uid }),
+    onSuccess: () => {
+      if (user?.uid) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.listForUser(user.uid),
+        });
+      }
+    },
+  });
+}
+
+export function useUpdateWorkspaceName(workspaceId: string | undefined) {
+  const queryClient = useQueryClient();
+  const { user } = useAuthStore();
+  return useMutation({
+    mutationFn: (name: string) =>
+      workspaceService.updateWorkspaceName({ workspaceId: workspaceId!, name }),
+    onSuccess: () => {
+      if (workspaceId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.detail(workspaceId),
+        });
+      }
+      if (user?.uid) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.listForUser(user.uid),
+        });
+      }
+    },
+  });
+}

--- a/uniqn-mobile/src/lib/database.types.ts
+++ b/uniqn-mobile/src/lib/database.types.ts
@@ -1990,6 +1990,10 @@ export type Database = {
         Args: { p_compensation: Json };
         Returns: string;
       };
+      accept_workspace_invitation: {
+        Args: { p_invitation_id: string };
+        Returns: Json;
+      };
       apply_with_capacity_check: {
         Args: {
           p_applicant_email?: string;
@@ -2118,6 +2122,7 @@ export type Database = {
       decrement_unread_counter:
         | { Args: { p_notification_id: string }; Returns: undefined }
         | { Args: { p_delta?: number; p_user_id: string }; Returns: undefined };
+      expire_pending_workspace_invitations: { Args: never; Returns: number };
       fn_cleanup_expired_fcm_tokens: { Args: never; Returns: number };
       fn_cleanup_rate_limits: { Args: never; Returns: number };
       fn_expire_by_last_work_date: { Args: never; Returns: number };
@@ -2175,6 +2180,10 @@ export type Database = {
         Returns: undefined;
       };
       increment_view_count: { Args: { posting_id: string }; Returns: undefined };
+      invite_workspace_member: {
+        Args: { p_invitee_user_id: string; p_workspace_id: string };
+        Returns: string;
+      };
       is_admin: { Args: never; Returns: boolean };
       is_employer_or_admin: { Args: never; Returns: boolean };
       is_workspace_member: {
@@ -2205,6 +2214,14 @@ export type Database = {
         Args: { p_app_id: string; p_category?: string; p_reason?: string };
         Returns: Json;
       };
+      reject_workspace_invitation: {
+        Args: { p_invitation_id: string };
+        Returns: undefined;
+      };
+      remove_workspace_member: {
+        Args: { p_user_id: string; p_workspace_id: string };
+        Returns: undefined;
+      };
       reset_unread_counter: { Args: { p_user_id: string }; Returns: undefined };
       review_report: {
         Args: {
@@ -2213,6 +2230,10 @@ export type Database = {
           p_reviewer_notes?: string;
           p_status: string;
         };
+        Returns: undefined;
+      };
+      revoke_workspace_invitation: {
+        Args: { p_invitation_id: string };
         Returns: undefined;
       };
       sync_schedule_board: { Args: { p_job_posting_id: string }; Returns: Json };

--- a/uniqn-mobile/src/lib/queryClient.ts
+++ b/uniqn-mobile/src/lib/queryClient.ts
@@ -320,6 +320,19 @@ export const queryKeys = {
     stats: () => [...queryKeys.jobManagement.all, 'stats'] as const,
   },
 
+  // 워크스페이스 협업 (PR #2)
+  workspaces: {
+    all: ['workspaces'] as const,
+    listForUser: (userId: string) => [...queryKeys.workspaces.all, 'list', userId] as const,
+    detail: (workspaceId: string) => [...queryKeys.workspaces.all, 'detail', workspaceId] as const,
+    members: (workspaceId: string) =>
+      [...queryKeys.workspaces.all, 'members', workspaceId] as const,
+    invitationsSent: (workspaceId: string) =>
+      [...queryKeys.workspaces.all, 'invitations', 'workspace', workspaceId] as const,
+    invitationsReceived: (userId: string) =>
+      [...queryKeys.workspaces.all, 'invitations', 'received', userId] as const,
+  },
+
   // 공고 템플릿 (구인자)
   templates: {
     all: ['templates'] as const,

--- a/uniqn-mobile/src/repositories/index.ts
+++ b/uniqn-mobile/src/repositories/index.ts
@@ -466,3 +466,22 @@ export type {
   FetchApplicationsOptions,
   FetchApplicationsResult,
 } from './supabase/EmployerApplicationRepository';
+
+// ============================================================================
+// 워크스페이스 협업 편집 (PR #2)
+// ============================================================================
+
+export type {
+  IWorkspaceRepository,
+  IWorkspaceMemberRepository,
+  IWorkspaceInvitationRepository,
+} from './interfaces';
+
+export {
+  SupabaseWorkspaceRepository,
+  SupabaseWorkspaceMemberRepository,
+  SupabaseWorkspaceInvitationRepository,
+  workspaceRepository,
+  workspaceMemberRepository,
+  workspaceInvitationRepository,
+} from './supabase';

--- a/uniqn-mobile/src/repositories/interfaces/IWorkspaceRepository.ts
+++ b/uniqn-mobile/src/repositories/interfaces/IWorkspaceRepository.ts
@@ -1,0 +1,73 @@
+/**
+ * UNIQN Mobile - 워크스페이스 Repository 인터페이스
+ *
+ * @description 공고 워크스페이스 협업 편집 (PR #2)
+ *              owner 단독 + editor 멤버 모델 (D2)
+ * @version 1.0.0
+ */
+
+import type {
+  Workspace,
+  WorkspaceMemberWithUser,
+  WorkspaceInvitation,
+  ReceivedWorkspaceInvitation,
+  AcceptInvitationResult,
+} from '@/types/workspace';
+
+export interface IWorkspaceRepository {
+  /**
+   * 워크스페이스 생성
+   * @throws AppError E3 cap 도달 / E5 권한 부족 / E1 네트워크
+   */
+  create(name: string, ownerId: string): Promise<Workspace>;
+
+  /** 단건 조회 — RLS 차단 시 undefined */
+  findById(id: string): Promise<Workspace | undefined>;
+
+  /** 내가 owner 인 워크스페이스 + editor 인 워크스페이스 모두 (UNION) */
+  findAllByMember(userId: string): Promise<Workspace[]>;
+
+  /** 이름 변경 (owner 만 — RLS 가 강제) */
+  updateName(id: string, name: string): Promise<Workspace>;
+}
+
+export interface IWorkspaceMemberRepository {
+  /** 멤버 목록 (owner 제외 editor 만 — workspace_members 테이블) */
+  findByWorkspaceWithUser(workspaceId: string): Promise<WorkspaceMemberWithUser[]>;
+
+  /** 본인이 속한 워크스페이스 ID 목록 (editor 으로) */
+  findWorkspaceIdsForUser(userId: string): Promise<string[]>;
+
+  /**
+   * 멤버 제거 (RPC 우회) — owner 만 호출 가능, RPC 가 권한 체크
+   * @throws AppError E5 권한 / E6 invalid state
+   */
+  removeViaRpc(workspaceId: string, userId: string): Promise<void>;
+}
+
+export interface IWorkspaceInvitationRepository {
+  /**
+   * 초대 발송 (owner 만, RPC 경유 atomic 권한 체크)
+   * @returns 새 초대 ID
+   * @throws AppError E3 검증 / E5 권한 / E6 비즈니스 (이미 멤버 / 이미 초대됨)
+   */
+  inviteViaRpc(workspaceId: string, inviteeUserId: string): Promise<string>;
+
+  /**
+   * 초대 수락 (race-safe atomic RPC)
+   * @returns workspaceId + idempotent 플래그
+   */
+  acceptViaRpc(invitationId: string): Promise<AcceptInvitationResult>;
+
+  /** 거절 (RPC) */
+  rejectViaRpc(invitationId: string): Promise<void>;
+
+  /** owner 가 보낸 초대 회수 (RPC) */
+  revokeViaRpc(invitationId: string): Promise<void>;
+
+  /** 본인이 받은 pending 초대 + 워크스페이스/초대자 정보 결합 */
+  findPendingForUser(userId: string): Promise<ReceivedWorkspaceInvitation[]>;
+
+  /** 워크스페이스의 모든 초대 (owner 화면) */
+  findByWorkspace(workspaceId: string): Promise<WorkspaceInvitation[]>;
+}

--- a/uniqn-mobile/src/repositories/interfaces/index.ts
+++ b/uniqn-mobile/src/repositories/interfaces/index.ts
@@ -126,3 +126,10 @@ export type {
   FetchScheduleMembershipsOptions,
   FetchBoardReportsOptions,
 } from './IBoardRepository';
+
+// 워크스페이스 협업 편집 (PR #2)
+export type {
+  IWorkspaceRepository,
+  IWorkspaceMemberRepository,
+  IWorkspaceInvitationRepository,
+} from './IWorkspaceRepository';

--- a/uniqn-mobile/src/repositories/supabase/WorkspaceInvitationRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/WorkspaceInvitationRepository.ts
@@ -1,0 +1,194 @@
+/**
+ * UNIQN Mobile - Supabase Workspace Invitation Repository
+ *
+ * @description 공고 워크스페이스 초대 (PR #2)
+ *              - invite/accept/reject/revoke 는 SECURITY DEFINER RPC 경유 (atomic + 권한 체크)
+ *              - SELECT 는 RLS workspace_invitations_select_relevant 필터링 적용
+ * @version 1.0.0
+ */
+
+import { supabase } from '@/lib/supabase';
+import { logger } from '@/utils/logger';
+import { isAppError, BusinessError } from '@/errors';
+import { handleSupabaseError, toCamelCase } from '@/utils/supabase';
+import { mapWorkspaceRpcError, WORKSPACE_ERROR_CODES } from '@/errors/workspace';
+import type {
+  WorkspaceInvitation,
+  ReceivedWorkspaceInvitation,
+  AcceptInvitationResult,
+} from '@/types/workspace';
+import type { IWorkspaceInvitationRepository } from '../interfaces/IWorkspaceRepository';
+
+const TABLE = 'workspace_invitations' as const;
+const COLUMNS =
+  'id, workspace_id, invitee_user_id, role, invited_by, status, expires_at, created_at, responded_at' as const;
+
+function rowToInvitation(row: Record<string, unknown>): WorkspaceInvitation {
+  return toCamelCase<WorkspaceInvitation>(row);
+}
+
+interface PendingJoinRow {
+  id: string;
+  workspace_id: string;
+  invitee_user_id: string;
+  role: 'editor';
+  invited_by: string;
+  status: WorkspaceInvitation['status'];
+  expires_at: string;
+  created_at: string;
+  responded_at: string | null;
+  workspaces: { name: string } | null;
+  inviter: { display_name: string | null } | null;
+}
+
+function rowToReceivedInvitation(row: PendingJoinRow): ReceivedWorkspaceInvitation {
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    inviteeUserId: row.invitee_user_id,
+    role: row.role,
+    invitedBy: row.invited_by,
+    status: row.status,
+    expiresAt: row.expires_at,
+    createdAt: row.created_at,
+    respondedAt: row.responded_at ?? null,
+    workspaceName: row.workspaces?.name ?? '',
+    inviterDisplayName: row.inviter?.display_name ?? null,
+  };
+}
+
+export class SupabaseWorkspaceInvitationRepository implements IWorkspaceInvitationRepository {
+  async inviteViaRpc(workspaceId: string, inviteeUserId: string): Promise<string> {
+    try {
+      logger.info('워크스페이스 초대 RPC', { workspaceId, inviteeUserId });
+      const { data, error } = await supabase.rpc('invite_workspace_member', {
+        p_workspace_id: workspaceId,
+        p_invitee_user_id: inviteeUserId,
+      });
+
+      if (error) {
+        const mapped = mapWorkspaceRpcError(error);
+        if (mapped) throw mapped;
+        handleSupabaseError(error, { operation: '워크스페이스 초대', table: TABLE });
+      }
+
+      const invitationId = data as string | null;
+      if (!invitationId) {
+        throw new BusinessError(WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_NOT_FOUND, {
+          userMessage: '초대 발송에 실패했습니다.',
+        });
+      }
+      return invitationId;
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '워크스페이스 초대', table: TABLE });
+    }
+  }
+
+  async acceptViaRpc(invitationId: string): Promise<AcceptInvitationResult> {
+    try {
+      logger.info('워크스페이스 초대 수락 RPC', { invitationId });
+      const { data, error } = await supabase.rpc('accept_workspace_invitation', {
+        p_invitation_id: invitationId,
+      });
+
+      if (error) {
+        const mapped = mapWorkspaceRpcError(error);
+        if (mapped) throw mapped;
+        handleSupabaseError(error, { operation: '초대 수락', table: TABLE });
+      }
+
+      const payload = (data ?? {}) as {
+        invitationId?: string;
+        workspaceId?: string;
+        idempotent?: boolean;
+      };
+      if (!payload.invitationId || !payload.workspaceId) {
+        throw new BusinessError(WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_NOT_FOUND, {
+          userMessage: '초대 응답을 처리하지 못했습니다.',
+        });
+      }
+      return {
+        invitationId: payload.invitationId,
+        workspaceId: payload.workspaceId,
+        idempotent: Boolean(payload.idempotent),
+      };
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '초대 수락', table: TABLE });
+    }
+  }
+
+  async rejectViaRpc(invitationId: string): Promise<void> {
+    try {
+      logger.info('워크스페이스 초대 거절 RPC', { invitationId });
+      const { error } = await supabase.rpc('reject_workspace_invitation', {
+        p_invitation_id: invitationId,
+      });
+      if (error) {
+        const mapped = mapWorkspaceRpcError(error);
+        if (mapped) throw mapped;
+        handleSupabaseError(error, { operation: '초대 거절', table: TABLE });
+      }
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '초대 거절', table: TABLE });
+    }
+  }
+
+  async revokeViaRpc(invitationId: string): Promise<void> {
+    try {
+      logger.info('워크스페이스 초대 회수 RPC', { invitationId });
+      const { error } = await supabase.rpc('revoke_workspace_invitation', {
+        p_invitation_id: invitationId,
+      });
+      if (error) {
+        const mapped = mapWorkspaceRpcError(error);
+        if (mapped) throw mapped;
+        handleSupabaseError(error, { operation: '초대 회수', table: TABLE });
+      }
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '초대 회수', table: TABLE });
+    }
+  }
+
+  async findPendingForUser(userId: string): Promise<ReceivedWorkspaceInvitation[]> {
+    try {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select(`${COLUMNS}, workspaces:workspace_id (name), inviter:invited_by (display_name)`)
+        .eq('invitee_user_id', userId)
+        .eq('status', 'pending')
+        .order('created_at', { ascending: false });
+
+      if (error) {
+        handleSupabaseError(error, { operation: '받은 초대 조회', table: TABLE });
+      }
+      return ((data ?? []) as unknown as PendingJoinRow[]).map(rowToReceivedInvitation);
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '받은 초대 조회', table: TABLE });
+    }
+  }
+
+  async findByWorkspace(workspaceId: string): Promise<WorkspaceInvitation[]> {
+    try {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select(COLUMNS)
+        .eq('workspace_id', workspaceId)
+        .order('created_at', { ascending: false });
+
+      if (error) {
+        handleSupabaseError(error, { operation: '워크스페이스 초대 목록 조회', table: TABLE });
+      }
+      return ((data ?? []) as Record<string, unknown>[]).map(rowToInvitation);
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '워크스페이스 초대 목록 조회', table: TABLE });
+    }
+  }
+}
+
+export const workspaceInvitationRepository = new SupabaseWorkspaceInvitationRepository();

--- a/uniqn-mobile/src/repositories/supabase/WorkspaceMemberRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/WorkspaceMemberRepository.ts
@@ -1,0 +1,108 @@
+/**
+ * UNIQN Mobile - Supabase Workspace Member Repository
+ *
+ * @description 공고 워크스페이스 멤버 (PR #2)
+ *              - editor 멤버만 (D2: owner는 workspaces.owner_id 단독)
+ *              - INSERT/UPDATE/DELETE 는 RPC 우회 (accept_workspace_invitation, remove_workspace_member)
+ * @version 1.0.0
+ */
+
+import { supabase } from '@/lib/supabase';
+import { logger } from '@/utils/logger';
+import { isAppError } from '@/errors';
+import { handleSupabaseError } from '@/utils/supabase';
+import { mapWorkspaceRpcError } from '@/errors/workspace';
+import type { WorkspaceMemberWithUser } from '@/types/workspace';
+import type { IWorkspaceMemberRepository } from '../interfaces/IWorkspaceRepository';
+
+const TABLE = 'workspace_members' as const;
+
+interface MemberJoinRow {
+  workspace_id: string;
+  user_id: string;
+  role: 'editor';
+  invited_by: string | null;
+  joined_at: string;
+  users: {
+    display_name: string | null;
+    email: string | null;
+    photo_url: string | null;
+  } | null;
+}
+
+function rowToMemberWithUser(row: MemberJoinRow): WorkspaceMemberWithUser {
+  return {
+    workspaceId: row.workspace_id,
+    userId: row.user_id,
+    role: row.role,
+    invitedBy: row.invited_by ?? null,
+    joinedAt: row.joined_at,
+    displayName: row.users?.display_name ?? null,
+    email: row.users?.email ?? null,
+    photoUrl: row.users?.photo_url ?? null,
+  };
+}
+
+export class SupabaseWorkspaceMemberRepository implements IWorkspaceMemberRepository {
+  async findByWorkspaceWithUser(workspaceId: string): Promise<WorkspaceMemberWithUser[]> {
+    try {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select(
+          'workspace_id, user_id, role, invited_by, joined_at, users:user_id (display_name, email, photo_url)'
+        )
+        .eq('workspace_id', workspaceId)
+        .order('joined_at', { ascending: true });
+
+      if (error) {
+        handleSupabaseError(error, { operation: '멤버 목록 조회', table: TABLE });
+      }
+
+      return ((data ?? []) as unknown as MemberJoinRow[]).map(rowToMemberWithUser);
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '멤버 목록 조회', table: TABLE });
+    }
+  }
+
+  async findWorkspaceIdsForUser(userId: string): Promise<string[]> {
+    try {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select('workspace_id')
+        .eq('user_id', userId);
+
+      if (error) {
+        handleSupabaseError(error, { operation: '내 워크스페이스 ID 조회', table: TABLE });
+      }
+      return (data ?? []).map((r) => (r as { workspace_id: string }).workspace_id);
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '내 워크스페이스 ID 조회', table: TABLE });
+    }
+  }
+
+  async removeViaRpc(workspaceId: string, userId: string): Promise<void> {
+    try {
+      logger.info('멤버 제거 RPC', { workspaceId, userId });
+      const { data, error } = await supabase.rpc('remove_workspace_member', {
+        p_workspace_id: workspaceId,
+        p_user_id: userId,
+      });
+
+      // supabase-js: 에러는 error 또는 data 응답 패턴 둘 다 가능
+      if (error) {
+        const mapped = mapWorkspaceRpcError(error);
+        if (mapped) throw mapped;
+        handleSupabaseError(error, { operation: '멤버 제거', table: TABLE });
+      }
+      // void RPC 는 data 를 사용하지 않음
+      void data;
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '멤버 제거', table: TABLE });
+    }
+  }
+}
+
+export const workspaceMemberRepository = new SupabaseWorkspaceMemberRepository();

--- a/uniqn-mobile/src/repositories/supabase/WorkspaceRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/WorkspaceRepository.ts
@@ -1,0 +1,111 @@
+/**
+ * UNIQN Mobile - Supabase Workspace Repository
+ *
+ * @description 공고 워크스페이스 (PR #2)
+ *              - workspaces 테이블 CRUD
+ *              - RLS 가 권한 강제 (workspaces_select_owner_or_member, _insert_employer_with_cap, _update_owner)
+ * @version 1.0.0
+ */
+
+import { supabase } from '@/lib/supabase';
+import { logger } from '@/utils/logger';
+import { isAppError } from '@/errors';
+import { handleSupabaseError, toCamelCase } from '@/utils/supabase';
+import { mapWorkspaceRpcError } from '@/errors/workspace';
+import type { Workspace } from '@/types/workspace';
+import type { IWorkspaceRepository } from '../interfaces/IWorkspaceRepository';
+
+const TABLE = 'workspaces' as const;
+const COLUMNS = 'id, name, owner_id, member_count, created_at, updated_at' as const;
+
+function rowToWorkspace(row: Record<string, unknown>): Workspace {
+  return toCamelCase<Workspace>(row);
+}
+
+export class SupabaseWorkspaceRepository implements IWorkspaceRepository {
+  async create(name: string, ownerId: string): Promise<Workspace> {
+    try {
+      logger.info('워크스페이스 생성 시작', { ownerId, name });
+
+      const { data, error } = await supabase
+        .from(TABLE)
+        .insert({ name, owner_id: ownerId })
+        .select(COLUMNS)
+        .single();
+
+      if (error) {
+        const mapped = mapWorkspaceRpcError(error);
+        if (mapped) throw mapped;
+        handleSupabaseError(error, { operation: '워크스페이스 생성', table: TABLE });
+      }
+
+      logger.info('워크스페이스 생성 완료', { workspaceId: data!.id });
+      return rowToWorkspace(data as Record<string, unknown>);
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '워크스페이스 생성', table: TABLE });
+    }
+  }
+
+  async findById(id: string): Promise<Workspace | undefined> {
+    try {
+      const { data, error } = await supabase.from(TABLE).select(COLUMNS).eq('id', id).maybeSingle();
+
+      if (error) {
+        handleSupabaseError(error, { operation: '워크스페이스 조회', table: TABLE });
+      }
+      return data ? rowToWorkspace(data as Record<string, unknown>) : undefined;
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '워크스페이스 조회', table: TABLE });
+    }
+  }
+
+  /**
+   * "내가 멤버인 모든 워크스페이스" — owner OR editor.
+   * RLS workspaces_select_owner_or_member 가 자동으로 필터링하므로 select * 만 호출.
+   */
+  async findAllByMember(_userId: string): Promise<Workspace[]> {
+    try {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select(COLUMNS)
+        .order('created_at', { ascending: true });
+
+      if (error) {
+        handleSupabaseError(error, { operation: '워크스페이스 목록 조회', table: TABLE });
+      }
+
+      return ((data ?? []) as Record<string, unknown>[]).map(rowToWorkspace);
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '워크스페이스 목록 조회', table: TABLE });
+    }
+  }
+
+  async updateName(id: string, name: string): Promise<Workspace> {
+    try {
+      logger.info('워크스페이스 이름 변경', { workspaceId: id });
+
+      const { data, error } = await supabase
+        .from(TABLE)
+        .update({ name })
+        .eq('id', id)
+        .select(COLUMNS)
+        .single();
+
+      if (error) {
+        const mapped = mapWorkspaceRpcError(error);
+        if (mapped) throw mapped;
+        handleSupabaseError(error, { operation: '워크스페이스 이름 변경', table: TABLE });
+      }
+
+      return rowToWorkspace(data as Record<string, unknown>);
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '워크스페이스 이름 변경', table: TABLE });
+    }
+  }
+}
+
+export const workspaceRepository = new SupabaseWorkspaceRepository();

--- a/uniqn-mobile/src/repositories/supabase/index.ts
+++ b/uniqn-mobile/src/repositories/supabase/index.ts
@@ -13,3 +13,14 @@ export { SupabaseInquiryRepository } from './InquiryRepository';
 export { SupabaseTemplateRepository } from './TemplateRepository';
 export { SupabaseEventQRRepository } from './EventQRRepository';
 export { SupabaseAdminRepository } from './AdminRepository';
+
+// 워크스페이스 협업 편집 (PR #2)
+export { SupabaseWorkspaceRepository, workspaceRepository } from './WorkspaceRepository';
+export {
+  SupabaseWorkspaceMemberRepository,
+  workspaceMemberRepository,
+} from './WorkspaceMemberRepository';
+export {
+  SupabaseWorkspaceInvitationRepository,
+  workspaceInvitationRepository,
+} from './WorkspaceInvitationRepository';

--- a/uniqn-mobile/src/schemas/__tests__/workspace.schema.test.ts
+++ b/uniqn-mobile/src/schemas/__tests__/workspace.schema.test.ts
@@ -1,0 +1,103 @@
+/**
+ * PR #2 — workspace zod schema 검증
+ *
+ * - XSS 차단 (xssValidation refine)
+ * - 이름 길이 제약 (1~50)
+ * - UUID 형식 강제
+ * - role enum 'editor' 단일
+ */
+
+import {
+  createWorkspaceSchema,
+  updateWorkspaceNameSchema,
+  inviteWorkspaceMemberSchema,
+  respondInvitationSchema,
+  workspaceRoleSchema,
+} from '@/schemas/workspace.schema';
+
+describe('workspace schemas (PR #2)', () => {
+  describe('createWorkspaceSchema', () => {
+    it('정상 입력 통과', () => {
+      const r = createWorkspaceSchema.safeParse({ name: '강남펍 워크스페이스' });
+      expect(r.success).toBe(true);
+    });
+
+    it('빈 문자열 거부', () => {
+      const r = createWorkspaceSchema.safeParse({ name: '' });
+      expect(r.success).toBe(false);
+    });
+
+    it('51자 거부', () => {
+      const r = createWorkspaceSchema.safeParse({ name: 'a'.repeat(51) });
+      expect(r.success).toBe(false);
+    });
+
+    it('XSS 시도 거부 — script 태그', () => {
+      const r = createWorkspaceSchema.safeParse({ name: '<script>alert(1)</script>' });
+      expect(r.success).toBe(false);
+    });
+
+    it('XSS 시도 거부 — javascript: URL', () => {
+      const r = createWorkspaceSchema.safeParse({ name: 'javascript:void(0)' });
+      expect(r.success).toBe(false);
+    });
+
+    it('이모지 포함 가능 (Unicode 안전)', () => {
+      const r = createWorkspaceSchema.safeParse({ name: '🎰 강남 포커룸' });
+      expect(r.success).toBe(true);
+    });
+  });
+
+  describe('updateWorkspaceNameSchema', () => {
+    it('워크스페이스 ID UUID 강제', () => {
+      const r = updateWorkspaceNameSchema.safeParse({
+        workspaceId: 'not-a-uuid',
+        name: '신규 이름',
+      });
+      expect(r.success).toBe(false);
+    });
+
+    it('정상 통과', () => {
+      const r = updateWorkspaceNameSchema.safeParse({
+        workspaceId: '123e4567-e89b-42d3-a456-426614174001',
+        name: '신규 이름',
+      });
+      expect(r.success).toBe(true);
+    });
+  });
+
+  describe('inviteWorkspaceMemberSchema', () => {
+    it('role default editor', () => {
+      const r = inviteWorkspaceMemberSchema.safeParse({
+        workspaceId: '123e4567-e89b-42d3-a456-426614174001',
+        inviteeUserId: '123e4567-e89b-42d3-a456-426614174002',
+      });
+      expect(r.success).toBe(true);
+      if (r.success) expect(r.data.role).toBe('editor');
+    });
+
+    it('role 외 값 거부 (D2: editor 단일)', () => {
+      const r = inviteWorkspaceMemberSchema.safeParse({
+        workspaceId: '123e4567-e89b-42d3-a456-426614174001',
+        inviteeUserId: '123e4567-e89b-42d3-a456-426614174002',
+        role: 'owner',
+      });
+      expect(r.success).toBe(false);
+    });
+  });
+
+  describe('respondInvitationSchema', () => {
+    it('UUID 강제', () => {
+      const r = respondInvitationSchema.safeParse({ invitationId: 'invalid' });
+      expect(r.success).toBe(false);
+    });
+  });
+
+  describe('workspaceRoleSchema (D2)', () => {
+    it("'editor' 만 허용", () => {
+      expect(workspaceRoleSchema.safeParse('editor').success).toBe(true);
+      expect(workspaceRoleSchema.safeParse('owner').success).toBe(false);
+      expect(workspaceRoleSchema.safeParse('admin').success).toBe(false);
+    });
+  });
+});

--- a/uniqn-mobile/src/schemas/index.ts
+++ b/uniqn-mobile/src/schemas/index.ts
@@ -341,3 +341,25 @@ export type {
 export { BoardJobSummarySchema, BoardPostMetadataSchema } from './boardMetadata.schema';
 
 export type { BoardJobSummarySchemaData, BoardPostMetadata } from './boardMetadata.schema';
+
+// 워크스페이스 협업 편집 (PR #2)
+export {
+  workspaceRoleSchema,
+  workspaceInvitationStatusSchema,
+  workspaceNameSchema,
+  createWorkspaceSchema,
+  updateWorkspaceNameSchema,
+  inviteWorkspaceMemberSchema,
+  removeWorkspaceMemberSchema,
+  respondInvitationSchema,
+} from './workspace.schema';
+
+export type {
+  WorkspaceRoleSchema,
+  WorkspaceInvitationStatusSchema,
+  CreateWorkspaceData,
+  UpdateWorkspaceNameData,
+  InviteWorkspaceMemberData,
+  RemoveWorkspaceMemberData,
+  RespondInvitationData,
+} from './workspace.schema';

--- a/uniqn-mobile/src/schemas/workspace.schema.ts
+++ b/uniqn-mobile/src/schemas/workspace.schema.ts
@@ -1,0 +1,97 @@
+/**
+ * UNIQN Mobile - 워크스페이스 관련 Zod 스키마
+ *
+ * @description 공고 워크스페이스 협업 편집 (PR #2)
+ * @version 1.0.0
+ *
+ * - workspaceSchema: 생성/수정 시 name 검증 (XSS + 길이)
+ * - inviteWorkspaceMemberSchema: 초대 RPC 입력
+ * - workspaceInvitationStatusSchema: status enum (DB CHECK 와 일치)
+ * - workspaceRoleSchema: 'editor' 단일 (D2 — owner 는 workspaces.owner_id 단독)
+ */
+
+import { z } from 'zod';
+import { xssValidation } from '@/utils/security';
+
+// ============================================================================
+// Enums
+// ============================================================================
+
+export const workspaceRoleSchema = z.literal('editor');
+export type WorkspaceRoleSchema = z.infer<typeof workspaceRoleSchema>;
+
+export const workspaceInvitationStatusSchema = z.enum([
+  'pending',
+  'accepted',
+  'rejected',
+  'revoked',
+  'expired',
+]);
+export type WorkspaceInvitationStatusSchema = z.infer<typeof workspaceInvitationStatusSchema>;
+
+// ============================================================================
+// Field schemas
+// ============================================================================
+
+/**
+ * 워크스페이스 이름 — DB CHECK (1~50자) + XSS
+ */
+export const workspaceNameSchema = z
+  .string({ error: '워크스페이스 이름을 입력해주세요' })
+  .trim()
+  .min(1, { message: '워크스페이스 이름을 입력해주세요' })
+  .max(50, { message: '워크스페이스 이름은 50자를 초과할 수 없습니다' })
+  .refine(xssValidation, { message: '특수문자가 포함될 수 없습니다' });
+
+// ============================================================================
+// 워크스페이스 생성 / 수정
+// ============================================================================
+
+/**
+ * 워크스페이스 생성 입력 (Service 진입점)
+ * owner_id 는 인증 컨텍스트에서 자동 주입 — 입력 받지 않음.
+ */
+export const createWorkspaceSchema = z.object({
+  name: workspaceNameSchema,
+});
+
+export type CreateWorkspaceData = z.infer<typeof createWorkspaceSchema>;
+
+/**
+ * 워크스페이스 이름 변경
+ */
+export const updateWorkspaceNameSchema = z.object({
+  workspaceId: z.string().uuid({ message: '올바른 워크스페이스 ID 가 아닙니다' }),
+  name: workspaceNameSchema,
+});
+
+export type UpdateWorkspaceNameData = z.infer<typeof updateWorkspaceNameSchema>;
+
+// ============================================================================
+// 멤버 초대 / 관리
+// ============================================================================
+
+export const inviteWorkspaceMemberSchema = z.object({
+  workspaceId: z.string().uuid({ message: '올바른 워크스페이스 ID 가 아닙니다' }),
+  inviteeUserId: z.string().uuid({ message: '올바른 사용자 ID 가 아닙니다' }),
+  role: workspaceRoleSchema.default('editor'),
+});
+
+export type InviteWorkspaceMemberData = z.infer<typeof inviteWorkspaceMemberSchema>;
+
+export const removeWorkspaceMemberSchema = z.object({
+  workspaceId: z.string().uuid(),
+  userId: z.string().uuid(),
+});
+
+export type RemoveWorkspaceMemberData = z.infer<typeof removeWorkspaceMemberSchema>;
+
+// ============================================================================
+// 초대 응답 (RPC 입력)
+// ============================================================================
+
+export const respondInvitationSchema = z.object({
+  invitationId: z.string().uuid({ message: '올바른 초대 ID 가 아닙니다' }),
+});
+
+export type RespondInvitationData = z.infer<typeof respondInvitationSchema>;

--- a/uniqn-mobile/src/services/index.ts
+++ b/uniqn-mobile/src/services/index.ts
@@ -46,3 +46,11 @@ export * from './reviewService';
 export * from './inquiryService';
 export * from './versionService';
 export * from './boardService';
+
+// 워크스페이스 협업 편집 (PR #2)
+export {
+  workspaceService,
+  workspaceInvitationService,
+  type InviteWorkspaceMemberOptions,
+  type InviteWorkspaceMemberResult,
+} from './workspace';

--- a/uniqn-mobile/src/services/workspace/index.ts
+++ b/uniqn-mobile/src/services/workspace/index.ts
@@ -1,0 +1,12 @@
+/**
+ * UNIQN Mobile - Workspace Services Barrel
+ *
+ * @description 공고 워크스페이스 협업 편집 (PR #2)
+ */
+
+export { workspaceService } from './workspaceService';
+export {
+  workspaceInvitationService,
+  type InviteWorkspaceMemberOptions,
+  type InviteWorkspaceMemberResult,
+} from './workspaceInvitationService';

--- a/uniqn-mobile/src/services/workspace/workspaceInvitationService.ts
+++ b/uniqn-mobile/src/services/workspace/workspaceInvitationService.ts
@@ -1,0 +1,109 @@
+/**
+ * UNIQN Mobile - Workspace Invitation Service
+ *
+ * @description 초대 라이프사이클 (PR #2)
+ *              invite/accept/reject/revoke — 모두 SECURITY DEFINER RPC 경유.
+ *              발송 후 푸시 알림은 별도 서비스 (pushNotificationService.sendWorkspaceInvitation).
+ * @version 1.0.0
+ */
+
+import { workspaceInvitationRepository, workspaceRepository } from '@/repositories';
+import { inviteWorkspaceMemberSchema, respondInvitationSchema } from '@/schemas/workspace.schema';
+import { ValidationError, ERROR_CODES } from '@/errors';
+import { logger } from '@/utils/logger';
+import type {
+  ReceivedWorkspaceInvitation,
+  WorkspaceInvitation,
+  AcceptInvitationResult,
+} from '@/types/workspace';
+
+function validateOrThrow<T>(
+  parsed: { success: boolean; data?: T; error?: { issues: { message: string }[] } },
+  fallback = '입력값을 확인해주세요'
+): T {
+  if (!parsed.success) {
+    const message = parsed.error?.issues[0]?.message ?? fallback;
+    throw new ValidationError(ERROR_CODES.VALIDATION_SCHEMA, { userMessage: message });
+  }
+  return parsed.data as T;
+}
+
+export interface InviteWorkspaceMemberOptions {
+  workspaceId: string;
+  inviteeUserId: string;
+}
+
+export interface InviteWorkspaceMemberResult {
+  invitationId: string;
+  workspaceName: string;
+}
+
+export const workspaceInvitationService = {
+  /**
+   * 멤버 초대 — owner 권한 체크는 RPC 단계에서 수행.
+   * 푸시 알림은 호출자가 별도 트리거 (Repository 가 invitationId 반환 후).
+   */
+  async invite(input: InviteWorkspaceMemberOptions): Promise<InviteWorkspaceMemberResult> {
+    const parsed = inviteWorkspaceMemberSchema.safeParse(input);
+    const data = validateOrThrow(parsed);
+
+    logger.info('워크스페이스 초대 시작', data);
+    const invitationId = await workspaceInvitationRepository.inviteViaRpc(
+      data.workspaceId,
+      data.inviteeUserId
+    );
+
+    const workspace = await workspaceRepository.findById(data.workspaceId);
+    return {
+      invitationId,
+      workspaceName: workspace?.name ?? '',
+    };
+  },
+
+  /**
+   * 초대 수락 (atomic + idempotent)
+   */
+  async accept(input: { invitationId: string }): Promise<AcceptInvitationResult> {
+    const parsed = respondInvitationSchema.safeParse(input);
+    const data = validateOrThrow(parsed);
+
+    logger.info('워크스페이스 초대 수락', data);
+    return workspaceInvitationRepository.acceptViaRpc(data.invitationId);
+  },
+
+  /**
+   * 초대 거절
+   */
+  async reject(input: { invitationId: string }): Promise<void> {
+    const parsed = respondInvitationSchema.safeParse(input);
+    const data = validateOrThrow(parsed);
+
+    logger.info('워크스페이스 초대 거절', data);
+    await workspaceInvitationRepository.rejectViaRpc(data.invitationId);
+  },
+
+  /**
+   * owner 가 보낸 초대 회수
+   */
+  async revoke(input: { invitationId: string }): Promise<void> {
+    const parsed = respondInvitationSchema.safeParse(input);
+    const data = validateOrThrow(parsed);
+
+    logger.info('워크스페이스 초대 회수', data);
+    await workspaceInvitationRepository.revokeViaRpc(data.invitationId);
+  },
+
+  /**
+   * 본인이 받은 pending 초대 (홈 화면 / 알림 화면에서 표시)
+   */
+  async listPendingForUser(userId: string): Promise<ReceivedWorkspaceInvitation[]> {
+    return workspaceInvitationRepository.findPendingForUser(userId);
+  },
+
+  /**
+   * 워크스페이스의 모든 초대 (owner 가 status 별로 필터링)
+   */
+  async listByWorkspace(workspaceId: string): Promise<WorkspaceInvitation[]> {
+    return workspaceInvitationRepository.findByWorkspace(workspaceId);
+  },
+};

--- a/uniqn-mobile/src/services/workspace/workspaceService.ts
+++ b/uniqn-mobile/src/services/workspace/workspaceService.ts
@@ -1,0 +1,87 @@
+/**
+ * UNIQN Mobile - Workspace Service
+ *
+ * @description 공고 워크스페이스 도메인 로직 (PR #2)
+ *              - 입력 검증 (zod)
+ *              - 권한 체크는 RLS 단독 (워크스페이스 정책 review C1)
+ *              - Hook 에서 UI 분기용 데이터만 제공
+ * @version 1.0.0
+ */
+
+import { workspaceRepository, workspaceMemberRepository } from '@/repositories';
+import {
+  createWorkspaceSchema,
+  updateWorkspaceNameSchema,
+  removeWorkspaceMemberSchema,
+} from '@/schemas/workspace.schema';
+import { ValidationError, ERROR_CODES, isAppError } from '@/errors';
+import { logger } from '@/utils/logger';
+import type { Workspace, WorkspaceMemberWithUser } from '@/types/workspace';
+
+function toValidationError(error: unknown): never {
+  if (isAppError(error)) throw error;
+  throw new ValidationError(ERROR_CODES.VALIDATION_SCHEMA, {
+    userMessage: '입력값을 확인해주세요',
+    metadata: { error: String(error) },
+  });
+}
+
+export const workspaceService = {
+  /**
+   * 새 워크스페이스 생성
+   * RLS 가 cap (10) 강제 — 도달 시 mapWorkspaceRpcError 가 WORKSPACE_CAP_REACHED 변환.
+   */
+  async createWorkspace(input: { name: string; ownerId: string }): Promise<Workspace> {
+    const parsed = createWorkspaceSchema.safeParse({ name: input.name });
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? '입력값 오류';
+      throw new ValidationError(ERROR_CODES.VALIDATION_SCHEMA, { userMessage: message });
+    }
+
+    return workspaceRepository.create(parsed.data.name, input.ownerId);
+  },
+
+  /**
+   * 워크스페이스 이름 변경 (owner 만 — RLS 강제)
+   */
+  async updateWorkspaceName(input: { workspaceId: string; name: string }): Promise<Workspace> {
+    const parsed = updateWorkspaceNameSchema.safeParse(input);
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? '입력값 오류';
+      throw new ValidationError(ERROR_CODES.VALIDATION_SCHEMA, { userMessage: message });
+    }
+    return workspaceRepository.updateName(parsed.data.workspaceId, parsed.data.name);
+  },
+
+  /**
+   * 사용자가 속한 모든 워크스페이스 (owner OR editor)
+   */
+  async listWorkspacesForUser(userId: string): Promise<Workspace[]> {
+    try {
+      return await workspaceRepository.findAllByMember(userId);
+    } catch (error) {
+      logger.warn('listWorkspacesForUser 실패', { userId, error: String(error) });
+      toValidationError(error);
+    }
+  },
+
+  /**
+   * 워크스페이스 멤버 (editor) 목록 + 사용자 정보
+   */
+  async listMembers(workspaceId: string): Promise<WorkspaceMemberWithUser[]> {
+    return workspaceMemberRepository.findByWorkspaceWithUser(workspaceId);
+  },
+
+  /**
+   * 멤버 제거 (owner 만 — RPC 권한 체크)
+   */
+  async removeMember(input: { workspaceId: string; userId: string }): Promise<void> {
+    const parsed = removeWorkspaceMemberSchema.safeParse(input);
+    if (!parsed.success) {
+      throw new ValidationError(ERROR_CODES.VALIDATION_SCHEMA, {
+        userMessage: '입력값을 확인해주세요',
+      });
+    }
+    await workspaceMemberRepository.removeViaRpc(parsed.data.workspaceId, parsed.data.userId);
+  },
+};

--- a/uniqn-mobile/src/shared/deeplink/NotificationRouteMap.ts
+++ b/uniqn-mobile/src/shared/deeplink/NotificationRouteMap.ts
@@ -116,6 +116,12 @@ export const NOTIFICATION_ROUTE_MAP: Record<
     data?.workLogId
       ? { name: 'reviews/detail', params: { workLogId: data.workLogId } }
       : { name: 'reviews/pending' },
+
+  // 워크스페이스 협업 (PR #2)
+  [NotificationType.WORKSPACE_INVITATION]: (data): DeepLinkRoute =>
+    data?.invitationId
+      ? { name: 'workspace/invitations', params: { invitationId: data.invitationId } }
+      : { name: 'workspace/invitations' },
 };
 
 export function getRouteForNotificationType(

--- a/uniqn-mobile/src/shared/deeplink/RouteMapper.ts
+++ b/uniqn-mobile/src/shared/deeplink/RouteMapper.ts
@@ -139,6 +139,14 @@ export class RouteMapper {
       case 'reviews/pending':
         return EXPO_ROUTES.reviewsPending;
 
+      // 워크스페이스 협업 (PR #2)
+      case 'workspace':
+        return EXPO_ROUTES.workspace;
+      case 'workspace/invite':
+        return EXPO_ROUTES.workspaceInvite;
+      case 'workspace/invitations':
+        return EXPO_ROUTES.workspaceInvitations;
+
       default: {
         const _exhaustive: never = route;
         void _exhaustive;

--- a/uniqn-mobile/src/shared/deeplink/RouteRegistry.ts
+++ b/uniqn-mobile/src/shared/deeplink/RouteRegistry.ts
@@ -63,6 +63,11 @@ export const EXPO_ROUTES = {
   reviewDetail: '/(app)/reviews/[workLogId]',
   reviewsPending: '/(app)/reviews/pending',
 
+  // 워크스페이스 협업 (PR #2)
+  workspace: '/(employer)/workspace',
+  workspaceInvite: '/(employer)/workspace/invite',
+  workspaceInvitations: '/(employer)/workspace/invitations',
+
   publicJobs: '/(public)/jobs',
   publicJobDetail: '/jobs/[id]',
 
@@ -109,6 +114,10 @@ export const AUTH_REQUIRED_ROUTES: ExpoRouteName[] = [
   'reviewDetail',
   'reviewsPending',
   'employerApplicationStatus',
+  // 워크스페이스 협업 (PR #2)
+  'workspace',
+  'workspaceInvite',
+  'workspaceInvitations',
 ];
 
 export const EMPLOYER_REQUIRED_ROUTES: ExpoRouteName[] = [

--- a/uniqn-mobile/src/shared/deeplink/__tests__/NotificationRouteMap.test.ts
+++ b/uniqn-mobile/src/shared/deeplink/__tests__/NotificationRouteMap.test.ts
@@ -12,7 +12,7 @@ describe('NotificationRouteMap', () => {
   it('covers every NotificationType', () => {
     const allNotificationTypes = Object.values(NotificationType) as NotificationType[];
 
-    expect(allNotificationTypes.length).toBe(43);
+    expect(allNotificationTypes.length).toBe(44);
 
     allNotificationTypes.forEach((type) => {
       expect(NOTIFICATION_ROUTE_MAP[type]).toBeDefined();

--- a/uniqn-mobile/src/shared/deeplink/types.ts
+++ b/uniqn-mobile/src/shared/deeplink/types.ts
@@ -52,7 +52,11 @@ export type DeepLinkRoute =
   | { name: 'admin/employer-application'; params: { id: string } }
   | { name: 'employer-application-status' }
   | { name: 'reviews/detail'; params: { workLogId: string } }
-  | { name: 'reviews/pending' };
+  | { name: 'reviews/pending' }
+  // 워크스페이스 협업 (PR #2)
+  | { name: 'workspace' }
+  | { name: 'workspace/invite'; params: { workspaceId: string } }
+  | { name: 'workspace/invitations'; params?: { invitationId?: string } };
 
 export interface ParsedDeepLink {
   url: string;

--- a/uniqn-mobile/src/types/notification.ts
+++ b/uniqn-mobile/src/types/notification.ts
@@ -118,6 +118,10 @@ export const NotificationType = {
   REVIEW_RECEIVED: 'review_received',
   /** 평가 마감 리마인더 (D-2) */
   REVIEW_REMINDER: 'review_reminder',
+
+  // === 워크스페이스 협업 (PR #2) ===
+  /** 워크스페이스 초대 발송 (invitee 에게) */
+  WORKSPACE_INVITATION: 'workspace_invitation',
 } as const;
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare -- const/type 합성 패턴
@@ -213,6 +217,9 @@ export const NOTIFICATION_TYPE_TO_CATEGORY: Record<NotificationType, Notificatio
   [NotificationType.REVIEW_REQUEST]: NotificationCategory.REVIEW,
   [NotificationType.REVIEW_RECEIVED]: NotificationCategory.REVIEW,
   [NotificationType.REVIEW_REMINDER]: NotificationCategory.REVIEW,
+
+  // 워크스페이스 협업 (PR #2)
+  [NotificationType.WORKSPACE_INVITATION]: NotificationCategory.SYSTEM,
 };
 
 // ============================================================================
@@ -286,6 +293,9 @@ export const NOTIFICATION_DEFAULT_PRIORITY: Record<NotificationType, Notificatio
   [NotificationType.REVIEW_REQUEST]: 'normal',
   [NotificationType.REVIEW_RECEIVED]: 'normal',
   [NotificationType.REVIEW_REMINDER]: 'high',
+
+  // 워크스페이스 협업 (PR #2)
+  [NotificationType.WORKSPACE_INVITATION]: 'normal',
 };
 
 // ============================================================================
@@ -459,6 +469,9 @@ export const NOTIFICATION_TYPE_TO_CHANNEL: Record<NotificationType, AndroidChann
   [NotificationType.REVIEW_REQUEST]: AndroidChannelId.DEFAULT,
   [NotificationType.REVIEW_RECEIVED]: AndroidChannelId.DEFAULT,
   [NotificationType.REVIEW_REMINDER]: AndroidChannelId.REMINDERS,
+
+  // 워크스페이스 협업 (PR #2)
+  [NotificationType.WORKSPACE_INVITATION]: AndroidChannelId.DEFAULT,
 };
 
 // ============================================================================
@@ -525,6 +538,9 @@ export const NOTIFICATION_TYPE_LABELS: Record<NotificationType, string> = {
   [NotificationType.REVIEW_REQUEST]: '평가 요청',
   [NotificationType.REVIEW_RECEIVED]: '평가 도착',
   [NotificationType.REVIEW_REMINDER]: '평가 마감 임박',
+
+  // 워크스페이스 협업 (PR #2)
+  [NotificationType.WORKSPACE_INVITATION]: '워크스페이스 초대',
 };
 
 /**

--- a/uniqn-mobile/src/types/workspace.ts
+++ b/uniqn-mobile/src/types/workspace.ts
@@ -1,0 +1,83 @@
+/**
+ * UNIQN Mobile - 워크스페이스 도메인 타입
+ *
+ * @description 공고 워크스페이스 협업 편집 (PR #2)
+ *              camelCase 도메인 / snake_case DB 분리 (memory: supabase-patterns #1)
+ * @version 1.0.0
+ */
+
+export type WorkspaceRole = 'editor';
+
+export type WorkspaceInvitationStatus = 'pending' | 'accepted' | 'rejected' | 'revoked' | 'expired';
+
+/**
+ * 워크스페이스 (소유 + 멤버 모두 사용)
+ */
+export interface Workspace {
+  id: string;
+  name: string;
+  ownerId: string;
+  /** owner 제외한 editor 수 (UI 에서는 +1 표시) */
+  memberCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * 워크스페이스 멤버 (editor 만)
+ */
+export interface WorkspaceMember {
+  workspaceId: string;
+  userId: string;
+  role: WorkspaceRole;
+  invitedBy: string | null;
+  joinedAt: string;
+}
+
+/**
+ * 멤버 목록에 사용자 표시용 정보 결합
+ */
+export interface WorkspaceMemberWithUser extends WorkspaceMember {
+  displayName: string | null;
+  email: string | null;
+  photoUrl: string | null;
+}
+
+/**
+ * 초대
+ */
+export interface WorkspaceInvitation {
+  id: string;
+  workspaceId: string;
+  inviteeUserId: string;
+  role: WorkspaceRole;
+  invitedBy: string;
+  status: WorkspaceInvitationStatus;
+  expiresAt: string;
+  createdAt: string;
+  respondedAt: string | null;
+}
+
+/**
+ * 받은 초대 목록 (워크스페이스/초대자 정보 결합)
+ */
+export interface ReceivedWorkspaceInvitation extends WorkspaceInvitation {
+  workspaceName: string;
+  inviterDisplayName: string | null;
+}
+
+/**
+ * accept_workspace_invitation RPC 반환
+ */
+export interface AcceptInvitationResult {
+  invitationId: string;
+  workspaceId: string;
+  /** 이미 수락 완료된 초대를 다시 수락한 경우 true */
+  idempotent: boolean;
+}
+
+export const WORKSPACE_LIMITS = {
+  MAX_PER_OWNER: 10,
+  MAX_NAME_LENGTH: 50,
+  INVITATION_TTL_DAYS: 7,
+} as const;

--- a/uniqn-mobile/supabase/migrations/20260430020000_workspace_invitation_rpcs.sql
+++ b/uniqn-mobile/supabase/migrations/20260430020000_workspace_invitation_rpcs.sql
@@ -1,0 +1,294 @@
+-- 공고 워크스페이스 협업 편집 (PR #2 — RPC 레이어)
+-- atomic invitation lifecycle: invite / accept / reject / revoke / expire / remove_member
+-- 모두 SECURITY DEFINER + 명시적 권한 체크 + idempotent
+
+-- ============================================================
+-- 1. invite_workspace_member — owner 가 사용자 초대
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.invite_workspace_member(
+  p_workspace_id uuid,
+  p_invitee_user_id uuid
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_owner_id uuid;
+  v_caller_id uuid := auth.uid();
+  v_invitation_id uuid;
+BEGIN
+  IF v_caller_id IS NULL THEN
+    RAISE EXCEPTION 'AUTH_REQUIRED' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_caller_id = p_invitee_user_id THEN
+    RAISE EXCEPTION 'SELF_INVITE_FORBIDDEN' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT owner_id INTO v_owner_id FROM public.workspaces WHERE id = p_workspace_id FOR SHARE;
+  IF v_owner_id IS NULL THEN
+    RAISE EXCEPTION 'WORKSPACE_NOT_FOUND' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_owner_id != v_caller_id THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED' USING ERRCODE = '42501';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.workspace_members
+    WHERE workspace_id = p_workspace_id AND user_id = p_invitee_user_id
+  ) THEN
+    RAISE EXCEPTION 'ALREADY_MEMBER' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_owner_id = p_invitee_user_id THEN
+    RAISE EXCEPTION 'ALREADY_MEMBER' USING ERRCODE = 'P0001';
+  END IF;
+
+  BEGIN
+    INSERT INTO public.workspace_invitations (workspace_id, invitee_user_id, invited_by)
+    VALUES (p_workspace_id, p_invitee_user_id, v_caller_id)
+    RETURNING id INTO v_invitation_id;
+  EXCEPTION WHEN unique_violation THEN
+    RAISE EXCEPTION 'ALREADY_INVITED' USING ERRCODE = 'P0001';
+  END;
+
+  RETURN v_invitation_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.invite_workspace_member(uuid, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.invite_workspace_member(uuid, uuid) TO authenticated;
+
+-- ============================================================
+-- 2. accept_workspace_invitation — invitee 가 수락 (CRITICAL race-safe)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.accept_workspace_invitation(
+  p_invitation_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_caller_id uuid := auth.uid();
+  v_inv record;
+  v_already_member boolean;
+BEGIN
+  IF v_caller_id IS NULL THEN
+    RAISE EXCEPTION 'AUTH_REQUIRED' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT * INTO v_inv FROM public.workspace_invitations WHERE id = p_invitation_id FOR UPDATE;
+  IF v_inv IS NULL THEN
+    RAISE EXCEPTION 'INVITATION_NOT_FOUND' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_inv.invitee_user_id != v_caller_id THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1 FROM public.workspace_members
+    WHERE workspace_id = v_inv.workspace_id AND user_id = v_caller_id
+  ) INTO v_already_member;
+
+  IF v_inv.status = 'accepted' AND v_already_member THEN
+    RETURN jsonb_build_object(
+      'invitationId', v_inv.id,
+      'workspaceId', v_inv.workspace_id,
+      'idempotent', true
+    );
+  END IF;
+
+  IF v_inv.status != 'pending' THEN
+    RAISE EXCEPTION 'INVITATION_%', upper(v_inv.status) USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_inv.expires_at < now() THEN
+    UPDATE public.workspace_invitations
+      SET status = 'expired', responded_at = now()
+      WHERE id = p_invitation_id;
+    RAISE EXCEPTION 'INVITATION_EXPIRED' USING ERRCODE = 'P0001';
+  END IF;
+
+  INSERT INTO public.workspace_members (workspace_id, user_id, invited_by, role)
+  VALUES (v_inv.workspace_id, v_caller_id, v_inv.invited_by, v_inv.role)
+  ON CONFLICT (workspace_id, user_id) DO NOTHING;
+
+  UPDATE public.workspace_invitations
+    SET status = 'accepted', responded_at = now()
+    WHERE id = p_invitation_id;
+
+  RETURN jsonb_build_object(
+    'invitationId', v_inv.id,
+    'workspaceId', v_inv.workspace_id,
+    'idempotent', false
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.accept_workspace_invitation(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.accept_workspace_invitation(uuid) TO authenticated;
+
+-- ============================================================
+-- 3. reject_workspace_invitation
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.reject_workspace_invitation(
+  p_invitation_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_caller_id uuid := auth.uid();
+  v_inv record;
+BEGIN
+  IF v_caller_id IS NULL THEN
+    RAISE EXCEPTION 'AUTH_REQUIRED' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT * INTO v_inv FROM public.workspace_invitations WHERE id = p_invitation_id FOR UPDATE;
+  IF v_inv IS NULL THEN
+    RAISE EXCEPTION 'INVITATION_NOT_FOUND' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_inv.invitee_user_id != v_caller_id THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_inv.status = 'rejected' THEN
+    RETURN;
+  END IF;
+
+  IF v_inv.status != 'pending' THEN
+    RAISE EXCEPTION 'INVITATION_%', upper(v_inv.status) USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.workspace_invitations
+    SET status = 'rejected', responded_at = now()
+    WHERE id = p_invitation_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.reject_workspace_invitation(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.reject_workspace_invitation(uuid) TO authenticated;
+
+-- ============================================================
+-- 4. revoke_workspace_invitation
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.revoke_workspace_invitation(
+  p_invitation_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_caller_id uuid := auth.uid();
+  v_inv record;
+  v_owner_id uuid;
+BEGIN
+  IF v_caller_id IS NULL THEN
+    RAISE EXCEPTION 'AUTH_REQUIRED' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT * INTO v_inv FROM public.workspace_invitations WHERE id = p_invitation_id FOR UPDATE;
+  IF v_inv IS NULL THEN
+    RAISE EXCEPTION 'INVITATION_NOT_FOUND' USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT owner_id INTO v_owner_id FROM public.workspaces WHERE id = v_inv.workspace_id;
+  IF v_owner_id != v_caller_id THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_inv.status = 'revoked' THEN
+    RETURN;
+  END IF;
+
+  IF v_inv.status != 'pending' THEN
+    RAISE EXCEPTION 'INVITATION_%', upper(v_inv.status) USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.workspace_invitations
+    SET status = 'revoked', responded_at = now()
+    WHERE id = p_invitation_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.revoke_workspace_invitation(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.revoke_workspace_invitation(uuid) TO authenticated;
+
+-- ============================================================
+-- 5. remove_workspace_member
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.remove_workspace_member(
+  p_workspace_id uuid,
+  p_user_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_caller_id uuid := auth.uid();
+  v_owner_id uuid;
+BEGIN
+  IF v_caller_id IS NULL THEN
+    RAISE EXCEPTION 'AUTH_REQUIRED' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT owner_id INTO v_owner_id FROM public.workspaces WHERE id = p_workspace_id FOR SHARE;
+  IF v_owner_id IS NULL THEN
+    RAISE EXCEPTION 'WORKSPACE_NOT_FOUND' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_owner_id != v_caller_id THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_user_id = v_owner_id THEN
+    RAISE EXCEPTION 'CANNOT_REMOVE_OWNER' USING ERRCODE = 'P0001';
+  END IF;
+
+  DELETE FROM public.workspace_members
+    WHERE workspace_id = p_workspace_id AND user_id = p_user_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.remove_workspace_member(uuid, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.remove_workspace_member(uuid, uuid) TO authenticated;
+
+-- ============================================================
+-- 6. expire_pending_workspace_invitations — pg_cron 일 1회 호출
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.expire_pending_workspace_invitations()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_count integer;
+BEGIN
+  WITH expired AS (
+    UPDATE public.workspace_invitations
+      SET status = 'expired', responded_at = now()
+      WHERE status = 'pending' AND expires_at < now()
+      RETURNING 1
+  )
+  SELECT count(*) INTO v_count FROM expired;
+  RETURN v_count;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.expire_pending_workspace_invitations() FROM PUBLIC, anon, authenticated;
+COMMENT ON FUNCTION public.expire_pending_workspace_invitations IS 'pg_cron 일 1회 호출 — pending 초대 만료 처리. 알림 없음 (D3).';

--- a/uniqn-mobile/supabase/migrations/20260430020100_workspace_invitation_expiry_cron.sql
+++ b/uniqn-mobile/supabase/migrations/20260430020100_workspace_invitation_expiry_cron.sql
@@ -1,0 +1,15 @@
+-- 공고 워크스페이스 협업 편집 (PR #2 — pg_cron expiry)
+-- KST 자정 (00:05) 일 1회 expire_pending_workspace_invitations 호출
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM cron.job WHERE jobname = 'expire-pending-workspace-invitations-daily'
+  ) THEN
+    PERFORM cron.schedule(
+      'expire-pending-workspace-invitations-daily',
+      '5 15 * * *',  -- 15:05 UTC = 00:05 KST 다음 날
+      $cron$ SELECT public.expire_pending_workspace_invitations(); $cron$
+    );
+  END IF;
+END$$;

--- a/uniqn-mobile/supabase/migrations/20260430020200_workspace_invitation_notify_trigger.sql
+++ b/uniqn-mobile/supabase/migrations/20260430020200_workspace_invitation_notify_trigger.sql
@@ -1,0 +1,58 @@
+-- 공고 워크스페이스 협업 편집 (PR #2) — 초대 시 인앱 알림 INSERT
+-- workspace_invitations INSERT (status='pending') 시 notifications 에 row 추가.
+-- 푸시 발송은 기존 notifications-push trigger 가 자동 처리.
+
+CREATE OR REPLACE FUNCTION public.notify_on_workspace_invitation_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_workspace_name text;
+  v_inviter_name text;
+BEGIN
+  IF NEW.status != 'pending' THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT name INTO v_workspace_name FROM public.workspaces WHERE id = NEW.workspace_id;
+  SELECT COALESCE(name, '알 수 없음') INTO v_inviter_name FROM public.users WHERE id = NEW.invited_by;
+
+  v_workspace_name := COALESCE(v_workspace_name, '워크스페이스');
+  v_inviter_name := COALESCE(v_inviter_name, '알 수 없음');
+
+  INSERT INTO public.notifications (
+    recipient_id, type, title, body, link, data, priority
+  )
+  VALUES (
+    NEW.invitee_user_id,
+    'workspace_invitation',
+    format('%s님이 워크스페이스에 초대했어요', v_inviter_name),
+    format('%s · 편집자 권한', v_workspace_name),
+    format('/workspace/invitations'),
+    jsonb_build_object(
+      'invitationId', NEW.id,
+      'workspaceId', NEW.workspace_id,
+      'workspaceName', v_workspace_name,
+      'inviterName', v_inviter_name,
+      'senderId', NEW.invited_by
+    ),
+    'normal'
+  );
+
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING '[notify_on_workspace_invitation_insert] failed for invitation % — %', NEW.id, SQLERRM;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS workspace_invitation_notify_insert ON public.workspace_invitations;
+CREATE TRIGGER workspace_invitation_notify_insert
+AFTER INSERT ON public.workspace_invitations
+FOR EACH ROW
+EXECUTE FUNCTION public.notify_on_workspace_invitation_insert();
+
+REVOKE EXECUTE ON FUNCTION public.notify_on_workspace_invitation_insert() FROM PUBLIC, anon, authenticated;
+COMMENT ON FUNCTION public.notify_on_workspace_invitation_insert IS '워크스페이스 초대 발송 시 invitee 에게 인앱 알림 INSERT (push 발송은 기존 trigger 가 처리).';


### PR DESCRIPTION
## Summary

PR #1 (M1 schema) 위에 stack — 워크스페이스 application layer.

- 6 SECURITY DEFINER RPC + pg_cron 만료 + 인앱 알림 trigger (3 마이그레이션)
- 도메인 타입 + Zod 스키마 (XSS refine + 길이/UUID 강제)
- 11 도메인 에러 코드 (E6080~E6090) + RPC 에러 토큰 매퍼
- 3 Repository (Workspace / WorkspaceMember / WorkspaceInvitation)
- 2 Service (workspaceService, workspaceInvitationService) — 권한 체크 RLS 단독
- 11 TanStack Query Hook (조회 4 + mutation 7) + queryKeys.workspaces 5 키
- 알림 타입 WORKSPACE_INVITATION + 4 exhaustive Record 갱신 + 3 deeplink 라우트

## Race condition 대응 (CRITICAL)

- accept_workspace_invitation: SELECT FOR UPDATE → status check → ON CONFLICT DO NOTHING (idempotent)
- workspace_invitations partial unique index (WHERE status='pending') 가 동시 INSERT 차단
- workspace_members composite PK 가 동시 멤버 INSERT 차단
- DB smoke test 통과 (composite PK, partial unique, ON CONFLICT 멱등성 직접 검증)

## Test plan

- [x] MCP apply_migration 3건 성공 (RPC + cron + notify trigger)
- [x] DB smoke test (race / 멱등성) 통과
- [x] schema test 12/12 + error mapping test 11/11 통과
- [x] NotificationRouteMap drift guard 18/18 통과 (43 → 44)
- [x] npm run quality 통과 (typecheck + lint 0 errors + format clean)
- [x] 전체 Jest 3919/3922 통과 (실패 3건 — scheduleService 2건 master 사전 결함, 이미 PR #1에서 인지)
- [x] supabase advisors 신규 critical 0건 (authenticated_security_definer 0029 lint은 의도적 — 기존 RPC 와 동일 패턴)

## 권한 모델 (D2 + Eng C1)

- workspaces RLS: SELECT (owner+멤버), INSERT (employer/admin + cap 10), UPDATE (owner)
- workspace_members SELECT 만 (write 는 RPC)
- workspace_invitations SELECT 만 (write 는 RPC)
- 모든 mutating RPC: SECURITY DEFINER + auth.uid() 체크 + owner/invitee 매칭

## 다음 PR

PR #3: UI 워크스페이스 설정 + 초대 흐름 (3 화면 + 11 surface specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)