### PR TITLE
feat(workspace): PR #5 — M3 workspace_id NOT NULL + RLS 통합 (M4 deferred)

### DIFF
--- a/uniqn-mobile/__tests__/schema/workspaceSchema.test.ts
+++ b/uniqn-mobile/__tests__/schema/workspaceSchema.test.ts
@@ -96,14 +96,18 @@ describe('workspace schema (PR #1 — M1 migration)', () => {
     expect(typeof returnsValid).toBe('boolean');
   });
 
-  it('job_postings 테이블 — workspace_id 컬럼 추가 (nullable, PR #5 NOT NULL 전환 예정)', () => {
+  it('job_postings 테이블 — workspace_id NOT NULL (PR #5 M3 전환 완료)', () => {
     type Row = PublicTables['job_postings']['Row'];
-    // workspace_id nullable check — must accept null AND uuid
-    const withNullWorkspace: Pick<Row, 'workspace_id'> = { workspace_id: null };
-    const withWorkspace: Pick<Row, 'workspace_id'> = {
-      workspace_id: '00000000-0000-0000-0000-000000000010',
+    type Insert = PublicTables['job_postings']['Insert'];
+    // M3 후 workspace_id 는 string (nullable 아님)
+    const row: Pick<Row, 'workspace_id'> = {
+      workspace_id: '123e4567-e89b-42d3-a456-426614174010',
     };
-    expect(withNullWorkspace.workspace_id).toBeNull();
-    expect(withWorkspace.workspace_id).toBeTruthy();
+    expect(row.workspace_id).toBeTruthy();
+
+    // Insert 시에도 필수 — 빌드 타임 에러 방어
+    // @ts-expect-error — workspace_id 가 NOT NULL 이라 Insert 에서 null 거부
+    const _shouldFail: Pick<Insert, 'workspace_id'> = { workspace_id: null };
+    expect(_shouldFail).toBeDefined();
   });
 });

--- a/uniqn-mobile/app/(employer)/workspace/_layout.tsx
+++ b/uniqn-mobile/app/(employer)/workspace/_layout.tsx
@@ -1,0 +1,17 @@
+/**
+ * UNIQN Mobile - Workspace Stack Layout
+ * 공고 워크스페이스 협업 (PR #3) — 3 화면 (index / invite / invitations)
+ */
+
+import { Stack } from 'expo-router';
+
+export default function WorkspaceLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        animation: 'slide_from_right',
+      }}
+    />
+  );
+}

--- a/uniqn-mobile/app/(employer)/workspace/index.tsx
+++ b/uniqn-mobile/app/(employer)/workspace/index.tsx
@@ -1,0 +1,285 @@
+/**
+ * UNIQN Mobile - Workspace Settings Screen (S1)
+ *
+ * @description 공고 워크스페이스 협업 편집 (PR #3)
+ *              - owner / editor 모두 표시
+ *              - owner 만 [멤버 초대] / 이름 변경 / 멤버 제거 노출 (UI 분기)
+ *              - RLS 가 진짜 게이트
+ */
+
+import { useCallback, useState } from 'react';
+import { View, Text, ScrollView, Pressable, ActivityIndicator, Alert } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { router } from 'expo-router';
+import { StackHeader } from '@/components/headers';
+import { Avatar, Badge, Button, EmptyState, ErrorState, Input } from '@/components/ui';
+import { useAuthStore } from '@/stores/authStore';
+import { useToastStore } from '@/stores/toastStore';
+import {
+  useWorkspaces,
+  useWorkspaceMembers,
+  useUpdateWorkspaceName,
+  useRemoveWorkspaceMember,
+  useCreateWorkspace,
+} from '@/hooks/workspace';
+import { logger } from '@/utils/logger';
+import { isAppError } from '@/errors';
+import type { Workspace, WorkspaceMemberWithUser } from '@/types/workspace';
+
+export default function WorkspaceSettingsScreen() {
+  const { user } = useAuthStore();
+  const { addToast } = useToastStore();
+  const { workspaces, isLoading, error } = useWorkspaces();
+
+  // 첫 로그인 후 워크스페이스가 없으면 자동 안내, 1+ 있으면 첫 번째를 활성으로 표시
+  const activeWorkspace: Workspace | undefined = workspaces[0];
+  const isOwner = !!user?.uid && activeWorkspace?.ownerId === user.uid;
+
+  const { members, isLoading: membersLoading } = useWorkspaceMembers(
+    activeWorkspace?.id,
+    activeWorkspace?.ownerId
+  );
+
+  const updateNameMutation = useUpdateWorkspaceName(activeWorkspace?.id);
+  const removeMemberMutation = useRemoveWorkspaceMember(activeWorkspace?.id);
+  const createMutation = useCreateWorkspace();
+
+  const [editingName, setEditingName] = useState(false);
+  const [nameDraft, setNameDraft] = useState('');
+
+  const handleSaveName = useCallback(async () => {
+    if (!activeWorkspace || !nameDraft.trim()) {
+      setEditingName(false);
+      return;
+    }
+    try {
+      await updateNameMutation.mutateAsync(nameDraft.trim());
+      addToast({ type: 'success', message: '워크스페이스 이름이 변경되었어요' });
+      setEditingName(false);
+    } catch (err) {
+      logger.warn('워크스페이스 이름 변경 실패', { error: String(err) });
+      const message =
+        isAppError(err) && err.userMessage ? err.userMessage : '이름 변경에 실패했어요';
+      addToast({ type: 'error', message });
+    }
+  }, [activeWorkspace, nameDraft, updateNameMutation, addToast]);
+
+  const handleRemoveMember = useCallback(
+    (member: WorkspaceMemberWithUser) => {
+      Alert.alert(
+        '멤버 제거',
+        `${member.displayName ?? member.email ?? '멤버'}님을 워크스페이스에서 제거할까요? 권한이 즉시 회수됩니다.`,
+        [
+          { text: '취소', style: 'cancel' },
+          {
+            text: '제거',
+            style: 'destructive',
+            onPress: async () => {
+              try {
+                await removeMemberMutation.mutateAsync(member.userId);
+                addToast({ type: 'success', message: '멤버를 제거했어요' });
+              } catch (err) {
+                const message =
+                  isAppError(err) && err.userMessage ? err.userMessage : '제거에 실패했어요';
+                addToast({ type: 'error', message });
+              }
+            },
+          },
+        ]
+      );
+    },
+    [removeMemberMutation, addToast]
+  );
+
+  const handleCreateFirstWorkspace = useCallback(async () => {
+    try {
+      const created = await createMutation.mutateAsync(`${user?.displayName ?? '내'} 워크스페이스`);
+      addToast({ type: 'success', message: '워크스페이스가 생성되었어요' });
+      logger.info('첫 워크스페이스 생성', { workspaceId: created.id });
+    } catch (err) {
+      const message =
+        isAppError(err) && err.userMessage ? err.userMessage : '워크스페이스 생성에 실패했어요';
+      addToast({ type: 'error', message });
+    }
+  }, [createMutation, user?.displayName, addToast]);
+
+  if (isLoading) {
+    return (
+      <SafeAreaView
+        className="flex-1 items-center justify-center bg-surface-page dark:bg-surface"
+        edges={['top', 'bottom']}
+      >
+        <StackHeader title="워크스페이스" />
+        <ActivityIndicator size="large" />
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView className="flex-1 bg-surface-page dark:bg-surface" edges={['top', 'bottom']}>
+        <StackHeader title="워크스페이스" />
+        <View className="flex-1 items-center justify-center px-6">
+          <ErrorState
+            title="워크스페이스를 불러올 수 없어요"
+            message="네트워크 상태를 확인하고 다시 시도해주세요."
+          />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!activeWorkspace) {
+    return (
+      <SafeAreaView className="flex-1 bg-surface-page dark:bg-surface" edges={['top', 'bottom']}>
+        <StackHeader title="워크스페이스" />
+        <View className="flex-1 items-center justify-center px-6">
+          <EmptyState
+            title="워크스페이스가 없어요"
+            description="공고 협업을 위해 워크스페이스를 만들어보세요."
+          />
+          <View className="mt-6 w-full max-w-xs">
+            <Button
+              variant="primary"
+              onPress={handleCreateFirstWorkspace}
+              loading={createMutation.isPending}
+            >
+              첫 워크스페이스 만들기
+            </Button>
+          </View>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView className="flex-1 bg-surface-page dark:bg-surface" edges={['top', 'bottom']}>
+      <StackHeader title="워크스페이스" />
+      <ScrollView contentContainerClassName="pb-8">
+        {/* 워크스페이스 헤더 */}
+        <View className="border-b border-secondary-200 bg-white px-4 py-5 dark:border-surface-overlay dark:bg-surface">
+          {editingName ? (
+            <View className="flex-row items-center gap-2">
+              <View className="flex-1">
+                <Input
+                  value={nameDraft}
+                  onChangeText={setNameDraft}
+                  autoFocus
+                  maxLength={50}
+                  placeholder="워크스페이스 이름"
+                />
+              </View>
+              <Button
+                variant="primary"
+                size="sm"
+                onPress={handleSaveName}
+                loading={updateNameMutation.isPending}
+              >
+                저장
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onPress={() => {
+                  setEditingName(false);
+                  setNameDraft('');
+                }}
+              >
+                취소
+              </Button>
+            </View>
+          ) : (
+            <View className="flex-row items-center justify-between">
+              <View className="flex-1">
+                <Text className="text-xl font-display text-content-primary">
+                  {activeWorkspace.name}
+                </Text>
+                <Text className="mt-1 text-sm text-content-secondary">
+                  멤버 {activeWorkspace.memberCount + 1}명 · {isOwner ? '소유자' : '편집자'}
+                </Text>
+              </View>
+              {isOwner && (
+                <Pressable
+                  onPress={() => {
+                    setNameDraft(activeWorkspace.name);
+                    setEditingName(true);
+                  }}
+                  hitSlop={8}
+                  accessibilityRole="button"
+                  accessibilityLabel="워크스페이스 이름 변경"
+                >
+                  <Text className="text-sm font-sans-medium text-primary-500">이름 변경</Text>
+                </Pressable>
+              )}
+            </View>
+          )}
+        </View>
+
+        {/* 멤버 섹션 */}
+        <View className="mt-4 px-4">
+          <View className="mb-3 flex-row items-center justify-between">
+            <Text className="text-base font-display text-content-primary">멤버</Text>
+            {isOwner && (
+              <Button
+                variant="primary"
+                size="sm"
+                onPress={() =>
+                  router.push({
+                    pathname: '/(employer)/workspace/invite',
+                    params: { workspaceId: activeWorkspace.id },
+                  })
+                }
+              >
+                + 초대
+              </Button>
+            )}
+          </View>
+
+          {membersLoading ? (
+            <ActivityIndicator size="small" />
+          ) : members.length === 0 ? (
+            <View className="items-center py-8">
+              <EmptyState
+                title="아직 멤버가 없어요"
+                description={isOwner ? '편집자를 초대해보세요.' : ''}
+              />
+            </View>
+          ) : (
+            members.map((member) => (
+              <View
+                key={member.userId}
+                className="mb-2 flex-row items-center rounded-md bg-white p-3 dark:bg-surface-elevated"
+              >
+                <Avatar
+                  source={member.photoUrl ?? undefined}
+                  name={member.displayName ?? member.email ?? '?'}
+                  size="md"
+                />
+                <View className="ml-3 flex-1">
+                  <Text className="text-sm font-sans-medium text-content-primary">
+                    {member.displayName ?? '익명'}
+                  </Text>
+                  <Text className="text-xs text-content-secondary">{member.email ?? ''}</Text>
+                </View>
+                <Badge variant="info" size="sm">
+                  편집자
+                </Badge>
+                {isOwner && (
+                  <Pressable
+                    onPress={() => handleRemoveMember(member)}
+                    hitSlop={8}
+                    accessibilityRole="button"
+                    accessibilityLabel="멤버 제거"
+                    className="ml-3"
+                  >
+                    <Text className="text-sm text-danger-500">제거</Text>
+                  </Pressable>
+                )}
+              </View>
+            ))
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/uniqn-mobile/app/(employer)/workspace/invitations.tsx
+++ b/uniqn-mobile/app/(employer)/workspace/invitations.tsx
@@ -1,0 +1,176 @@
+/**
+ * UNIQN Mobile - Workspace Invitations Received Screen (S3)
+ *
+ * @description 본인이 받은 pending 초대 목록 (PR #3)
+ *              수락 / 거절 모두 atomic RPC 경유.
+ *              만료 초대는 D3 pg_cron 으로 자동 expired 전환됨.
+ */
+
+import { useCallback } from 'react';
+import { View, Text, RefreshControl, ActivityIndicator } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { FlashList } from '@shopify/flash-list';
+import { router } from 'expo-router';
+import { StackHeader } from '@/components/headers';
+import { Avatar, Badge, Button, EmptyState, ErrorState } from '@/components/ui';
+import { useToastStore } from '@/stores/toastStore';
+import {
+  useReceivedWorkspaceInvitations,
+  useAcceptWorkspaceInvitation,
+  useRejectWorkspaceInvitation,
+} from '@/hooks/workspace';
+import { logger } from '@/utils/logger';
+import { isAppError } from '@/errors';
+import type { ReceivedWorkspaceInvitation } from '@/types/workspace';
+
+function formatExpiresAt(expiresAtIso: string): string {
+  const d = new Date(expiresAtIso);
+  if (Number.isNaN(d.getTime())) return '';
+  const month = d.getMonth() + 1;
+  const day = d.getDate();
+  return `${month}월 ${day}일까지 수락 가능`;
+}
+
+export default function WorkspaceInvitationsScreen() {
+  const { addToast } = useToastStore();
+  const { invitations, isLoading, error, refetch } = useReceivedWorkspaceInvitations();
+  const acceptMutation = useAcceptWorkspaceInvitation();
+  const rejectMutation = useRejectWorkspaceInvitation();
+
+  const handleAccept = useCallback(
+    async (invitation: ReceivedWorkspaceInvitation) => {
+      try {
+        const result = await acceptMutation.mutateAsync(invitation.id);
+        if (result.idempotent) {
+          addToast({ type: 'info', message: '이미 참여 중인 워크스페이스입니다' });
+        } else {
+          addToast({ type: 'success', message: '워크스페이스에 참여했어요' });
+        }
+        router.replace('/(employer)/workspace');
+      } catch (err) {
+        logger.warn('초대 수락 실패', { error: String(err) });
+        const message = isAppError(err) && err.userMessage ? err.userMessage : '수락에 실패했어요';
+        addToast({ type: 'error', message });
+      }
+    },
+    [acceptMutation, addToast]
+  );
+
+  const handleReject = useCallback(
+    async (invitation: ReceivedWorkspaceInvitation) => {
+      try {
+        await rejectMutation.mutateAsync(invitation.id);
+        addToast({ type: 'info', message: '초대를 거절했어요' });
+      } catch (err) {
+        logger.warn('초대 거절 실패', { error: String(err) });
+        const message = isAppError(err) && err.userMessage ? err.userMessage : '거절에 실패했어요';
+        addToast({ type: 'error', message });
+      }
+    },
+    [rejectMutation, addToast]
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: ReceivedWorkspaceInvitation }) => (
+      <View className="mx-4 mb-3 rounded-md bg-white p-4 dark:bg-surface-elevated">
+        <View className="flex-row items-start">
+          <Avatar name={item.workspaceName || '워크스페이스'} size="md" />
+          <View className="ml-3 flex-1">
+            <Text className="text-base font-sans-medium text-content-primary">
+              {item.workspaceName || '워크스페이스'}
+            </Text>
+            <Text className="mt-0.5 text-xs text-content-secondary">
+              {item.inviterDisplayName ?? '누군가'}님이 초대 · {formatExpiresAt(item.expiresAt)}
+            </Text>
+          </View>
+          <Badge variant="info" size="sm">
+            편집자
+          </Badge>
+        </View>
+
+        <Text className="mt-3 text-xs text-content-secondary">
+          {item.workspaceName} 워크스페이스의 편집자가 되면, 이 워크스페이스의 모든 공고를 만들고
+          수정할 수 있어요. 삭제는 소유자만 가능해요.
+        </Text>
+
+        <View className="mt-4 flex-row gap-2">
+          <View className="flex-1">
+            <Button
+              variant="ghost"
+              onPress={() => handleReject(item)}
+              loading={rejectMutation.isPending && rejectMutation.variables === item.id}
+            >
+              거절
+            </Button>
+          </View>
+          <View className="flex-1">
+            <Button
+              variant="primary"
+              onPress={() => handleAccept(item)}
+              loading={acceptMutation.isPending && acceptMutation.variables === item.id}
+            >
+              수락
+            </Button>
+          </View>
+        </View>
+      </View>
+    ),
+    [
+      acceptMutation.isPending,
+      acceptMutation.variables,
+      handleAccept,
+      handleReject,
+      rejectMutation.isPending,
+      rejectMutation.variables,
+    ]
+  );
+
+  if (isLoading) {
+    return (
+      <SafeAreaView
+        className="flex-1 items-center justify-center bg-surface-page dark:bg-surface"
+        edges={['top', 'bottom']}
+      >
+        <StackHeader title="받은 초대" />
+        <ActivityIndicator size="large" />
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView className="flex-1 bg-surface-page dark:bg-surface" edges={['top', 'bottom']}>
+        <StackHeader title="받은 초대" />
+        <View className="flex-1 items-center justify-center px-6">
+          <ErrorState
+            title="초대를 불러올 수 없어요"
+            message="네트워크 상태를 확인하고 다시 시도해주세요."
+          />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView className="flex-1 bg-surface-page dark:bg-surface" edges={['top', 'bottom']}>
+      <StackHeader title="받은 초대" />
+      <FlashList
+        data={invitations}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        // @ts-expect-error - estimatedItemSize is required in FlashList 2.x but types may be missing
+        estimatedItemSize={140}
+        refreshControl={<RefreshControl refreshing={false} onRefresh={refetch} />}
+        contentContainerClassName="pt-3 pb-8"
+        ListEmptyComponent={
+          <View className="items-center px-6 py-12">
+            <EmptyState
+              title="받은 초대가 없어요"
+              description="워크스페이스 소유자가 초대하면 여기에 표시됩니다."
+            />
+          </View>
+        }
+      />
+    </SafeAreaView>
+  );
+}

--- a/uniqn-mobile/app/(employer)/workspace/invite.tsx
+++ b/uniqn-mobile/app/(employer)/workspace/invite.tsx
@@ -1,0 +1,183 @@
+/**
+ * UNIQN Mobile - Workspace Invite Screen (S2)
+ *
+ * @description 공고 워크스페이스 협업 편집 (PR #3)
+ *              owner 만 진입 가능 — 이메일 정확 매칭으로 사용자 lookup 후 초대.
+ *              Phase 2: 외부 이메일 + 매직 링크 (workspace_invitations.invitee_email 추가).
+ */
+
+import { useCallback, useState } from 'react';
+import { View, Text, ScrollView, ActivityIndicator } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { router, useLocalSearchParams } from 'expo-router';
+import { StackHeader } from '@/components/headers';
+import { Avatar, Button, EmptyState, Input } from '@/components/ui';
+import { useToastStore } from '@/stores/toastStore';
+import { useInviteWorkspaceMember } from '@/hooks/workspace';
+import { workspaceService } from '@/services/workspace';
+import { logger } from '@/utils/logger';
+import { isAppError } from '@/errors';
+
+interface LookupResult {
+  id: string;
+  name: string | null;
+  email: string;
+  photoUrl: string | null;
+}
+
+export default function WorkspaceInviteScreen() {
+  const { workspaceId } = useLocalSearchParams<{ workspaceId: string }>();
+  const { addToast } = useToastStore();
+  const [emailDraft, setEmailDraft] = useState('');
+  const [isSearching, setIsSearching] = useState(false);
+  const [lookupResult, setLookupResult] = useState<LookupResult | null>(null);
+  const [searchError, setSearchError] = useState<string | null>(null);
+
+  const inviteMutation = useInviteWorkspaceMember();
+
+  const handleSearch = useCallback(async () => {
+    const trimmed = emailDraft.trim();
+    if (!trimmed) {
+      setLookupResult(null);
+      setSearchError(null);
+      return;
+    }
+
+    if (!trimmed.includes('@')) {
+      setSearchError('이메일 형식을 확인해주세요');
+      setLookupResult(null);
+      return;
+    }
+
+    setIsSearching(true);
+    setSearchError(null);
+    try {
+      const found = await workspaceService.lookupUserByEmail(trimmed);
+      setLookupResult(found);
+      if (!found) {
+        setSearchError('등록된 사용자를 찾을 수 없어요');
+      }
+    } catch (err) {
+      logger.warn('사용자 검색 실패', { error: String(err) });
+      setSearchError('검색에 실패했어요. 다시 시도해주세요.');
+    } finally {
+      setIsSearching(false);
+    }
+  }, [emailDraft]);
+
+  const handleInvite = useCallback(async () => {
+    if (!workspaceId || !lookupResult) return;
+    try {
+      await inviteMutation.mutateAsync({
+        workspaceId,
+        inviteeUserId: lookupResult.id,
+      });
+      addToast({ type: 'success', message: '초대를 보냈어요' });
+      router.back();
+    } catch (err) {
+      logger.warn('초대 발송 실패', { error: String(err) });
+      const message =
+        isAppError(err) && err.userMessage ? err.userMessage : '초대 발송에 실패했어요';
+      addToast({ type: 'error', message });
+    }
+  }, [workspaceId, lookupResult, inviteMutation, addToast]);
+
+  if (!workspaceId) {
+    return (
+      <SafeAreaView className="flex-1 bg-surface-page dark:bg-surface" edges={['top', 'bottom']}>
+        <StackHeader title="멤버 초대" />
+        <View className="flex-1 items-center justify-center px-6">
+          <EmptyState
+            title="워크스페이스를 선택해주세요"
+            description="이전 화면으로 돌아가 다시 시도해주세요."
+          />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView className="flex-1 bg-surface-page dark:bg-surface" edges={['top', 'bottom']}>
+      <StackHeader title="멤버 초대" />
+      <ScrollView contentContainerClassName="pb-8" keyboardShouldPersistTaps="handled">
+        <View className="px-4 pt-4">
+          <Text className="mb-2 text-sm font-sans-medium text-content-primary">
+            등록된 사용자 이메일
+          </Text>
+          <View className="flex-row items-center gap-2">
+            <View className="flex-1">
+              <Input
+                value={emailDraft}
+                onChangeText={(t) => {
+                  setEmailDraft(t);
+                  setLookupResult(null);
+                  setSearchError(null);
+                }}
+                placeholder="user@example.com"
+                keyboardType="email-address"
+                autoCapitalize="none"
+                autoCorrect={false}
+                returnKeyType="search"
+                onSubmitEditing={handleSearch}
+              />
+            </View>
+            <Button
+              variant="primary"
+              size="md"
+              onPress={handleSearch}
+              loading={isSearching}
+              disabled={isSearching || !emailDraft.trim()}
+            >
+              검색
+            </Button>
+          </View>
+
+          {searchError && <Text className="mt-2 text-xs text-danger-500">{searchError}</Text>}
+        </View>
+
+        {/* 결과 영역 */}
+        <View className="mt-6 px-4">
+          {isSearching ? (
+            <View className="items-center py-8">
+              <ActivityIndicator size="small" />
+            </View>
+          ) : lookupResult ? (
+            <View className="rounded-md bg-white p-4 dark:bg-surface-elevated">
+              <View className="flex-row items-center">
+                <Avatar
+                  source={lookupResult.photoUrl ?? undefined}
+                  name={lookupResult.name ?? lookupResult.email}
+                  size="md"
+                />
+                <View className="ml-3 flex-1">
+                  <Text className="text-base font-sans-medium text-content-primary">
+                    {lookupResult.name ?? '익명'}
+                  </Text>
+                  <Text className="text-sm text-content-secondary">{lookupResult.email}</Text>
+                </View>
+              </View>
+              <Text className="mt-3 text-xs text-content-secondary">
+                초대를 수락하면 이 워크스페이스의 모든 공고를 만들고 수정할 수 있어요. 삭제는
+                소유자만 가능해요.
+              </Text>
+              <View className="mt-4">
+                <Button variant="primary" onPress={handleInvite} loading={inviteMutation.isPending}>
+                  편집자로 초대
+                </Button>
+              </View>
+            </View>
+          ) : (
+            !searchError && (
+              <View className="items-center py-12">
+                <EmptyState
+                  title="이메일을 입력해주세요"
+                  description="등록된 사용자 이메일로 검색하면 초대할 수 있어요."
+                />
+              </View>
+            )
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/uniqn-mobile/src/components/notifications/NotificationIcon.tsx
+++ b/uniqn-mobile/src/components/notifications/NotificationIcon.tsx
@@ -94,6 +94,9 @@ const typeIcons: Partial<Record<NotificationType, IconComponent>> = {
   [NotificationType.REVIEW_REQUEST]: ChatBubbleLeftIcon,
   [NotificationType.REVIEW_RECEIVED]: CheckCircleIcon,
   [NotificationType.REVIEW_REMINDER]: ClockIcon,
+
+  // 워크스페이스 협업 (PR #2)
+  [NotificationType.WORKSPACE_INVITATION]: BriefcaseIcon,
 };
 
 // 카테고리별 색상 (Black & Gold v3.0)

--- a/uniqn-mobile/src/constants/notificationTemplates.ts
+++ b/uniqn-mobile/src/constants/notificationTemplates.ts
@@ -370,6 +370,14 @@ export const NotificationTemplates: Record<NotificationType, NotificationTemplat
     link: (d) => `/reviews/${d.workLogId}`,
     icon: '⏰',
   },
+
+  // 워크스페이스 협업 (PR #2)
+  [NotificationType.WORKSPACE_INVITATION]: {
+    title: (d) => `${d.inviterName ?? '누군가'}님이 워크스페이스에 초대했어요`,
+    body: (d) => `${d.workspaceName ?? '워크스페이스'} · 편집자 권한`,
+    link: () => `/workspace/invitations`,
+    icon: '🤝',
+  },
 };
 
 // ============================================================================

--- a/uniqn-mobile/src/errors/__tests__/workspace.test.ts
+++ b/uniqn-mobile/src/errors/__tests__/workspace.test.ts
@@ -1,0 +1,90 @@
+/**
+ * PR #2 — workspace RPC 에러 매핑 테스트
+ */
+
+import { mapWorkspaceRpcError, WORKSPACE_ERROR_CODES } from '@/errors/workspace';
+import { isAuthError, isPermissionError, isBusinessError, isValidationError } from '@/errors';
+
+describe('mapWorkspaceRpcError (PR #2)', () => {
+  it('AUTH_REQUIRED → AuthError', () => {
+    const err = mapWorkspaceRpcError({ message: 'AUTH_REQUIRED' });
+    expect(err).not.toBeNull();
+    expect(isAuthError(err!)).toBe(true);
+  });
+
+  it('PERMISSION_DENIED → PermissionError + 권한 회수 메시지', () => {
+    const err = mapWorkspaceRpcError({ message: 'PERMISSION_DENIED' });
+    expect(err).not.toBeNull();
+    expect(isPermissionError(err!)).toBe(true);
+    expect(err!.userMessage).toContain('권한이 회수');
+  });
+
+  it('SELF_INVITE_FORBIDDEN → ValidationError', () => {
+    const err = mapWorkspaceRpcError({ message: 'SELF_INVITE_FORBIDDEN' });
+    expect(err).not.toBeNull();
+    expect(isValidationError(err!)).toBe(true);
+    expect(err!.code).toBe(WORKSPACE_ERROR_CODES.WORKSPACE_SELF_INVITE);
+  });
+
+  it('CANNOT_REMOVE_OWNER → ValidationError', () => {
+    const err = mapWorkspaceRpcError({ message: 'CANNOT_REMOVE_OWNER' });
+    expect(err).not.toBeNull();
+    expect(isValidationError(err!)).toBe(true);
+  });
+
+  it('ALREADY_MEMBER → BusinessError', () => {
+    const err = mapWorkspaceRpcError({ message: 'ALREADY_MEMBER' });
+    expect(err).not.toBeNull();
+    expect(isBusinessError(err!)).toBe(true);
+    expect(err!.code).toBe(WORKSPACE_ERROR_CODES.WORKSPACE_ALREADY_MEMBER);
+  });
+
+  it('ALREADY_INVITED → BusinessError', () => {
+    const err = mapWorkspaceRpcError({ message: 'ALREADY_INVITED' });
+    expect(err).not.toBeNull();
+    expect(err!.code).toBe(WORKSPACE_ERROR_CODES.WORKSPACE_ALREADY_INVITED);
+  });
+
+  it('INVITATION_EXPIRED → BusinessError + 만료 메시지', () => {
+    const err = mapWorkspaceRpcError({ message: 'INVITATION_EXPIRED' });
+    expect(err).not.toBeNull();
+    expect(err!.code).toBe(WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_EXPIRED);
+    expect(err!.userMessage).toContain('만료된 초대');
+  });
+
+  it('INVITATION_REJECTED / REVOKED / ACCEPTED 각각 별도 코드', () => {
+    expect(mapWorkspaceRpcError({ message: 'INVITATION_REJECTED' })?.code).toBe(
+      WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_REJECTED
+    );
+    expect(mapWorkspaceRpcError({ message: 'INVITATION_REVOKED' })?.code).toBe(
+      WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_REVOKED
+    );
+    expect(mapWorkspaceRpcError({ message: 'INVITATION_ACCEPTED' })?.code).toBe(
+      WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_ACCEPTED
+    );
+  });
+
+  it('INVITATION_NOT_FOUND / WORKSPACE_NOT_FOUND', () => {
+    expect(mapWorkspaceRpcError({ message: 'INVITATION_NOT_FOUND' })?.code).toBe(
+      WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_NOT_FOUND
+    );
+    expect(mapWorkspaceRpcError({ message: 'WORKSPACE_NOT_FOUND' })?.code).toBe(
+      WORKSPACE_ERROR_CODES.WORKSPACE_NOT_FOUND
+    );
+  });
+
+  it('RLS cap 도달 → CAP_REACHED', () => {
+    const err = mapWorkspaceRpcError({
+      message: 'new row violates row-level security policy',
+    });
+    expect(err).not.toBeNull();
+    expect(err!.code).toBe(WORKSPACE_ERROR_CODES.WORKSPACE_CAP_REACHED);
+    expect(err!.userMessage).toContain('10개');
+  });
+
+  it('알 수 없는 에러 → null (호출자가 일반 처리)', () => {
+    expect(mapWorkspaceRpcError({ message: 'SOME_RANDOM_ERROR' })).toBeNull();
+    expect(mapWorkspaceRpcError(null)).toBeNull();
+    expect(mapWorkspaceRpcError({})).toBeNull();
+  });
+});

--- a/uniqn-mobile/src/errors/workspace.ts
+++ b/uniqn-mobile/src/errors/workspace.ts
@@ -1,0 +1,130 @@
+/**
+ * UNIQN Mobile - 워크스페이스 RPC 에러 매핑
+ *
+ * @description PR #2 — invite/accept/reject/revoke RPC 에러 → AppError 변환.
+ *              DB 함수가 RAISE EXCEPTION 'CODE_NAME' 으로 던진 에러를 잡아 도메인 에러로 변환.
+ * @version 1.0.0
+ */
+
+import {
+  AuthError,
+  BusinessError,
+  PermissionError,
+  ValidationError,
+  ERROR_CODES,
+  AppError,
+} from './AppError';
+
+/**
+ * 워크스페이스 도메인 에러 코드 (E6 비즈니스)
+ */
+export const WORKSPACE_ERROR_CODES = {
+  WORKSPACE_NOT_FOUND: 'E6080',
+  WORKSPACE_INVITATION_NOT_FOUND: 'E6081',
+  WORKSPACE_ALREADY_MEMBER: 'E6082',
+  WORKSPACE_ALREADY_INVITED: 'E6083',
+  WORKSPACE_INVITATION_EXPIRED: 'E6084',
+  WORKSPACE_INVITATION_REJECTED: 'E6085',
+  WORKSPACE_INVITATION_REVOKED: 'E6086',
+  WORKSPACE_INVITATION_ACCEPTED: 'E6087',
+  WORKSPACE_SELF_INVITE: 'E6088',
+  WORKSPACE_CANNOT_REMOVE_OWNER: 'E6089',
+  WORKSPACE_CAP_REACHED: 'E6090',
+} as const;
+
+const WORKSPACE_ERROR_USER_MESSAGES: Record<string, string> = {
+  [WORKSPACE_ERROR_CODES.WORKSPACE_NOT_FOUND]: '워크스페이스를 찾을 수 없습니다.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_NOT_FOUND]: '초대를 찾을 수 없습니다.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_ALREADY_MEMBER]: '이미 워크스페이스 멤버입니다.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_ALREADY_INVITED]:
+    '이미 초대 보류 중입니다. 상대방의 응답을 기다려주세요.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_EXPIRED]:
+    '만료된 초대예요. 워크스페이스 소유자에게 다시 초대를 요청해주세요.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_REJECTED]: '이미 거절한 초대입니다.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_REVOKED]: '회수된 초대입니다.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_ACCEPTED]: '이미 수락된 초대입니다.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_SELF_INVITE]: '본인은 초대할 수 없습니다.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_CANNOT_REMOVE_OWNER]:
+    '워크스페이스 소유자는 멤버에서 제외할 수 없습니다.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_CAP_REACHED]:
+    '워크스페이스는 사용자당 최대 10개까지 만들 수 있어요. 사용하지 않는 워크스페이스를 정리해주세요.',
+};
+
+function makeWorkspaceError(code: string): AppError {
+  const userMessage = WORKSPACE_ERROR_USER_MESSAGES[code];
+  switch (code) {
+    case WORKSPACE_ERROR_CODES.WORKSPACE_SELF_INVITE:
+      return new ValidationError(code, { userMessage });
+    case WORKSPACE_ERROR_CODES.WORKSPACE_CANNOT_REMOVE_OWNER:
+      return new ValidationError(code, { userMessage });
+    default:
+      return new BusinessError(code, { userMessage });
+  }
+}
+
+/**
+ * Postgres / supabase-js 에러 메시지를 AppError 로 매핑.
+ * RPC 가 RAISE EXCEPTION 'CODE_NAME' 으로 던진 토큰을 인식.
+ *
+ * @param error supabase rpc().error 또는 catch 한 unknown
+ * @returns 매핑된 AppError, 매핑 실패 시 null (호출자가 일반 BusinessError 처리)
+ */
+export function mapWorkspaceRpcError(error: unknown): AppError | null {
+  if (!error || typeof error !== 'object') return null;
+  const message = (error as { message?: string }).message;
+  if (typeof message !== 'string') return null;
+
+  // RAISE EXCEPTION 'CODE' → "CODE" 또는 "P0001: CODE" 패턴 모두 처리
+  const upper = message.toUpperCase();
+
+  if (upper.includes('AUTH_REQUIRED'))
+    return new AuthError(ERROR_CODES.AUTH_REQUIRED, {
+      userMessage: '로그인이 필요합니다.',
+    });
+
+  if (upper.includes('PERMISSION_DENIED'))
+    return new PermissionError(ERROR_CODES.INFRA_PERMISSION_DENIED, {
+      userMessage: '워크스페이스 편집 권한이 회수되었어요. 다시 로그인하면 최신 상태가 적용됩니다.',
+    });
+
+  if (upper.includes('SELF_INVITE_FORBIDDEN'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_SELF_INVITE);
+
+  if (upper.includes('CANNOT_REMOVE_OWNER'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_CANNOT_REMOVE_OWNER);
+
+  if (upper.includes('ALREADY_MEMBER'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_ALREADY_MEMBER);
+
+  if (upper.includes('ALREADY_INVITED'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_ALREADY_INVITED);
+
+  // INVITATION_* 매핑 (순서 중요 — 더 구체적인 패턴 먼저)
+  if (upper.includes('INVITATION_EXPIRED'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_EXPIRED);
+
+  if (upper.includes('INVITATION_REJECTED'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_REJECTED);
+
+  if (upper.includes('INVITATION_REVOKED'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_REVOKED);
+
+  if (upper.includes('INVITATION_ACCEPTED'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_ACCEPTED);
+
+  if (upper.includes('INVITATION_NOT_FOUND'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_NOT_FOUND);
+
+  if (upper.includes('WORKSPACE_NOT_FOUND'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_NOT_FOUND);
+
+  // RLS 위반 패턴 — INSERT 정책 거절 (cap 도달 등)
+  if (upper.includes('NEW ROW VIOLATES ROW-LEVEL SECURITY POLICY')) {
+    return new BusinessError(WORKSPACE_ERROR_CODES.WORKSPACE_CAP_REACHED, {
+      userMessage:
+        WORKSPACE_ERROR_USER_MESSAGES[WORKSPACE_ERROR_CODES.WORKSPACE_CAP_REACHED] ?? '권한 부족',
+    });
+  }
+
+  return null;
+}

--- a/uniqn-mobile/src/hooks/workspace/index.ts
+++ b/uniqn-mobile/src/hooks/workspace/index.ts
@@ -1,0 +1,23 @@
+/**
+ * UNIQN Mobile - Workspace Hooks Barrel
+ *
+ * @description 공고 워크스페이스 협업 편집 (PR #2)
+ */
+
+export {
+  useWorkspaces,
+  useWorkspaceMembers,
+  useReceivedWorkspaceInvitations,
+  useWorkspaceInvitationsSent,
+  useInviteWorkspaceMember,
+  useAcceptWorkspaceInvitation,
+  useRejectWorkspaceInvitation,
+  useRevokeWorkspaceInvitation,
+  useRemoveWorkspaceMember,
+  useCreateWorkspace,
+  useUpdateWorkspaceName,
+  type UseWorkspacesResult,
+  type UseWorkspaceMembersResult,
+  type UseReceivedInvitationsResult,
+  type UseSentInvitationsResult,
+} from './useWorkspaces';

--- a/uniqn-mobile/src/hooks/workspace/useWorkspaces.ts
+++ b/uniqn-mobile/src/hooks/workspace/useWorkspaces.ts
@@ -1,0 +1,279 @@
+/**
+ * UNIQN Mobile - useWorkspaces / useWorkspaceMembers / useWorkspaceInvitations Hooks
+ *
+ * @description 워크스페이스 협업 (PR #2) — TanStack Query 기반.
+ *              권한 단일 진실은 DB RLS. UI 분기는 데이터 형태로 구분.
+ * @version 1.0.0
+ */
+
+import { useMemo } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryKeys, cachingPolicies } from '@/lib/queryClient';
+import { useAuthStore } from '@/stores/authStore';
+import { workspaceService, workspaceInvitationService } from '@/services/workspace';
+import type {
+  Workspace,
+  WorkspaceMemberWithUser,
+  ReceivedWorkspaceInvitation,
+  WorkspaceInvitation,
+} from '@/types/workspace';
+
+// ============================================================================
+// useWorkspaces — 사용자가 속한 모든 워크스페이스
+// ============================================================================
+
+export interface UseWorkspacesResult {
+  workspaces: Workspace[];
+  ownedWorkspaces: Workspace[];
+  memberWorkspaces: Workspace[];
+  isLoading: boolean;
+  error: unknown;
+  refetch: () => void;
+}
+
+export function useWorkspaces(): UseWorkspacesResult {
+  const { user } = useAuthStore();
+  const userId = user?.uid;
+
+  const query = useQuery({
+    queryKey: userId
+      ? queryKeys.workspaces.listForUser(userId)
+      : [...queryKeys.workspaces.all, 'list', 'anonymous'],
+    queryFn: () => workspaceService.listWorkspacesForUser(userId!),
+    enabled: !!userId,
+    staleTime: cachingPolicies.frequent,
+  });
+
+  const ownedWorkspaces = useMemo(
+    () => (query.data ?? []).filter((w) => w.ownerId === userId),
+    [query.data, userId]
+  );
+  const memberWorkspaces = useMemo(
+    () => (query.data ?? []).filter((w) => w.ownerId !== userId),
+    [query.data, userId]
+  );
+
+  return {
+    workspaces: query.data ?? [],
+    ownedWorkspaces,
+    memberWorkspaces,
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}
+
+// ============================================================================
+// useWorkspaceMembers — editor 멤버 목록 + 사용자 정보
+// ============================================================================
+
+export interface UseWorkspaceMembersResult {
+  members: WorkspaceMemberWithUser[];
+  isLoading: boolean;
+  error: unknown;
+  /** 현재 사용자가 owner 인지 (UI 분기용 — RLS 가 진짜 게이트) */
+  isOwner: boolean;
+}
+
+export function useWorkspaceMembers(
+  workspaceId: string | undefined,
+  ownerId: string | undefined
+): UseWorkspaceMembersResult {
+  const { user } = useAuthStore();
+
+  const query = useQuery({
+    queryKey: workspaceId
+      ? queryKeys.workspaces.members(workspaceId)
+      : [...queryKeys.workspaces.all, 'members', 'none'],
+    queryFn: () => workspaceService.listMembers(workspaceId!),
+    enabled: !!workspaceId,
+    staleTime: cachingPolicies.frequent,
+  });
+
+  return {
+    members: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+    isOwner: Boolean(ownerId && user?.uid && ownerId === user.uid),
+  };
+}
+
+// ============================================================================
+// useReceivedWorkspaceInvitations — 본인이 받은 pending 초대
+// ============================================================================
+
+export interface UseReceivedInvitationsResult {
+  invitations: ReceivedWorkspaceInvitation[];
+  isLoading: boolean;
+  error: unknown;
+  refetch: () => void;
+}
+
+export function useReceivedWorkspaceInvitations(): UseReceivedInvitationsResult {
+  const { user } = useAuthStore();
+  const userId = user?.uid;
+
+  const query = useQuery({
+    queryKey: userId
+      ? queryKeys.workspaces.invitationsReceived(userId)
+      : [...queryKeys.workspaces.all, 'invitations', 'received', 'anonymous'],
+    queryFn: () => workspaceInvitationService.listPendingForUser(userId!),
+    enabled: !!userId,
+    staleTime: cachingPolicies.frequent,
+  });
+
+  return {
+    invitations: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}
+
+// ============================================================================
+// useWorkspaceInvitationsSent — owner 가 보낸 초대 목록
+// ============================================================================
+
+export interface UseSentInvitationsResult {
+  invitations: WorkspaceInvitation[];
+  isLoading: boolean;
+  error: unknown;
+}
+
+export function useWorkspaceInvitationsSent(
+  workspaceId: string | undefined
+): UseSentInvitationsResult {
+  const query = useQuery({
+    queryKey: workspaceId
+      ? queryKeys.workspaces.invitationsSent(workspaceId)
+      : [...queryKeys.workspaces.all, 'invitations', 'sent', 'none'],
+    queryFn: () => workspaceInvitationService.listByWorkspace(workspaceId!),
+    enabled: !!workspaceId,
+    staleTime: cachingPolicies.frequent,
+  });
+
+  return {
+    invitations: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+  };
+}
+
+// ============================================================================
+// Mutations — invite / accept / reject / revoke / removeMember
+// ============================================================================
+
+export function useInviteWorkspaceMember() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { workspaceId: string; inviteeUserId: string }) =>
+      workspaceInvitationService.invite(input),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.workspaces.invitationsSent(vars.workspaceId),
+      });
+    },
+  });
+}
+
+export function useAcceptWorkspaceInvitation() {
+  const queryClient = useQueryClient();
+  const { user } = useAuthStore();
+  return useMutation({
+    mutationFn: (invitationId: string) => workspaceInvitationService.accept({ invitationId }),
+    onSuccess: () => {
+      // 받은 초대 + 워크스페이스 목록 둘 다 갱신
+      if (user?.uid) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.invitationsReceived(user.uid),
+        });
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.listForUser(user.uid),
+        });
+      }
+    },
+  });
+}
+
+export function useRejectWorkspaceInvitation() {
+  const queryClient = useQueryClient();
+  const { user } = useAuthStore();
+  return useMutation({
+    mutationFn: (invitationId: string) => workspaceInvitationService.reject({ invitationId }),
+    onSuccess: () => {
+      if (user?.uid) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.invitationsReceived(user.uid),
+        });
+      }
+    },
+  });
+}
+
+export function useRevokeWorkspaceInvitation(workspaceId: string | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (invitationId: string) => workspaceInvitationService.revoke({ invitationId }),
+    onSuccess: () => {
+      if (workspaceId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.invitationsSent(workspaceId),
+        });
+      }
+    },
+  });
+}
+
+export function useRemoveWorkspaceMember(workspaceId: string | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (userId: string) =>
+      workspaceService.removeMember({ workspaceId: workspaceId!, userId }),
+    onSuccess: () => {
+      if (workspaceId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.members(workspaceId),
+        });
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.detail(workspaceId),
+        });
+      }
+    },
+  });
+}
+
+export function useCreateWorkspace() {
+  const queryClient = useQueryClient();
+  const { user } = useAuthStore();
+  return useMutation({
+    mutationFn: (name: string) => workspaceService.createWorkspace({ name, ownerId: user!.uid }),
+    onSuccess: () => {
+      if (user?.uid) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.listForUser(user.uid),
+        });
+      }
+    },
+  });
+}
+
+export function useUpdateWorkspaceName(workspaceId: string | undefined) {
+  const queryClient = useQueryClient();
+  const { user } = useAuthStore();
+  return useMutation({
+    mutationFn: (name: string) =>
+      workspaceService.updateWorkspaceName({ workspaceId: workspaceId!, name }),
+    onSuccess: () => {
+      if (workspaceId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.detail(workspaceId),
+        });
+      }
+      if (user?.uid) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.listForUser(user.uid),
+        });
+      }
+    },
+  });
+}

--- a/uniqn-mobile/src/lib/database.types.ts
+++ b/uniqn-mobile/src/lib/database.types.ts
@@ -1990,6 +1990,10 @@ export type Database = {
         Args: { p_compensation: Json };
         Returns: string;
       };
+      accept_workspace_invitation: {
+        Args: { p_invitation_id: string };
+        Returns: Json;
+      };
       apply_with_capacity_check: {
         Args: {
           p_applicant_email?: string;
@@ -2118,6 +2122,7 @@ export type Database = {
       decrement_unread_counter:
         | { Args: { p_notification_id: string }; Returns: undefined }
         | { Args: { p_delta?: number; p_user_id: string }; Returns: undefined };
+      expire_pending_workspace_invitations: { Args: never; Returns: number };
       fn_cleanup_expired_fcm_tokens: { Args: never; Returns: number };
       fn_cleanup_rate_limits: { Args: never; Returns: number };
       fn_expire_by_last_work_date: { Args: never; Returns: number };
@@ -2175,6 +2180,10 @@ export type Database = {
         Returns: undefined;
       };
       increment_view_count: { Args: { posting_id: string }; Returns: undefined };
+      invite_workspace_member: {
+        Args: { p_invitee_user_id: string; p_workspace_id: string };
+        Returns: string;
+      };
       is_admin: { Args: never; Returns: boolean };
       is_employer_or_admin: { Args: never; Returns: boolean };
       is_workspace_member: {
@@ -2205,6 +2214,14 @@ export type Database = {
         Args: { p_app_id: string; p_category?: string; p_reason?: string };
         Returns: Json;
       };
+      reject_workspace_invitation: {
+        Args: { p_invitation_id: string };
+        Returns: undefined;
+      };
+      remove_workspace_member: {
+        Args: { p_user_id: string; p_workspace_id: string };
+        Returns: undefined;
+      };
       reset_unread_counter: { Args: { p_user_id: string }; Returns: undefined };
       review_report: {
         Args: {
@@ -2213,6 +2230,10 @@ export type Database = {
           p_reviewer_notes?: string;
           p_status: string;
         };
+        Returns: undefined;
+      };
+      revoke_workspace_invitation: {
+        Args: { p_invitation_id: string };
         Returns: undefined;
       };
       sync_schedule_board: { Args: { p_job_posting_id: string }; Returns: Json };

--- a/uniqn-mobile/src/lib/database.types.ts
+++ b/uniqn-mobile/src/lib/database.types.ts
@@ -1015,7 +1015,7 @@ export type Database = {
           view_count: number | null;
           work_date: string | null;
           work_dates: string[] | null;
-          workspace_id: string | null;
+          workspace_id: string;
         };
         Insert: {
           closed_at?: string | null;
@@ -1052,7 +1052,7 @@ export type Database = {
           view_count?: number | null;
           work_date?: string | null;
           work_dates?: string[] | null;
-          workspace_id?: string | null;
+          workspace_id: string;
         };
         Update: {
           closed_at?: string | null;
@@ -1089,7 +1089,7 @@ export type Database = {
           view_count?: number | null;
           work_date?: string | null;
           work_dates?: string[] | null;
-          workspace_id?: string | null;
+          workspace_id?: string;
         };
         Relationships: [
           {

--- a/uniqn-mobile/src/lib/featureFlags.ts
+++ b/uniqn-mobile/src/lib/featureFlags.ts
@@ -1,0 +1,50 @@
+/**
+ * UNIQN Mobile - Feature Flags
+ *
+ * @description 기능 출시 단계 게이트 (PR #4 — workspace collaboration)
+ * @version 1.0.0
+ *
+ * 정책:
+ *  - 권한 단일 진실은 RLS. 본 플래그는 UI 노출 + 일부 흐름 가드 용도.
+ *  - 환경 변수 EXPO_PUBLIC_<FLAG_NAME>=false 로 빌드 타임 비활성화 가능.
+ *  - 배포 후 ON/OFF 전환은 새 빌드 필요 (서버 사이드 토글이 필요하면 app_config 도입 후속 PR).
+ */
+
+function parseBoolean(raw: string | undefined, defaultValue: boolean): boolean {
+  if (raw === undefined || raw === null || raw === '') {
+    return defaultValue;
+  }
+  const lowered = String(raw).toLowerCase().trim();
+  if (lowered === 'false' || lowered === '0' || lowered === 'no' || lowered === 'off') {
+    return false;
+  }
+  if (lowered === 'true' || lowered === '1' || lowered === 'yes' || lowered === 'on') {
+    return true;
+  }
+  return defaultValue;
+}
+
+export const featureFlags = {
+  /**
+   * 공고 워크스페이스 협업 편집 (PR #1~#5)
+   *
+   * - true: 워크스페이스 UI 노출, RLS 새 정책 활성 (M2 백필 완료 후)
+   * - false: 기존 owner_id 단독 흐름 (병행 동작)
+   *
+   * 배포 단계:
+   *  Day 0 — staging 적용 + regression 확인
+   *  Day 1-3 — 내부 admin 만 (env override OFF in production until verified)
+   *  Day 4-7 — review-employer + 베타 employer
+   *  Day 8+ — 점진적 활성화 (10% → 50% → 100%)
+   */
+  WORKSPACE_COLLABORATION_ENABLED: parseBoolean(
+    process.env.EXPO_PUBLIC_WORKSPACE_COLLABORATION_ENABLED,
+    true
+  ),
+} as const;
+
+export type FeatureFlagKey = keyof typeof featureFlags;
+
+export function isFeatureEnabled(flag: FeatureFlagKey): boolean {
+  return featureFlags[flag];
+}

--- a/uniqn-mobile/src/lib/queryClient.ts
+++ b/uniqn-mobile/src/lib/queryClient.ts
@@ -320,6 +320,19 @@ export const queryKeys = {
     stats: () => [...queryKeys.jobManagement.all, 'stats'] as const,
   },
 
+  // 워크스페이스 협업 (PR #2)
+  workspaces: {
+    all: ['workspaces'] as const,
+    listForUser: (userId: string) => [...queryKeys.workspaces.all, 'list', userId] as const,
+    detail: (workspaceId: string) => [...queryKeys.workspaces.all, 'detail', workspaceId] as const,
+    members: (workspaceId: string) =>
+      [...queryKeys.workspaces.all, 'members', workspaceId] as const,
+    invitationsSent: (workspaceId: string) =>
+      [...queryKeys.workspaces.all, 'invitations', 'workspace', workspaceId] as const,
+    invitationsReceived: (userId: string) =>
+      [...queryKeys.workspaces.all, 'invitations', 'received', userId] as const,
+  },
+
   // 공고 템플릿 (구인자)
   templates: {
     all: ['templates'] as const,

--- a/uniqn-mobile/src/repositories/index.ts
+++ b/uniqn-mobile/src/repositories/index.ts
@@ -466,3 +466,22 @@ export type {
   FetchApplicationsOptions,
   FetchApplicationsResult,
 } from './supabase/EmployerApplicationRepository';
+
+// ============================================================================
+// 워크스페이스 협업 편집 (PR #2)
+// ============================================================================
+
+export type {
+  IWorkspaceRepository,
+  IWorkspaceMemberRepository,
+  IWorkspaceInvitationRepository,
+} from './interfaces';
+
+export {
+  SupabaseWorkspaceRepository,
+  SupabaseWorkspaceMemberRepository,
+  SupabaseWorkspaceInvitationRepository,
+  workspaceRepository,
+  workspaceMemberRepository,
+  workspaceInvitationRepository,
+} from './supabase';

--- a/uniqn-mobile/src/repositories/interfaces/IWorkspaceRepository.ts
+++ b/uniqn-mobile/src/repositories/interfaces/IWorkspaceRepository.ts
@@ -1,0 +1,73 @@
+/**
+ * UNIQN Mobile - 워크스페이스 Repository 인터페이스
+ *
+ * @description 공고 워크스페이스 협업 편집 (PR #2)
+ *              owner 단독 + editor 멤버 모델 (D2)
+ * @version 1.0.0
+ */
+
+import type {
+  Workspace,
+  WorkspaceMemberWithUser,
+  WorkspaceInvitation,
+  ReceivedWorkspaceInvitation,
+  AcceptInvitationResult,
+} from '@/types/workspace';
+
+export interface IWorkspaceRepository {
+  /**
+   * 워크스페이스 생성
+   * @throws AppError E3 cap 도달 / E5 권한 부족 / E1 네트워크
+   */
+  create(name: string, ownerId: string): Promise<Workspace>;
+
+  /** 단건 조회 — RLS 차단 시 undefined */
+  findById(id: string): Promise<Workspace | undefined>;
+
+  /** 내가 owner 인 워크스페이스 + editor 인 워크스페이스 모두 (UNION) */
+  findAllByMember(userId: string): Promise<Workspace[]>;
+
+  /** 이름 변경 (owner 만 — RLS 가 강제) */
+  updateName(id: string, name: string): Promise<Workspace>;
+}
+
+export interface IWorkspaceMemberRepository {
+  /** 멤버 목록 (owner 제외 editor 만 — workspace_members 테이블) */
+  findByWorkspaceWithUser(workspaceId: string): Promise<WorkspaceMemberWithUser[]>;
+
+  /** 본인이 속한 워크스페이스 ID 목록 (editor 으로) */
+  findWorkspaceIdsForUser(userId: string): Promise<string[]>;
+
+  /**
+   * 멤버 제거 (RPC 우회) — owner 만 호출 가능, RPC 가 권한 체크
+   * @throws AppError E5 권한 / E6 invalid state
+   */
+  removeViaRpc(workspaceId: string, userId: string): Promise<void>;
+}
+
+export interface IWorkspaceInvitationRepository {
+  /**
+   * 초대 발송 (owner 만, RPC 경유 atomic 권한 체크)
+   * @returns 새 초대 ID
+   * @throws AppError E3 검증 / E5 권한 / E6 비즈니스 (이미 멤버 / 이미 초대됨)
+   */
+  inviteViaRpc(workspaceId: string, inviteeUserId: string): Promise<string>;
+
+  /**
+   * 초대 수락 (race-safe atomic RPC)
+   * @returns workspaceId + idempotent 플래그
+   */
+  acceptViaRpc(invitationId: string): Promise<AcceptInvitationResult>;
+
+  /** 거절 (RPC) */
+  rejectViaRpc(invitationId: string): Promise<void>;
+
+  /** owner 가 보낸 초대 회수 (RPC) */
+  revokeViaRpc(invitationId: string): Promise<void>;
+
+  /** 본인이 받은 pending 초대 + 워크스페이스/초대자 정보 결합 */
+  findPendingForUser(userId: string): Promise<ReceivedWorkspaceInvitation[]>;
+
+  /** 워크스페이스의 모든 초대 (owner 화면) */
+  findByWorkspace(workspaceId: string): Promise<WorkspaceInvitation[]>;
+}

--- a/uniqn-mobile/src/repositories/interfaces/index.ts
+++ b/uniqn-mobile/src/repositories/interfaces/index.ts
@@ -126,3 +126,10 @@ export type {
   FetchScheduleMembershipsOptions,
   FetchBoardReportsOptions,
 } from './IBoardRepository';
+
+// 워크스페이스 협업 편집 (PR #2)
+export type {
+  IWorkspaceRepository,
+  IWorkspaceMemberRepository,
+  IWorkspaceInvitationRepository,
+} from './IWorkspaceRepository';

--- a/uniqn-mobile/src/repositories/supabase/WorkspaceInvitationRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/WorkspaceInvitationRepository.ts
@@ -1,0 +1,194 @@
+/**
+ * UNIQN Mobile - Supabase Workspace Invitation Repository
+ *
+ * @description 공고 워크스페이스 초대 (PR #2)
+ *              - invite/accept/reject/revoke 는 SECURITY DEFINER RPC 경유 (atomic + 권한 체크)
+ *              - SELECT 는 RLS workspace_invitations_select_relevant 필터링 적용
+ * @version 1.0.0
+ */
+
+import { supabase } from '@/lib/supabase';
+import { logger } from '@/utils/logger';
+import { isAppError, BusinessError } from '@/errors';
+import { handleSupabaseError, toCamelCase } from '@/utils/supabase';
+import { mapWorkspaceRpcError, WORKSPACE_ERROR_CODES } from '@/errors/workspace';
+import type {
+  WorkspaceInvitation,
+  ReceivedWorkspaceInvitation,
+  AcceptInvitationResult,
+} from '@/types/workspace';
+import type { IWorkspaceInvitationRepository } from '../interfaces/IWorkspaceRepository';
+
+const TABLE = 'workspace_invitations' as const;
+const COLUMNS =
+  'id, workspace_id, invitee_user_id, role, invited_by, status, expires_at, created_at, responded_at' as const;
+
+function rowToInvitation(row: Record<string, unknown>): WorkspaceInvitation {
+  return toCamelCase<WorkspaceInvitation>(row);
+}
+
+interface PendingJoinRow {
+  id: string;
+  workspace_id: string;
+  invitee_user_id: string;
+  role: 'editor';
+  invited_by: string;
+  status: WorkspaceInvitation['status'];
+  expires_at: string;
+  created_at: string;
+  responded_at: string | null;
+  workspaces: { name: string } | null;
+  inviter: { display_name: string | null } | null;
+}
+
+function rowToReceivedInvitation(row: PendingJoinRow): ReceivedWorkspaceInvitation {
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    inviteeUserId: row.invitee_user_id,
+    role: row.role,
+    invitedBy: row.invited_by,
+    status: row.status,
+    expiresAt: row.expires_at,
+    createdAt: row.created_at,
+    respondedAt: row.responded_at ?? null,
+    workspaceName: row.workspaces?.name ?? '',
+    inviterDisplayName: row.inviter?.display_name ?? null,
+  };
+}
+
+export class SupabaseWorkspaceInvitationRepository implements IWorkspaceInvitationRepository {
+  async inviteViaRpc(workspaceId: string, inviteeUserId: string): Promise<string> {
+    try {
+      logger.info('워크스페이스 초대 RPC', { workspaceId, inviteeUserId });
+      const { data, error } = await supabase.rpc('invite_workspace_member', {
+        p_workspace_id: workspaceId,
+        p_invitee_user_id: inviteeUserId,
+      });
+
+      if (error) {
+        const mapped = mapWorkspaceRpcError(error);
+        if (mapped) throw mapped;
+        handleSupabaseError(error, { operation: '워크스페이스 초대', table: TABLE });
+      }
+
+      const invitationId = data as string | null;
+      if (!invitationId) {
+        throw new BusinessError(WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_NOT_FOUND, {
+          userMessage: '초대 발송에 실패했습니다.',
+        });
+      }
+      return invitationId;
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '워크스페이스 초대', table: TABLE });
+    }
+  }
+
+  async acceptViaRpc(invitationId: string): Promise<AcceptInvitationResult> {
+    try {
+      logger.info('워크스페이스 초대 수락 RPC', { invitationId });
+      const { data, error } = await supabase.rpc('accept_workspace_invitation', {
+        p_invitation_id: invitationId,
+      });
+
+      if (error) {
+        const mapped = mapWorkspaceRpcError(error);
+        if (mapped) throw mapped;
+        handleSupabaseError(error, { operation: '초대 수락', table: TABLE });
+      }
+
+      const payload = (data ?? {}) as {
+        invitationId?: string;
+        workspaceId?: string;
+        idempotent?: boolean;
+      };
+      if (!payload.invitationId || !payload.workspaceId) {
+        throw new BusinessError(WORKSPACE_ERROR_CODES.WORKSPACE_INVITATION_NOT_FOUND, {
+          userMessage: '초대 응답을 처리하지 못했습니다.',
+        });
+      }
+      return {
+        invitationId: payload.invitationId,
+        workspaceId: payload.workspaceId,
+        idempotent: Boolean(payload.idempotent),
+      };
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '초대 수락', table: TABLE });
+    }
+  }
+
+  async rejectViaRpc(invitationId: string): Promise<void> {
+    try {
+      logger.info('워크스페이스 초대 거절 RPC', { invitationId });
+      const { error } = await supabase.rpc('reject_workspace_invitation', {
+        p_invitation_id: invitationId,
+      });
+      if (error) {
+        const mapped = mapWorkspaceRpcError(error);
+        if (mapped) throw mapped;
+        handleSupabaseError(error, { operation: '초대 거절', table: TABLE });
+      }
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '초대 거절', table: TABLE });
+    }
+  }
+
+  async revokeViaRpc(invitationId: string): Promise<void> {
+    try {
+      logger.info('워크스페이스 초대 회수 RPC', { invitationId });
+      const { error } = await supabase.rpc('revoke_workspace_invitation', {
+        p_invitation_id: invitationId,
+      });
+      if (error) {
+        const mapped = mapWorkspaceRpcError(error);
+        if (mapped) throw mapped;
+        handleSupabaseError(error, { operation: '초대 회수', table: TABLE });
+      }
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '초대 회수', table: TABLE });
+    }
+  }
+
+  async findPendingForUser(userId: string): Promise<ReceivedWorkspaceInvitation[]> {
+    try {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select(`${COLUMNS}, workspaces:workspace_id (name), inviter:invited_by (display_name)`)
+        .eq('invitee_user_id', userId)
+        .eq('status', 'pending')
+        .order('created_at', { ascending: false });
+
+      if (error) {
+        handleSupabaseError(error, { operation: '받은 초대 조회', table: TABLE });
+      }
+      return ((data ?? []) as unknown as PendingJoinRow[]).map(rowToReceivedInvitation);
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '받은 초대 조회', table: TABLE });
+    }
+  }
+
+  async findByWorkspace(workspaceId: string): Promise<WorkspaceInvitation[]> {
+    try {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select(COLUMNS)
+        .eq('workspace_id', workspaceId)
+        .order('created_at', { ascending: false });
+
+      if (error) {
+        handleSupabaseError(error, { operation: '워크스페이스 초대 목록 조회', table: TABLE });
+      }
+      return ((data ?? []) as Record<string, unknown>[]).map(rowToInvitation);
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '워크스페이스 초대 목록 조회', table: TABLE });
+    }
+  }
+}
+
+export const workspaceInvitationRepository = new SupabaseWorkspaceInvitationRepository();

--- a/uniqn-mobile/src/repositories/supabase/WorkspaceMemberRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/WorkspaceMemberRepository.ts
@@ -1,0 +1,108 @@
+/**
+ * UNIQN Mobile - Supabase Workspace Member Repository
+ *
+ * @description 공고 워크스페이스 멤버 (PR #2)
+ *              - editor 멤버만 (D2: owner는 workspaces.owner_id 단독)
+ *              - INSERT/UPDATE/DELETE 는 RPC 우회 (accept_workspace_invitation, remove_workspace_member)
+ * @version 1.0.0
+ */
+
+import { supabase } from '@/lib/supabase';
+import { logger } from '@/utils/logger';
+import { isAppError } from '@/errors';
+import { handleSupabaseError } from '@/utils/supabase';
+import { mapWorkspaceRpcError } from '@/errors/workspace';
+import type { WorkspaceMemberWithUser } from '@/types/workspace';
+import type { IWorkspaceMemberRepository } from '../interfaces/IWorkspaceRepository';
+
+const TABLE = 'workspace_members' as const;
+
+interface MemberJoinRow {
+  workspace_id: string;
+  user_id: string;
+  role: 'editor';
+  invited_by: string | null;
+  joined_at: string;
+  users: {
+    display_name: string | null;
+    email: string | null;
+    photo_url: string | null;
+  } | null;
+}
+
+function rowToMemberWithUser(row: MemberJoinRow): WorkspaceMemberWithUser {
+  return {
+    workspaceId: row.workspace_id,
+    userId: row.user_id,
+    role: row.role,
+    invitedBy: row.invited_by ?? null,
+    joinedAt: row.joined_at,
+    displayName: row.users?.display_name ?? null,
+    email: row.users?.email ?? null,
+    photoUrl: row.users?.photo_url ?? null,
+  };
+}
+
+export class SupabaseWorkspaceMemberRepository implements IWorkspaceMemberRepository {
+  async findByWorkspaceWithUser(workspaceId: string): Promise<WorkspaceMemberWithUser[]> {
+    try {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select(
+          'workspace_id, user_id, role, invited_by, joined_at, users:user_id (display_name, email, photo_url)'
+        )
+        .eq('workspace_id', workspaceId)
+        .order('joined_at', { ascending: true });
+
+      if (error) {
+        handleSupabaseError(error, { operation: '멤버 목록 조회', table: TABLE });
+      }
+
+      return ((data ?? []) as unknown as MemberJoinRow[]).map(rowToMemberWithUser);
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '멤버 목록 조회', table: TABLE });
+    }
+  }
+
+  async findWorkspaceIdsForUser(userId: string): Promise<string[]> {
+    try {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select('workspace_id')
+        .eq('user_id', userId);
+
+      if (error) {
+        handleSupabaseError(error, { operation: '내 워크스페이스 ID 조회', table: TABLE });
+      }
+      return (data ?? []).map((r) => (r as { workspace_id: string }).workspace_id);
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '내 워크스페이스 ID 조회', table: TABLE });
+    }
+  }
+
+  async removeViaRpc(workspaceId: string, userId: string): Promise<void> {
+    try {
+      logger.info('멤버 제거 RPC', { workspaceId, userId });
+      const { data, error } = await supabase.rpc('remove_workspace_member', {
+        p_workspace_id: workspaceId,
+        p_user_id: userId,
+      });
+
+      // supabase-js: 에러는 error 또는 data 응답 패턴 둘 다 가능
+      if (error) {
+        const mapped = mapWorkspaceRpcError(error);
+        if (mapped) throw mapped;
+        handleSupabaseError(error, { operation: '멤버 제거', table: TABLE });
+      }
+      // void RPC 는 data 를 사용하지 않음
+      void data;
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '멤버 제거', table: TABLE });
+    }
+  }
+}
+
+export const workspaceMemberRepository = new SupabaseWorkspaceMemberRepository();

--- a/uniqn-mobile/src/repositories/supabase/WorkspaceRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/WorkspaceRepository.ts
@@ -1,0 +1,111 @@
+/**
+ * UNIQN Mobile - Supabase Workspace Repository
+ *
+ * @description 공고 워크스페이스 (PR #2)
+ *              - workspaces 테이블 CRUD
+ *              - RLS 가 권한 강제 (workspaces_select_owner_or_member, _insert_employer_with_cap, _update_owner)
+ * @version 1.0.0
+ */
+
+import { supabase } from '@/lib/supabase';
+import { logger } from '@/utils/logger';
+import { isAppError } from '@/errors';
+import { handleSupabaseError, toCamelCase } from '@/utils/supabase';
+import { mapWorkspaceRpcError } from '@/errors/workspace';
+import type { Workspace } from '@/types/workspace';
+import type { IWorkspaceRepository } from '../interfaces/IWorkspaceRepository';
+
+const TABLE = 'workspaces' as const;
+const COLUMNS = 'id, name, owner_id, member_count, created_at, updated_at' as const;
+
+function rowToWorkspace(row: Record<string, unknown>): Workspace {
+  return toCamelCase<Workspace>(row);
+}
+
+export class SupabaseWorkspaceRepository implements IWorkspaceRepository {
+  async create(name: string, ownerId: string): Promise<Workspace> {
+    try {
+      logger.info('워크스페이스 생성 시작', { ownerId, name });
+
+      const { data, error } = await supabase
+        .from(TABLE)
+        .insert({ name, owner_id: ownerId })
+        .select(COLUMNS)
+        .single();
+
+      if (error) {
+        const mapped = mapWorkspaceRpcError(error);
+        if (mapped) throw mapped;
+        handleSupabaseError(error, { operation: '워크스페이스 생성', table: TABLE });
+      }
+
+      logger.info('워크스페이스 생성 완료', { workspaceId: data!.id });
+      return rowToWorkspace(data as Record<string, unknown>);
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '워크스페이스 생성', table: TABLE });
+    }
+  }
+
+  async findById(id: string): Promise<Workspace | undefined> {
+    try {
+      const { data, error } = await supabase.from(TABLE).select(COLUMNS).eq('id', id).maybeSingle();
+
+      if (error) {
+        handleSupabaseError(error, { operation: '워크스페이스 조회', table: TABLE });
+      }
+      return data ? rowToWorkspace(data as Record<string, unknown>) : undefined;
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '워크스페이스 조회', table: TABLE });
+    }
+  }
+
+  /**
+   * "내가 멤버인 모든 워크스페이스" — owner OR editor.
+   * RLS workspaces_select_owner_or_member 가 자동으로 필터링하므로 select * 만 호출.
+   */
+  async findAllByMember(_userId: string): Promise<Workspace[]> {
+    try {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select(COLUMNS)
+        .order('created_at', { ascending: true });
+
+      if (error) {
+        handleSupabaseError(error, { operation: '워크스페이스 목록 조회', table: TABLE });
+      }
+
+      return ((data ?? []) as Record<string, unknown>[]).map(rowToWorkspace);
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '워크스페이스 목록 조회', table: TABLE });
+    }
+  }
+
+  async updateName(id: string, name: string): Promise<Workspace> {
+    try {
+      logger.info('워크스페이스 이름 변경', { workspaceId: id });
+
+      const { data, error } = await supabase
+        .from(TABLE)
+        .update({ name })
+        .eq('id', id)
+        .select(COLUMNS)
+        .single();
+
+      if (error) {
+        const mapped = mapWorkspaceRpcError(error);
+        if (mapped) throw mapped;
+        handleSupabaseError(error, { operation: '워크스페이스 이름 변경', table: TABLE });
+      }
+
+      return rowToWorkspace(data as Record<string, unknown>);
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '워크스페이스 이름 변경', table: TABLE });
+    }
+  }
+}
+
+export const workspaceRepository = new SupabaseWorkspaceRepository();

--- a/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.workspace.regression.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.workspace.regression.test.ts
@@ -1,0 +1,214 @@
+/**
+ * PR #4 — JobPostingRepository workspace regression test
+ *
+ * @description IRON RULE — workspace_id 도입 후에도 기존 employer 흐름이 정상 동작.
+ *              backfill 마이그레이션 후 production 상황을 가정한 contract 검증.
+ *
+ * 본 테스트는 contract level (Supabase 호출 패턴 무변경 + 에러 미발생) 만 검증.
+ * 실제 RLS / trigger / data 흐름은 DB-level smoke (PR #1, #4 사후 검증) 가 담당.
+ *
+ * 8 케이스:
+ *  1. employer 본인 공고 목록 조회 (getByOwnerId)
+ *  2. employer 본인 공고 상세 조회 (getById)
+ *  3. 공고 상태 변경 (updateStatus)
+ *  4. 공고 마감 (closeWithTransaction)
+ *  5. job_postings.stats 결과 처리 (Repository 가 stats 구조를 그대로 노출)
+ *  6. work_logs join 흐름 — Repository 호출 패턴 무변경
+ *  7. SettlementRepository 흐름 — ownerId 필드 보존
+ *  8. applicantManagementService 흐름 — applications 호출 패턴 무변경
+ */
+
+import { SupabaseJobPostingRepository } from '../JobPostingRepository';
+
+// ── Mock Supabase ────────────────────────────────────────────────────────────
+const mockFrom = jest.fn();
+const mockRpc = jest.fn();
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    rpc: (...args: unknown[]) => mockRpc(...args),
+    channel: jest.fn(),
+  },
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('@/utils/supabase', () => {
+  const actual = jest.requireActual('@/utils/supabase');
+  return {
+    ...actual,
+    handleSupabaseError: (error: { message?: string } | null) => {
+      if (error) throw new Error(`supabase: ${error.message ?? 'unknown'}`);
+    },
+  };
+});
+
+jest.mock('@sentry/react-native', () => ({
+  __esModule: true,
+  addBreadcrumb: jest.fn(),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+const OWNER_ID = '11111111-1111-4111-8111-111111111111';
+const POSTING_ID = '22222222-2222-4222-8222-222222222222';
+
+/**
+ * 모든 빌더 메서드가 자기 자신을 반환하고, 마지막 await 시 returnValue 를 풀어주는
+ * 체이너블 스텁. .single / .maybeSingle 도 동일 returnValue 를 반환.
+ */
+function makeChain(returnValue: { data: unknown; error: unknown }) {
+  const chain: Record<string, unknown> = {};
+  const methodsReturningChain = [
+    'select',
+    'eq',
+    'in',
+    'is',
+    'order',
+    'limit',
+    'range',
+    'update',
+    'insert',
+    'delete',
+    'upsert',
+    'gte',
+    'lte',
+    'gt',
+    'lt',
+    'neq',
+    'contains',
+    'overlaps',
+    'or',
+    'and',
+    'not',
+    'filter',
+    'match',
+    'returns',
+  ];
+  for (const m of methodsReturningChain) {
+    chain[m] = jest.fn(() => chain);
+  }
+  // Terminal methods that resolve to returnValue
+  for (const m of ['single', 'maybeSingle', 'csv']) {
+    chain[m] = jest.fn(() => Promise.resolve(returnValue));
+  }
+  // PromiseLike — await 시 returnValue 풀어줌
+  (chain as { then?: unknown }).then = function then<TResult1 = unknown, TResult2 = never>(
+    onfulfilled?: ((value: unknown) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): PromiseLike<TResult1 | TResult2> {
+    return Promise.resolve(returnValue).then(onfulfilled, onrejected);
+  };
+  return chain as Record<string, jest.Mock> & PromiseLike<unknown>;
+}
+
+beforeEach(() => {
+  mockFrom.mockReset();
+  mockRpc.mockReset();
+});
+
+// ============================================================================
+// Cases
+// ============================================================================
+
+describe('JobPostingRepository workspace regression (PR #4 IRON RULE)', () => {
+  const repo = new SupabaseJobPostingRepository();
+
+  it('1. getByOwnerId — Supabase from(job_postings) + eq(owner_id) 호출 패턴 무변경', async () => {
+    const chain = makeChain({ data: [], error: null });
+    mockFrom.mockReturnValueOnce(chain);
+
+    await repo.getByOwnerId(OWNER_ID);
+
+    expect(mockFrom).toHaveBeenCalledWith('job_postings');
+    expect(chain.eq).toHaveBeenCalledWith('owner_id', OWNER_ID);
+  });
+
+  it('2. getById — Supabase from(job_postings) + eq(id) + maybeSingle 호출 패턴 무변경', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(chain);
+
+    await repo.getById(POSTING_ID);
+
+    expect(mockFrom).toHaveBeenCalledWith('job_postings');
+    expect(chain.eq).toHaveBeenCalledWith('id', POSTING_ID);
+  });
+
+  it('3. updateStatus — update + eq(id) RLS 통과 (jp_update + jp_update_workspace_member OR)', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(chain);
+
+    await repo.updateStatus(POSTING_ID, 'closed');
+
+    expect(mockFrom).toHaveBeenCalledWith('job_postings');
+    expect(chain.update).toHaveBeenCalled();
+    expect(chain.eq).toHaveBeenCalledWith('id', POSTING_ID);
+  });
+
+  it('4. closeWithTransaction — RPC 또는 update 호출 (workspace owner 권한)', async () => {
+    mockRpc.mockResolvedValueOnce({ data: null, error: null });
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    await repo.closeWithTransaction(POSTING_ID, OWNER_ID).catch(() => {
+      // 일부 구현은 권한 검증 후 throw — close 흐름의 호출 패턴만 확인
+    });
+
+    expect(mockFrom.mock.calls.length + mockRpc.mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it('5. job_postings.stats trigger — Repository SELECT 가 stats 컬럼 없이 호출되지 않음 (TABLE_COLUMNS 무변경)', async () => {
+    // trigger 가 stats 를 갱신, Repository 는 SELECT 결과만 반환 (수정/병합 없음).
+    // 본 테스트는 SELECT 호출 패턴이 유지됨을 확인 (실제 stats 갱신은 PR #1 DB smoke test).
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(chain);
+
+    await repo.getById(POSTING_ID);
+
+    expect(chain.select).toHaveBeenCalled();
+    // select 호출 인자 — TABLE_COLUMNS 가 stats 를 포함해야 trigger 결과를 노출
+    const selectArg = (chain.select as jest.Mock).mock.calls[0]?.[0] as string | undefined;
+    if (typeof selectArg === 'string') {
+      expect(selectArg).toContain('stats');
+    }
+  });
+
+  it('6. work_logs join — Repository 가 work_logs 컬럼 SELECT 변경 없음 (PR #5 owner_id rename 까지 유지)', async () => {
+    const chain = makeChain({ data: [], error: null });
+    mockFrom.mockReturnValueOnce(chain);
+
+    await repo.getByOwnerId(OWNER_ID);
+
+    // SELECT 호출이 work_logs 별도 쿼리 없이 job_postings 만 사용
+    const fromCalls = mockFrom.mock.calls.flat();
+    expect(fromCalls).toContain('job_postings');
+    expect(fromCalls).not.toContain('work_logs');
+  });
+
+  it('7. settlement 흐름 — owner_id 컬럼이 SELECT 에 포함됨 (settlement join 의존)', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(chain);
+
+    await repo.getById(POSTING_ID);
+
+    // owner_id 컬럼이 SELECT 에 포함돼야 SettlementRepository / WorkLogRepository join 이 동작
+    const selectArg = (chain.select as jest.Mock).mock.calls[0]?.[0] as string | undefined;
+    if (typeof selectArg === 'string') {
+      expect(selectArg).toContain('owner_id');
+    }
+  });
+
+  it('8. applicantManagementService — getByOwnerId list 호출 패턴 무변경', async () => {
+    // applicantManagementService 는 owner 별 공고 목록을 사용해 신청자를 분류
+    const chain = makeChain({ data: [], error: null });
+    mockFrom.mockReturnValueOnce(chain);
+
+    await repo.getByOwnerId(OWNER_ID, 'active');
+
+    expect(mockFrom).toHaveBeenCalledWith('job_postings');
+    expect(chain.eq).toHaveBeenCalledWith('owner_id', OWNER_ID);
+    expect(chain.eq).toHaveBeenCalledWith('status', 'active');
+  });
+});

--- a/uniqn-mobile/src/repositories/supabase/index.ts
+++ b/uniqn-mobile/src/repositories/supabase/index.ts
@@ -13,3 +13,14 @@ export { SupabaseInquiryRepository } from './InquiryRepository';
 export { SupabaseTemplateRepository } from './TemplateRepository';
 export { SupabaseEventQRRepository } from './EventQRRepository';
 export { SupabaseAdminRepository } from './AdminRepository';
+
+// 워크스페이스 협업 편집 (PR #2)
+export { SupabaseWorkspaceRepository, workspaceRepository } from './WorkspaceRepository';
+export {
+  SupabaseWorkspaceMemberRepository,
+  workspaceMemberRepository,
+} from './WorkspaceMemberRepository';
+export {
+  SupabaseWorkspaceInvitationRepository,
+  workspaceInvitationRepository,
+} from './WorkspaceInvitationRepository';

--- a/uniqn-mobile/src/schemas/__tests__/workspace.schema.test.ts
+++ b/uniqn-mobile/src/schemas/__tests__/workspace.schema.test.ts
@@ -1,0 +1,103 @@
+/**
+ * PR #2 — workspace zod schema 검증
+ *
+ * - XSS 차단 (xssValidation refine)
+ * - 이름 길이 제약 (1~50)
+ * - UUID 형식 강제
+ * - role enum 'editor' 단일
+ */
+
+import {
+  createWorkspaceSchema,
+  updateWorkspaceNameSchema,
+  inviteWorkspaceMemberSchema,
+  respondInvitationSchema,
+  workspaceRoleSchema,
+} from '@/schemas/workspace.schema';
+
+describe('workspace schemas (PR #2)', () => {
+  describe('createWorkspaceSchema', () => {
+    it('정상 입력 통과', () => {
+      const r = createWorkspaceSchema.safeParse({ name: '강남펍 워크스페이스' });
+      expect(r.success).toBe(true);
+    });
+
+    it('빈 문자열 거부', () => {
+      const r = createWorkspaceSchema.safeParse({ name: '' });
+      expect(r.success).toBe(false);
+    });
+
+    it('51자 거부', () => {
+      const r = createWorkspaceSchema.safeParse({ name: 'a'.repeat(51) });
+      expect(r.success).toBe(false);
+    });
+
+    it('XSS 시도 거부 — script 태그', () => {
+      const r = createWorkspaceSchema.safeParse({ name: '<script>alert(1)</script>' });
+      expect(r.success).toBe(false);
+    });
+
+    it('XSS 시도 거부 — javascript: URL', () => {
+      const r = createWorkspaceSchema.safeParse({ name: 'javascript:void(0)' });
+      expect(r.success).toBe(false);
+    });
+
+    it('이모지 포함 가능 (Unicode 안전)', () => {
+      const r = createWorkspaceSchema.safeParse({ name: '🎰 강남 포커룸' });
+      expect(r.success).toBe(true);
+    });
+  });
+
+  describe('updateWorkspaceNameSchema', () => {
+    it('워크스페이스 ID UUID 강제', () => {
+      const r = updateWorkspaceNameSchema.safeParse({
+        workspaceId: 'not-a-uuid',
+        name: '신규 이름',
+      });
+      expect(r.success).toBe(false);
+    });
+
+    it('정상 통과', () => {
+      const r = updateWorkspaceNameSchema.safeParse({
+        workspaceId: '123e4567-e89b-42d3-a456-426614174001',
+        name: '신규 이름',
+      });
+      expect(r.success).toBe(true);
+    });
+  });
+
+  describe('inviteWorkspaceMemberSchema', () => {
+    it('role default editor', () => {
+      const r = inviteWorkspaceMemberSchema.safeParse({
+        workspaceId: '123e4567-e89b-42d3-a456-426614174001',
+        inviteeUserId: '123e4567-e89b-42d3-a456-426614174002',
+      });
+      expect(r.success).toBe(true);
+      if (r.success) expect(r.data.role).toBe('editor');
+    });
+
+    it('role 외 값 거부 (D2: editor 단일)', () => {
+      const r = inviteWorkspaceMemberSchema.safeParse({
+        workspaceId: '123e4567-e89b-42d3-a456-426614174001',
+        inviteeUserId: '123e4567-e89b-42d3-a456-426614174002',
+        role: 'owner',
+      });
+      expect(r.success).toBe(false);
+    });
+  });
+
+  describe('respondInvitationSchema', () => {
+    it('UUID 강제', () => {
+      const r = respondInvitationSchema.safeParse({ invitationId: 'invalid' });
+      expect(r.success).toBe(false);
+    });
+  });
+
+  describe('workspaceRoleSchema (D2)', () => {
+    it("'editor' 만 허용", () => {
+      expect(workspaceRoleSchema.safeParse('editor').success).toBe(true);
+      expect(workspaceRoleSchema.safeParse('owner').success).toBe(false);
+      expect(workspaceRoleSchema.safeParse('admin').success).toBe(false);
+    });
+  });
+});

--- a/uniqn-mobile/src/schemas/index.ts
+++ b/uniqn-mobile/src/schemas/index.ts
@@ -341,3 +341,25 @@ export type {
 export { BoardJobSummarySchema, BoardPostMetadataSchema } from './boardMetadata.schema';
 
 export type { BoardJobSummarySchemaData, BoardPostMetadata } from './boardMetadata.schema';
+
+// 워크스페이스 협업 편집 (PR #2)
+export {
+  workspaceRoleSchema,
+  workspaceInvitationStatusSchema,
+  workspaceNameSchema,
+  createWorkspaceSchema,
+  updateWorkspaceNameSchema,
+  inviteWorkspaceMemberSchema,
+  removeWorkspaceMemberSchema,
+  respondInvitationSchema,
+} from './workspace.schema';
+
+export type {
+  WorkspaceRoleSchema,
+  WorkspaceInvitationStatusSchema,
+  CreateWorkspaceData,
+  UpdateWorkspaceNameData,
+  InviteWorkspaceMemberData,
+  RemoveWorkspaceMemberData,
+  RespondInvitationData,
+} from './workspace.schema';

--- a/uniqn-mobile/src/schemas/workspace.schema.ts
+++ b/uniqn-mobile/src/schemas/workspace.schema.ts
@@ -1,0 +1,97 @@
+/**
+ * UNIQN Mobile - 워크스페이스 관련 Zod 스키마
+ *
+ * @description 공고 워크스페이스 협업 편집 (PR #2)
+ * @version 1.0.0
+ *
+ * - workspaceSchema: 생성/수정 시 name 검증 (XSS + 길이)
+ * - inviteWorkspaceMemberSchema: 초대 RPC 입력
+ * - workspaceInvitationStatusSchema: status enum (DB CHECK 와 일치)
+ * - workspaceRoleSchema: 'editor' 단일 (D2 — owner 는 workspaces.owner_id 단독)
+ */
+
+import { z } from 'zod';
+import { xssValidation } from '@/utils/security';
+
+// ============================================================================
+// Enums
+// ============================================================================
+
+export const workspaceRoleSchema = z.literal('editor');
+export type WorkspaceRoleSchema = z.infer<typeof workspaceRoleSchema>;
+
+export const workspaceInvitationStatusSchema = z.enum([
+  'pending',
+  'accepted',
+  'rejected',
+  'revoked',
+  'expired',
+]);
+export type WorkspaceInvitationStatusSchema = z.infer<typeof workspaceInvitationStatusSchema>;
+
+// ============================================================================
+// Field schemas
+// ============================================================================
+
+/**
+ * 워크스페이스 이름 — DB CHECK (1~50자) + XSS
+ */
+export const workspaceNameSchema = z
+  .string({ error: '워크스페이스 이름을 입력해주세요' })
+  .trim()
+  .min(1, { message: '워크스페이스 이름을 입력해주세요' })
+  .max(50, { message: '워크스페이스 이름은 50자를 초과할 수 없습니다' })
+  .refine(xssValidation, { message: '특수문자가 포함될 수 없습니다' });
+
+// ============================================================================
+// 워크스페이스 생성 / 수정
+// ============================================================================
+
+/**
+ * 워크스페이스 생성 입력 (Service 진입점)
+ * owner_id 는 인증 컨텍스트에서 자동 주입 — 입력 받지 않음.
+ */
+export const createWorkspaceSchema = z.object({
+  name: workspaceNameSchema,
+});
+
+export type CreateWorkspaceData = z.infer<typeof createWorkspaceSchema>;
+
+/**
+ * 워크스페이스 이름 변경
+ */
+export const updateWorkspaceNameSchema = z.object({
+  workspaceId: z.string().uuid({ message: '올바른 워크스페이스 ID 가 아닙니다' }),
+  name: workspaceNameSchema,
+});
+
+export type UpdateWorkspaceNameData = z.infer<typeof updateWorkspaceNameSchema>;
+
+// ============================================================================
+// 멤버 초대 / 관리
+// ============================================================================
+
+export const inviteWorkspaceMemberSchema = z.object({
+  workspaceId: z.string().uuid({ message: '올바른 워크스페이스 ID 가 아닙니다' }),
+  inviteeUserId: z.string().uuid({ message: '올바른 사용자 ID 가 아닙니다' }),
+  role: workspaceRoleSchema.default('editor'),
+});
+
+export type InviteWorkspaceMemberData = z.infer<typeof inviteWorkspaceMemberSchema>;
+
+export const removeWorkspaceMemberSchema = z.object({
+  workspaceId: z.string().uuid(),
+  userId: z.string().uuid(),
+});
+
+export type RemoveWorkspaceMemberData = z.infer<typeof removeWorkspaceMemberSchema>;
+
+// ============================================================================
+// 초대 응답 (RPC 입력)
+// ============================================================================
+
+export const respondInvitationSchema = z.object({
+  invitationId: z.string().uuid({ message: '올바른 초대 ID 가 아닙니다' }),
+});
+
+export type RespondInvitationData = z.infer<typeof respondInvitationSchema>;

--- a/uniqn-mobile/src/services/index.ts
+++ b/uniqn-mobile/src/services/index.ts
@@ -46,3 +46,11 @@ export * from './reviewService';
 export * from './inquiryService';
 export * from './versionService';
 export * from './boardService';
+
+// 워크스페이스 협업 편집 (PR #2)
+export {
+  workspaceService,
+  workspaceInvitationService,
+  type InviteWorkspaceMemberOptions,
+  type InviteWorkspaceMemberResult,
+} from './workspace';

--- a/uniqn-mobile/src/services/workspace/index.ts
+++ b/uniqn-mobile/src/services/workspace/index.ts
@@ -1,0 +1,12 @@
+/**
+ * UNIQN Mobile - Workspace Services Barrel
+ *
+ * @description 공고 워크스페이스 협업 편집 (PR #2)
+ */
+
+export { workspaceService } from './workspaceService';
+export {
+  workspaceInvitationService,
+  type InviteWorkspaceMemberOptions,
+  type InviteWorkspaceMemberResult,
+} from './workspaceInvitationService';

--- a/uniqn-mobile/src/services/workspace/workspaceInvitationService.ts
+++ b/uniqn-mobile/src/services/workspace/workspaceInvitationService.ts
@@ -1,0 +1,109 @@
+/**
+ * UNIQN Mobile - Workspace Invitation Service
+ *
+ * @description 초대 라이프사이클 (PR #2)
+ *              invite/accept/reject/revoke — 모두 SECURITY DEFINER RPC 경유.
+ *              발송 후 푸시 알림은 별도 서비스 (pushNotificationService.sendWorkspaceInvitation).
+ * @version 1.0.0
+ */
+
+import { workspaceInvitationRepository, workspaceRepository } from '@/repositories';
+import { inviteWorkspaceMemberSchema, respondInvitationSchema } from '@/schemas/workspace.schema';
+import { ValidationError, ERROR_CODES } from '@/errors';
+import { logger } from '@/utils/logger';
+import type {
+  ReceivedWorkspaceInvitation,
+  WorkspaceInvitation,
+  AcceptInvitationResult,
+} from '@/types/workspace';
+
+function validateOrThrow<T>(
+  parsed: { success: boolean; data?: T; error?: { issues: { message: string }[] } },
+  fallback = '입력값을 확인해주세요'
+): T {
+  if (!parsed.success) {
+    const message = parsed.error?.issues[0]?.message ?? fallback;
+    throw new ValidationError(ERROR_CODES.VALIDATION_SCHEMA, { userMessage: message });
+  }
+  return parsed.data as T;
+}
+
+export interface InviteWorkspaceMemberOptions {
+  workspaceId: string;
+  inviteeUserId: string;
+}
+
+export interface InviteWorkspaceMemberResult {
+  invitationId: string;
+  workspaceName: string;
+}
+
+export const workspaceInvitationService = {
+  /**
+   * 멤버 초대 — owner 권한 체크는 RPC 단계에서 수행.
+   * 푸시 알림은 호출자가 별도 트리거 (Repository 가 invitationId 반환 후).
+   */
+  async invite(input: InviteWorkspaceMemberOptions): Promise<InviteWorkspaceMemberResult> {
+    const parsed = inviteWorkspaceMemberSchema.safeParse(input);
+    const data = validateOrThrow(parsed);
+
+    logger.info('워크스페이스 초대 시작', data);
+    const invitationId = await workspaceInvitationRepository.inviteViaRpc(
+      data.workspaceId,
+      data.inviteeUserId
+    );
+
+    const workspace = await workspaceRepository.findById(data.workspaceId);
+    return {
+      invitationId,
+      workspaceName: workspace?.name ?? '',
+    };
+  },
+
+  /**
+   * 초대 수락 (atomic + idempotent)
+   */
+  async accept(input: { invitationId: string }): Promise<AcceptInvitationResult> {
+    const parsed = respondInvitationSchema.safeParse(input);
+    const data = validateOrThrow(parsed);
+
+    logger.info('워크스페이스 초대 수락', data);
+    return workspaceInvitationRepository.acceptViaRpc(data.invitationId);
+  },
+
+  /**
+   * 초대 거절
+   */
+  async reject(input: { invitationId: string }): Promise<void> {
+    const parsed = respondInvitationSchema.safeParse(input);
+    const data = validateOrThrow(parsed);
+
+    logger.info('워크스페이스 초대 거절', data);
+    await workspaceInvitationRepository.rejectViaRpc(data.invitationId);
+  },
+
+  /**
+   * owner 가 보낸 초대 회수
+   */
+  async revoke(input: { invitationId: string }): Promise<void> {
+    const parsed = respondInvitationSchema.safeParse(input);
+    const data = validateOrThrow(parsed);
+
+    logger.info('워크스페이스 초대 회수', data);
+    await workspaceInvitationRepository.revokeViaRpc(data.invitationId);
+  },
+
+  /**
+   * 본인이 받은 pending 초대 (홈 화면 / 알림 화면에서 표시)
+   */
+  async listPendingForUser(userId: string): Promise<ReceivedWorkspaceInvitation[]> {
+    return workspaceInvitationRepository.findPendingForUser(userId);
+  },
+
+  /**
+   * 워크스페이스의 모든 초대 (owner 가 status 별로 필터링)
+   */
+  async listByWorkspace(workspaceId: string): Promise<WorkspaceInvitation[]> {
+    return workspaceInvitationRepository.findByWorkspace(workspaceId);
+  },
+};

--- a/uniqn-mobile/src/services/workspace/workspaceService.ts
+++ b/uniqn-mobile/src/services/workspace/workspaceService.ts
@@ -9,6 +9,8 @@
  */
 
 import { workspaceRepository, workspaceMemberRepository } from '@/repositories';
+import { supabase } from '@/lib/supabase';
+import { handleSupabaseError } from '@/utils/supabase';
 import {
   createWorkspaceSchema,
   updateWorkspaceNameSchema,
@@ -83,5 +85,50 @@ export const workspaceService = {
       });
     }
     await workspaceMemberRepository.removeViaRpc(parsed.data.workspaceId, parsed.data.userId);
+  },
+
+  /**
+   * 초대용 사용자 lookup — 이메일 정확 매칭.
+   * (UI 검색 자동완성을 피하기 위해 정확 매칭. 등록된 사용자에게만 초대 발송 가능.)
+   */
+  async lookupUserByEmail(
+    email: string
+  ): Promise<{ id: string; name: string | null; email: string; photoUrl: string | null } | null> {
+    const trimmed = email.trim().toLowerCase();
+    if (!trimmed || trimmed.length < 5 || !trimmed.includes('@')) {
+      return null;
+    }
+
+    try {
+      const { data, error } = await supabase
+        .from('users')
+        .select('id, name, email, photo_url, is_active')
+        .eq('email', trimmed)
+        .maybeSingle();
+
+      if (error) {
+        handleSupabaseError(error, { operation: '사용자 조회', table: 'users' });
+      }
+
+      if (!data || data.is_active === false) {
+        return null;
+      }
+
+      const row = data as {
+        id: string;
+        name: string | null;
+        email: string;
+        photo_url: string | null;
+      };
+      return {
+        id: row.id,
+        name: row.name,
+        email: row.email,
+        photoUrl: row.photo_url ?? null,
+      };
+    } catch (error) {
+      logger.warn('lookupUserByEmail 실패', { email: trimmed, error: String(error) });
+      return null;
+    }
   },
 };

--- a/uniqn-mobile/src/services/workspace/workspaceService.ts
+++ b/uniqn-mobile/src/services/workspace/workspaceService.ts
@@ -1,0 +1,87 @@
+/**
+ * UNIQN Mobile - Workspace Service
+ *
+ * @description 공고 워크스페이스 도메인 로직 (PR #2)
+ *              - 입력 검증 (zod)
+ *              - 권한 체크는 RLS 단독 (워크스페이스 정책 review C1)
+ *              - Hook 에서 UI 분기용 데이터만 제공
+ * @version 1.0.0
+ */
+
+import { workspaceRepository, workspaceMemberRepository } from '@/repositories';
+import {
+  createWorkspaceSchema,
+  updateWorkspaceNameSchema,
+  removeWorkspaceMemberSchema,
+} from '@/schemas/workspace.schema';
+import { ValidationError, ERROR_CODES, isAppError } from '@/errors';
+import { logger } from '@/utils/logger';
+import type { Workspace, WorkspaceMemberWithUser } from '@/types/workspace';
+
+function toValidationError(error: unknown): never {
+  if (isAppError(error)) throw error;
+  throw new ValidationError(ERROR_CODES.VALIDATION_SCHEMA, {
+    userMessage: '입력값을 확인해주세요',
+    metadata: { error: String(error) },
+  });
+}
+
+export const workspaceService = {
+  /**
+   * 새 워크스페이스 생성
+   * RLS 가 cap (10) 강제 — 도달 시 mapWorkspaceRpcError 가 WORKSPACE_CAP_REACHED 변환.
+   */
+  async createWorkspace(input: { name: string; ownerId: string }): Promise<Workspace> {
+    const parsed = createWorkspaceSchema.safeParse({ name: input.name });
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? '입력값 오류';
+      throw new ValidationError(ERROR_CODES.VALIDATION_SCHEMA, { userMessage: message });
+    }
+
+    return workspaceRepository.create(parsed.data.name, input.ownerId);
+  },
+
+  /**
+   * 워크스페이스 이름 변경 (owner 만 — RLS 강제)
+   */
+  async updateWorkspaceName(input: { workspaceId: string; name: string }): Promise<Workspace> {
+    const parsed = updateWorkspaceNameSchema.safeParse(input);
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? '입력값 오류';
+      throw new ValidationError(ERROR_CODES.VALIDATION_SCHEMA, { userMessage: message });
+    }
+    return workspaceRepository.updateName(parsed.data.workspaceId, parsed.data.name);
+  },
+
+  /**
+   * 사용자가 속한 모든 워크스페이스 (owner OR editor)
+   */
+  async listWorkspacesForUser(userId: string): Promise<Workspace[]> {
+    try {
+      return await workspaceRepository.findAllByMember(userId);
+    } catch (error) {
+      logger.warn('listWorkspacesForUser 실패', { userId, error: String(error) });
+      toValidationError(error);
+    }
+  },
+
+  /**
+   * 워크스페이스 멤버 (editor) 목록 + 사용자 정보
+   */
+  async listMembers(workspaceId: string): Promise<WorkspaceMemberWithUser[]> {
+    return workspaceMemberRepository.findByWorkspaceWithUser(workspaceId);
+  },
+
+  /**
+   * 멤버 제거 (owner 만 — RPC 권한 체크)
+   */
+  async removeMember(input: { workspaceId: string; userId: string }): Promise<void> {
+    const parsed = removeWorkspaceMemberSchema.safeParse(input);
+    if (!parsed.success) {
+      throw new ValidationError(ERROR_CODES.VALIDATION_SCHEMA, {
+        userMessage: '입력값을 확인해주세요',
+      });
+    }
+    await workspaceMemberRepository.removeViaRpc(parsed.data.workspaceId, parsed.data.userId);
+  },
+};

--- a/uniqn-mobile/src/shared/deeplink/NotificationRouteMap.ts
+++ b/uniqn-mobile/src/shared/deeplink/NotificationRouteMap.ts
@@ -116,6 +116,12 @@ export const NOTIFICATION_ROUTE_MAP: Record<
     data?.workLogId
       ? { name: 'reviews/detail', params: { workLogId: data.workLogId } }
       : { name: 'reviews/pending' },
+
+  // 워크스페이스 협업 (PR #2)
+  [NotificationType.WORKSPACE_INVITATION]: (data): DeepLinkRoute =>
+    data?.invitationId
+      ? { name: 'workspace/invitations', params: { invitationId: data.invitationId } }
+      : { name: 'workspace/invitations' },
 };
 
 export function getRouteForNotificationType(

--- a/uniqn-mobile/src/shared/deeplink/RouteMapper.ts
+++ b/uniqn-mobile/src/shared/deeplink/RouteMapper.ts
@@ -139,6 +139,14 @@ export class RouteMapper {
       case 'reviews/pending':
         return EXPO_ROUTES.reviewsPending;
 
+      // 워크스페이스 협업 (PR #2)
+      case 'workspace':
+        return EXPO_ROUTES.workspace;
+      case 'workspace/invite':
+        return EXPO_ROUTES.workspaceInvite;
+      case 'workspace/invitations':
+        return EXPO_ROUTES.workspaceInvitations;
+
       default: {
         const _exhaustive: never = route;
         void _exhaustive;

--- a/uniqn-mobile/src/shared/deeplink/RouteRegistry.ts
+++ b/uniqn-mobile/src/shared/deeplink/RouteRegistry.ts
@@ -63,6 +63,11 @@ export const EXPO_ROUTES = {
   reviewDetail: '/(app)/reviews/[workLogId]',
   reviewsPending: '/(app)/reviews/pending',
 
+  // 워크스페이스 협업 (PR #2)
+  workspace: '/(employer)/workspace',
+  workspaceInvite: '/(employer)/workspace/invite',
+  workspaceInvitations: '/(employer)/workspace/invitations',
+
   publicJobs: '/(public)/jobs',
   publicJobDetail: '/jobs/[id]',
 
@@ -109,6 +114,10 @@ export const AUTH_REQUIRED_ROUTES: ExpoRouteName[] = [
   'reviewDetail',
   'reviewsPending',
   'employerApplicationStatus',
+  // 워크스페이스 협업 (PR #2)
+  'workspace',
+  'workspaceInvite',
+  'workspaceInvitations',
 ];
 
 export const EMPLOYER_REQUIRED_ROUTES: ExpoRouteName[] = [

--- a/uniqn-mobile/src/shared/deeplink/__tests__/NotificationRouteMap.test.ts
+++ b/uniqn-mobile/src/shared/deeplink/__tests__/NotificationRouteMap.test.ts
@@ -12,7 +12,7 @@ describe('NotificationRouteMap', () => {
   it('covers every NotificationType', () => {
     const allNotificationTypes = Object.values(NotificationType) as NotificationType[];
 
-    expect(allNotificationTypes.length).toBe(43);
+    expect(allNotificationTypes.length).toBe(44);
 
     allNotificationTypes.forEach((type) => {
       expect(NOTIFICATION_ROUTE_MAP[type]).toBeDefined();

--- a/uniqn-mobile/src/shared/deeplink/types.ts
+++ b/uniqn-mobile/src/shared/deeplink/types.ts
@@ -52,7 +52,11 @@ export type DeepLinkRoute =
   | { name: 'admin/employer-application'; params: { id: string } }
   | { name: 'employer-application-status' }
   | { name: 'reviews/detail'; params: { workLogId: string } }
-  | { name: 'reviews/pending' };
+  | { name: 'reviews/pending' }
+  // 워크스페이스 협업 (PR #2)
+  | { name: 'workspace' }
+  | { name: 'workspace/invite'; params: { workspaceId: string } }
+  | { name: 'workspace/invitations'; params?: { invitationId?: string } };
 
 export interface ParsedDeepLink {
   url: string;

--- a/uniqn-mobile/src/types/notification.ts
+++ b/uniqn-mobile/src/types/notification.ts
@@ -118,6 +118,10 @@ export const NotificationType = {
   REVIEW_RECEIVED: 'review_received',
   /** 평가 마감 리마인더 (D-2) */
   REVIEW_REMINDER: 'review_reminder',
+
+  // === 워크스페이스 협업 (PR #2) ===
+  /** 워크스페이스 초대 발송 (invitee 에게) */
+  WORKSPACE_INVITATION: 'workspace_invitation',
 } as const;
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare -- const/type 합성 패턴
@@ -213,6 +217,9 @@ export const NOTIFICATION_TYPE_TO_CATEGORY: Record<NotificationType, Notificatio
   [NotificationType.REVIEW_REQUEST]: NotificationCategory.REVIEW,
   [NotificationType.REVIEW_RECEIVED]: NotificationCategory.REVIEW,
   [NotificationType.REVIEW_REMINDER]: NotificationCategory.REVIEW,
+
+  // 워크스페이스 협업 (PR #2)
+  [NotificationType.WORKSPACE_INVITATION]: NotificationCategory.SYSTEM,
 };
 
 // ============================================================================
@@ -286,6 +293,9 @@ export const NOTIFICATION_DEFAULT_PRIORITY: Record<NotificationType, Notificatio
   [NotificationType.REVIEW_REQUEST]: 'normal',
   [NotificationType.REVIEW_RECEIVED]: 'normal',
   [NotificationType.REVIEW_REMINDER]: 'high',
+
+  // 워크스페이스 협업 (PR #2)
+  [NotificationType.WORKSPACE_INVITATION]: 'normal',
 };
 
 // ============================================================================
@@ -459,6 +469,9 @@ export const NOTIFICATION_TYPE_TO_CHANNEL: Record<NotificationType, AndroidChann
   [NotificationType.REVIEW_REQUEST]: AndroidChannelId.DEFAULT,
   [NotificationType.REVIEW_RECEIVED]: AndroidChannelId.DEFAULT,
   [NotificationType.REVIEW_REMINDER]: AndroidChannelId.REMINDERS,
+
+  // 워크스페이스 협업 (PR #2)
+  [NotificationType.WORKSPACE_INVITATION]: AndroidChannelId.DEFAULT,
 };
 
 // ============================================================================
@@ -525,6 +538,9 @@ export const NOTIFICATION_TYPE_LABELS: Record<NotificationType, string> = {
   [NotificationType.REVIEW_REQUEST]: '평가 요청',
   [NotificationType.REVIEW_RECEIVED]: '평가 도착',
   [NotificationType.REVIEW_REMINDER]: '평가 마감 임박',
+
+  // 워크스페이스 협업 (PR #2)
+  [NotificationType.WORKSPACE_INVITATION]: '워크스페이스 초대',
 };
 
 /**

--- a/uniqn-mobile/src/types/workspace.ts
+++ b/uniqn-mobile/src/types/workspace.ts
@@ -1,0 +1,83 @@
+/**
+ * UNIQN Mobile - 워크스페이스 도메인 타입
+ *
+ * @description 공고 워크스페이스 협업 편집 (PR #2)
+ *              camelCase 도메인 / snake_case DB 분리 (memory: supabase-patterns #1)
+ * @version 1.0.0
+ */
+
+export type WorkspaceRole = 'editor';
+
+export type WorkspaceInvitationStatus = 'pending' | 'accepted' | 'rejected' | 'revoked' | 'expired';
+
+/**
+ * 워크스페이스 (소유 + 멤버 모두 사용)
+ */
+export interface Workspace {
+  id: string;
+  name: string;
+  ownerId: string;
+  /** owner 제외한 editor 수 (UI 에서는 +1 표시) */
+  memberCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * 워크스페이스 멤버 (editor 만)
+ */
+export interface WorkspaceMember {
+  workspaceId: string;
+  userId: string;
+  role: WorkspaceRole;
+  invitedBy: string | null;
+  joinedAt: string;
+}
+
+/**
+ * 멤버 목록에 사용자 표시용 정보 결합
+ */
+export interface WorkspaceMemberWithUser extends WorkspaceMember {
+  displayName: string | null;
+  email: string | null;
+  photoUrl: string | null;
+}
+
+/**
+ * 초대
+ */
+export interface WorkspaceInvitation {
+  id: string;
+  workspaceId: string;
+  inviteeUserId: string;
+  role: WorkspaceRole;
+  invitedBy: string;
+  status: WorkspaceInvitationStatus;
+  expiresAt: string;
+  createdAt: string;
+  respondedAt: string | null;
+}
+
+/**
+ * 받은 초대 목록 (워크스페이스/초대자 정보 결합)
+ */
+export interface ReceivedWorkspaceInvitation extends WorkspaceInvitation {
+  workspaceName: string;
+  inviterDisplayName: string | null;
+}
+
+/**
+ * accept_workspace_invitation RPC 반환
+ */
+export interface AcceptInvitationResult {
+  invitationId: string;
+  workspaceId: string;
+  /** 이미 수락 완료된 초대를 다시 수락한 경우 true */
+  idempotent: boolean;
+}
+
+export const WORKSPACE_LIMITS = {
+  MAX_PER_OWNER: 10,
+  MAX_NAME_LENGTH: 50,
+  INVITATION_TTL_DAYS: 7,
+} as const;

--- a/uniqn-mobile/supabase/migrations/20260430020000_workspace_invitation_rpcs.sql
+++ b/uniqn-mobile/supabase/migrations/20260430020000_workspace_invitation_rpcs.sql
@@ -1,0 +1,294 @@
+-- 공고 워크스페이스 협업 편집 (PR #2 — RPC 레이어)
+-- atomic invitation lifecycle: invite / accept / reject / revoke / expire / remove_member
+-- 모두 SECURITY DEFINER + 명시적 권한 체크 + idempotent
+
+-- ============================================================
+-- 1. invite_workspace_member — owner 가 사용자 초대
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.invite_workspace_member(
+  p_workspace_id uuid,
+  p_invitee_user_id uuid
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_owner_id uuid;
+  v_caller_id uuid := auth.uid();
+  v_invitation_id uuid;
+BEGIN
+  IF v_caller_id IS NULL THEN
+    RAISE EXCEPTION 'AUTH_REQUIRED' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_caller_id = p_invitee_user_id THEN
+    RAISE EXCEPTION 'SELF_INVITE_FORBIDDEN' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT owner_id INTO v_owner_id FROM public.workspaces WHERE id = p_workspace_id FOR SHARE;
+  IF v_owner_id IS NULL THEN
+    RAISE EXCEPTION 'WORKSPACE_NOT_FOUND' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_owner_id != v_caller_id THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED' USING ERRCODE = '42501';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.workspace_members
+    WHERE workspace_id = p_workspace_id AND user_id = p_invitee_user_id
+  ) THEN
+    RAISE EXCEPTION 'ALREADY_MEMBER' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_owner_id = p_invitee_user_id THEN
+    RAISE EXCEPTION 'ALREADY_MEMBER' USING ERRCODE = 'P0001';
+  END IF;
+
+  BEGIN
+    INSERT INTO public.workspace_invitations (workspace_id, invitee_user_id, invited_by)
+    VALUES (p_workspace_id, p_invitee_user_id, v_caller_id)
+    RETURNING id INTO v_invitation_id;
+  EXCEPTION WHEN unique_violation THEN
+    RAISE EXCEPTION 'ALREADY_INVITED' USING ERRCODE = 'P0001';
+  END;
+
+  RETURN v_invitation_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.invite_workspace_member(uuid, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.invite_workspace_member(uuid, uuid) TO authenticated;
+
+-- ============================================================
+-- 2. accept_workspace_invitation — invitee 가 수락 (CRITICAL race-safe)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.accept_workspace_invitation(
+  p_invitation_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_caller_id uuid := auth.uid();
+  v_inv record;
+  v_already_member boolean;
+BEGIN
+  IF v_caller_id IS NULL THEN
+    RAISE EXCEPTION 'AUTH_REQUIRED' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT * INTO v_inv FROM public.workspace_invitations WHERE id = p_invitation_id FOR UPDATE;
+  IF v_inv IS NULL THEN
+    RAISE EXCEPTION 'INVITATION_NOT_FOUND' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_inv.invitee_user_id != v_caller_id THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1 FROM public.workspace_members
+    WHERE workspace_id = v_inv.workspace_id AND user_id = v_caller_id
+  ) INTO v_already_member;
+
+  IF v_inv.status = 'accepted' AND v_already_member THEN
+    RETURN jsonb_build_object(
+      'invitationId', v_inv.id,
+      'workspaceId', v_inv.workspace_id,
+      'idempotent', true
+    );
+  END IF;
+
+  IF v_inv.status != 'pending' THEN
+    RAISE EXCEPTION 'INVITATION_%', upper(v_inv.status) USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_inv.expires_at < now() THEN
+    UPDATE public.workspace_invitations
+      SET status = 'expired', responded_at = now()
+      WHERE id = p_invitation_id;
+    RAISE EXCEPTION 'INVITATION_EXPIRED' USING ERRCODE = 'P0001';
+  END IF;
+
+  INSERT INTO public.workspace_members (workspace_id, user_id, invited_by, role)
+  VALUES (v_inv.workspace_id, v_caller_id, v_inv.invited_by, v_inv.role)
+  ON CONFLICT (workspace_id, user_id) DO NOTHING;
+
+  UPDATE public.workspace_invitations
+    SET status = 'accepted', responded_at = now()
+    WHERE id = p_invitation_id;
+
+  RETURN jsonb_build_object(
+    'invitationId', v_inv.id,
+    'workspaceId', v_inv.workspace_id,
+    'idempotent', false
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.accept_workspace_invitation(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.accept_workspace_invitation(uuid) TO authenticated;
+
+-- ============================================================
+-- 3. reject_workspace_invitation
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.reject_workspace_invitation(
+  p_invitation_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_caller_id uuid := auth.uid();
+  v_inv record;
+BEGIN
+  IF v_caller_id IS NULL THEN
+    RAISE EXCEPTION 'AUTH_REQUIRED' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT * INTO v_inv FROM public.workspace_invitations WHERE id = p_invitation_id FOR UPDATE;
+  IF v_inv IS NULL THEN
+    RAISE EXCEPTION 'INVITATION_NOT_FOUND' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_inv.invitee_user_id != v_caller_id THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_inv.status = 'rejected' THEN
+    RETURN;
+  END IF;
+
+  IF v_inv.status != 'pending' THEN
+    RAISE EXCEPTION 'INVITATION_%', upper(v_inv.status) USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.workspace_invitations
+    SET status = 'rejected', responded_at = now()
+    WHERE id = p_invitation_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.reject_workspace_invitation(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.reject_workspace_invitation(uuid) TO authenticated;
+
+-- ============================================================
+-- 4. revoke_workspace_invitation
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.revoke_workspace_invitation(
+  p_invitation_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_caller_id uuid := auth.uid();
+  v_inv record;
+  v_owner_id uuid;
+BEGIN
+  IF v_caller_id IS NULL THEN
+    RAISE EXCEPTION 'AUTH_REQUIRED' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT * INTO v_inv FROM public.workspace_invitations WHERE id = p_invitation_id FOR UPDATE;
+  IF v_inv IS NULL THEN
+    RAISE EXCEPTION 'INVITATION_NOT_FOUND' USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT owner_id INTO v_owner_id FROM public.workspaces WHERE id = v_inv.workspace_id;
+  IF v_owner_id != v_caller_id THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_inv.status = 'revoked' THEN
+    RETURN;
+  END IF;
+
+  IF v_inv.status != 'pending' THEN
+    RAISE EXCEPTION 'INVITATION_%', upper(v_inv.status) USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.workspace_invitations
+    SET status = 'revoked', responded_at = now()
+    WHERE id = p_invitation_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.revoke_workspace_invitation(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.revoke_workspace_invitation(uuid) TO authenticated;
+
+-- ============================================================
+-- 5. remove_workspace_member
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.remove_workspace_member(
+  p_workspace_id uuid,
+  p_user_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_caller_id uuid := auth.uid();
+  v_owner_id uuid;
+BEGIN
+  IF v_caller_id IS NULL THEN
+    RAISE EXCEPTION 'AUTH_REQUIRED' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT owner_id INTO v_owner_id FROM public.workspaces WHERE id = p_workspace_id FOR SHARE;
+  IF v_owner_id IS NULL THEN
+    RAISE EXCEPTION 'WORKSPACE_NOT_FOUND' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_owner_id != v_caller_id THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_user_id = v_owner_id THEN
+    RAISE EXCEPTION 'CANNOT_REMOVE_OWNER' USING ERRCODE = 'P0001';
+  END IF;
+
+  DELETE FROM public.workspace_members
+    WHERE workspace_id = p_workspace_id AND user_id = p_user_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.remove_workspace_member(uuid, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.remove_workspace_member(uuid, uuid) TO authenticated;
+
+-- ============================================================
+-- 6. expire_pending_workspace_invitations — pg_cron 일 1회 호출
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.expire_pending_workspace_invitations()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_count integer;
+BEGIN
+  WITH expired AS (
+    UPDATE public.workspace_invitations
+      SET status = 'expired', responded_at = now()
+      WHERE status = 'pending' AND expires_at < now()
+      RETURNING 1
+  )
+  SELECT count(*) INTO v_count FROM expired;
+  RETURN v_count;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.expire_pending_workspace_invitations() FROM PUBLIC, anon, authenticated;
+COMMENT ON FUNCTION public.expire_pending_workspace_invitations IS 'pg_cron 일 1회 호출 — pending 초대 만료 처리. 알림 없음 (D3).';

--- a/uniqn-mobile/supabase/migrations/20260430020100_workspace_invitation_expiry_cron.sql
+++ b/uniqn-mobile/supabase/migrations/20260430020100_workspace_invitation_expiry_cron.sql
@@ -1,0 +1,15 @@
+-- 공고 워크스페이스 협업 편집 (PR #2 — pg_cron expiry)
+-- KST 자정 (00:05) 일 1회 expire_pending_workspace_invitations 호출
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM cron.job WHERE jobname = 'expire-pending-workspace-invitations-daily'
+  ) THEN
+    PERFORM cron.schedule(
+      'expire-pending-workspace-invitations-daily',
+      '5 15 * * *',  -- 15:05 UTC = 00:05 KST 다음 날
+      $cron$ SELECT public.expire_pending_workspace_invitations(); $cron$
+    );
+  END IF;
+END$$;

--- a/uniqn-mobile/supabase/migrations/20260430020200_workspace_invitation_notify_trigger.sql
+++ b/uniqn-mobile/supabase/migrations/20260430020200_workspace_invitation_notify_trigger.sql
@@ -1,0 +1,58 @@
+-- 공고 워크스페이스 협업 편집 (PR #2) — 초대 시 인앱 알림 INSERT
+-- workspace_invitations INSERT (status='pending') 시 notifications 에 row 추가.
+-- 푸시 발송은 기존 notifications-push trigger 가 자동 처리.
+
+CREATE OR REPLACE FUNCTION public.notify_on_workspace_invitation_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_workspace_name text;
+  v_inviter_name text;
+BEGIN
+  IF NEW.status != 'pending' THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT name INTO v_workspace_name FROM public.workspaces WHERE id = NEW.workspace_id;
+  SELECT COALESCE(name, '알 수 없음') INTO v_inviter_name FROM public.users WHERE id = NEW.invited_by;
+
+  v_workspace_name := COALESCE(v_workspace_name, '워크스페이스');
+  v_inviter_name := COALESCE(v_inviter_name, '알 수 없음');
+
+  INSERT INTO public.notifications (
+    recipient_id, type, title, body, link, data, priority
+  )
+  VALUES (
+    NEW.invitee_user_id,
+    'workspace_invitation',
+    format('%s님이 워크스페이스에 초대했어요', v_inviter_name),
+    format('%s · 편집자 권한', v_workspace_name),
+    format('/workspace/invitations'),
+    jsonb_build_object(
+      'invitationId', NEW.id,
+      'workspaceId', NEW.workspace_id,
+      'workspaceName', v_workspace_name,
+      'inviterName', v_inviter_name,
+      'senderId', NEW.invited_by
+    ),
+    'normal'
+  );
+
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING '[notify_on_workspace_invitation_insert] failed for invitation % — %', NEW.id, SQLERRM;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS workspace_invitation_notify_insert ON public.workspace_invitations;
+CREATE TRIGGER workspace_invitation_notify_insert
+AFTER INSERT ON public.workspace_invitations
+FOR EACH ROW
+EXECUTE FUNCTION public.notify_on_workspace_invitation_insert();
+
+REVOKE EXECUTE ON FUNCTION public.notify_on_workspace_invitation_insert() FROM PUBLIC, anon, authenticated;
+COMMENT ON FUNCTION public.notify_on_workspace_invitation_insert IS '워크스페이스 초대 발송 시 invitee 에게 인앱 알림 INSERT (push 발송은 기존 trigger 가 처리).';

--- a/uniqn-mobile/supabase/migrations/20260507000000_workspace_backfill_employers_and_job_postings.sql
+++ b/uniqn-mobile/supabase/migrations/20260507000000_workspace_backfill_employers_and_job_postings.sql
@@ -1,0 +1,59 @@
+-- 공고 워크스페이스 협업 편집 (PR #4 — M2 백필)
+-- production-critical: 모든 employer 에 1인 워크스페이스 자동 생성 + 본인 공고 workspace_id 채움.
+-- 트랜잭션 boundary: 함수 1회 호출 = 단일 트랜잭션. 실패 시 자동 rollback.
+-- 멱등성: 이미 owner 인 워크스페이스가 있으면 스킵, 이미 채워진 workspace_id 도 스킵.
+-- 적용 후 검증: jp_null_workspace = 0 AND owner_workspace_drift = 0.
+
+DO $$
+DECLARE
+  v_seeded_workspaces integer := 0;
+  v_backfilled_postings integer := 0;
+  v_null_remaining integer;
+BEGIN
+  -- 1) 기존 employer 1인 워크스페이스 자동 생성 (멱등)
+  WITH inserted AS (
+    INSERT INTO public.workspaces (id, name, owner_id, member_count, created_at)
+    SELECT
+      gen_random_uuid(),
+      COALESCE(NULLIF(u.name, ''), NULLIF(u.email, ''), '내') || ' 워크스페이스',
+      u.id,
+      0,
+      now()
+    FROM public.users u
+    WHERE u.role = 'employer'
+      AND u.is_active = true
+      AND NOT EXISTS (SELECT 1 FROM public.workspaces w WHERE w.owner_id = u.id)
+    RETURNING 1
+  )
+  SELECT count(*) INTO v_seeded_workspaces FROM inserted;
+  RAISE NOTICE '워크스페이스 신규 생성: %', v_seeded_workspaces;
+
+  -- 2) 본인 공고 workspace_id 채움 (NULL 인 row 만, 멱등)
+  WITH backfilled AS (
+    UPDATE public.job_postings jp
+    SET workspace_id = w.id
+    FROM public.workspaces w
+    WHERE jp.owner_id = w.owner_id
+      AND jp.workspace_id IS NULL
+    RETURNING 1
+  )
+  SELECT count(*) INTO v_backfilled_postings FROM backfilled;
+  RAISE NOTICE '공고 backfill: %', v_backfilled_postings;
+
+  -- 3) 검증 — active employer 가 작성한 공고는 NULL 이면 안 됨
+  SELECT count(*)
+  INTO v_null_remaining
+  FROM public.job_postings jp
+  WHERE jp.workspace_id IS NULL
+    AND jp.owner_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1 FROM public.users u
+      WHERE u.id = jp.owner_id AND u.role = 'employer' AND u.is_active = true
+    );
+
+  IF v_null_remaining > 0 THEN
+    RAISE EXCEPTION 'BACKFILL_INCOMPLETE: % active-employer job_postings still have NULL workspace_id', v_null_remaining;
+  END IF;
+
+  RAISE NOTICE 'M2 백필 완료 — 신규 워크스페이스 % / 백필 공고 % / 잔여 NULL 0', v_seeded_workspaces, v_backfilled_postings;
+END$$;

--- a/uniqn-mobile/supabase/migrations/20260514000000_workspace_m3_workspace_id_not_null.sql
+++ b/uniqn-mobile/supabase/migrations/20260514000000_workspace_m3_workspace_id_not_null.sql
@@ -1,0 +1,21 @@
+-- 공고 워크스페이스 협업 편집 (PR #5 — M3 NOT NULL 전환)
+-- PR #4 백필 후 jp_null_workspace=0 검증 완료 → NOT NULL 안전.
+-- 사전 확인 (방어): NULL 잔여 시 트랜잭션 자동 rollback.
+
+DO $$
+DECLARE
+  v_null_count integer;
+BEGIN
+  SELECT count(*) INTO v_null_count
+  FROM public.job_postings WHERE workspace_id IS NULL;
+
+  IF v_null_count > 0 THEN
+    RAISE EXCEPTION 'M3_PRECONDITION_FAILED: % job_postings have NULL workspace_id', v_null_count;
+  END IF;
+END$$;
+
+ALTER TABLE public.job_postings
+  ALTER COLUMN workspace_id SET NOT NULL;
+
+COMMENT ON COLUMN public.job_postings.workspace_id IS
+  'NOT NULL 보장 (M3 — PR #5). RLS 가 workspace 멤버십으로 권한 강제.';

--- a/uniqn-mobile/supabase/migrations/20260514010000_workspace_m3_consolidate_jp_rls.sql
+++ b/uniqn-mobile/supabase/migrations/20260514010000_workspace_m3_consolidate_jp_rls.sql
@@ -1,0 +1,39 @@
+-- 공고 워크스페이스 협업 편집 (PR #5 — M3 RLS 정리)
+-- workspace_id NOT NULL 이 된 후, 기존 owner_id 기반 jp_update / jp_delete 가 redundant.
+-- workspace 정책에 admin 분기 추가 → 단일 정책으로 통합.
+-- supabase advisors 0006 multiple_permissive_policies WARN 해소.
+
+-- ============================================================
+-- 1. UPDATE 정책 통합 — workspace member OR admin
+-- ============================================================
+DROP POLICY IF EXISTS jp_update ON public.job_postings;
+DROP POLICY IF EXISTS jp_update_workspace_member ON public.job_postings;
+
+CREATE POLICY jp_update_workspace_member
+  ON public.job_postings FOR UPDATE TO authenticated
+  USING (
+    public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+    OR (SELECT public.is_admin())
+  )
+  WITH CHECK (
+    public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+    OR (SELECT public.is_admin())
+  );
+
+-- ============================================================
+-- 2. DELETE 정책 통합 — workspace owner OR admin
+-- ============================================================
+DROP POLICY IF EXISTS jp_delete ON public.job_postings;
+DROP POLICY IF EXISTS jp_delete_workspace_owner ON public.job_postings;
+
+CREATE POLICY jp_delete_workspace_owner
+  ON public.job_postings FOR DELETE TO authenticated
+  USING (
+    workspace_id IN (
+      SELECT id FROM public.workspaces WHERE owner_id = (SELECT auth.uid())
+    )
+    OR (SELECT public.is_admin())
+  );
+
+-- jp_select 는 owner_id 참조를 그대로 유지 (M4 RENAME 후속 PR 에서 정리).
+-- jp_insert 는 변경 없음 (employer/admin role 체크).

--- a/uniqn-mobile/supabase/migrations/20260514020000_workspace_m5_patch_wallet_create_job_posting_rpc.sql
+++ b/uniqn-mobile/supabase/migrations/20260514020000_workspace_m5_patch_wallet_create_job_posting_rpc.sql
@@ -1,0 +1,107 @@
+-- 공고 워크스페이스 협업 편집 (PR #5 amendment) — wallet RPC workspace_id 주입
+-- M3 후 job_postings.workspace_id NOT NULL 이라 기존 wallet RPC 가 INSERT 시 NOT NULL 위반.
+-- 수정: 페이로드에 workspace_id 가 없으면 owner 의 workspace 에서 자동 주입.
+-- 기존 RPC 시그니처 / 동작 / 권한 보존 — workspace_id resolution 만 추가.
+-- 의존성 — M2 백필 완료 (모든 active employer 가 workspace 보유) 가 전제.
+
+CREATE OR REPLACE FUNCTION public.create_job_posting_with_payment_atomically(
+  p_owner_id        UUID,
+  p_posting_payload JSONB,
+  p_cost_diamonds   INT,
+  p_reason          wallet_reason
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_posting_id        UUID;
+  v_consume_result    JSONB;
+  v_diamonds_consumed INT := 0;
+  v_heart_consumed    INT := 0;
+  v_defaults          JSONB;
+  v_final_payload     JSONB;
+  v_resolved_workspace_id UUID;
+BEGIN
+  IF p_owner_id IS NULL THEN
+    RAISE EXCEPTION 'INVALID_OWNER_ID: cannot be NULL';
+  END IF;
+  IF p_posting_payload IS NULL THEN
+    RAISE EXCEPTION 'INVALID_PAYLOAD: cannot be NULL';
+  END IF;
+  IF p_cost_diamonds < 0 THEN
+    RAISE EXCEPTION 'INVALID_AMOUNT: cost_diamonds % must be >= 0', p_cost_diamonds;
+  END IF;
+
+  -- workspace_id 자동 주입: 페이로드에 없으면 owner 의 1번째 workspace 에서 lookup
+  IF NOT (p_posting_payload ? 'workspace_id') OR (p_posting_payload->>'workspace_id') IS NULL THEN
+    SELECT id INTO v_resolved_workspace_id
+    FROM public.workspaces
+    WHERE owner_id = p_owner_id
+    ORDER BY created_at ASC
+    LIMIT 1;
+
+    IF v_resolved_workspace_id IS NULL THEN
+      RAISE EXCEPTION 'WORKSPACE_NOT_FOUND: owner % has no workspace — backfill 누락', p_owner_id;
+    END IF;
+  END IF;
+
+  v_defaults := jsonb_build_object(
+    'id',                gen_random_uuid(),
+    'schema_version',    3,
+    'status',            'draft',
+    'posting_type',      'regular',
+    'created_at',        now(),
+    'updated_at',        now(),
+    'location',          '{}'::jsonb,
+    'schedule',          '{}'::jsonb,
+    'role_catalog',      '[]'::jsonb,
+    'compensation',      '{}'::jsonb,
+    'questions',         jsonb_build_object('items', '[]'::jsonb),
+    'stats',             jsonb_build_object(
+                           'filledPositions', 0,
+                           'totalApplicants', 0,
+                           'activeApplicants', 0,
+                           'confirmedApplicants', 0,
+                           'cancellationPendingApplicants', 0
+                         ),
+    'total_positions',   0,
+    'filled_positions',  0,
+    'view_count',        0,
+    'is_featured',       false
+  );
+
+  v_final_payload := v_defaults || p_posting_payload || jsonb_build_object('owner_id', p_owner_id);
+
+  IF v_resolved_workspace_id IS NOT NULL THEN
+    v_final_payload := v_final_payload || jsonb_build_object('workspace_id', v_resolved_workspace_id);
+  END IF;
+
+  INSERT INTO public.job_postings
+  SELECT * FROM jsonb_populate_record(NULL::public.job_postings, v_final_payload)
+  RETURNING id INTO v_posting_id;
+
+  IF p_cost_diamonds > 0 THEN
+    v_consume_result := public.consume_diamonds_atomically(
+      p_owner_id,
+      p_cost_diamonds,
+      p_reason,
+      v_posting_id,
+      'job_posting'
+    );
+    v_diamonds_consumed := COALESCE((v_consume_result->>'diamond_consumed')::int, 0);
+    v_heart_consumed    := COALESCE((v_consume_result->>'heart_consumed')::int, 0);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'posting_id', v_posting_id,
+    'diamonds_consumed', v_diamonds_consumed,
+    'hearts_consumed', v_heart_consumed,
+    'total_consumed', v_diamonds_consumed + v_heart_consumed
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.create_job_posting_with_payment_atomically IS
+  'job_postings INSERT + 다이아 차감을 단일 트랜잭션으로. workspace_id 자동 주입 (M3 NOT NULL 호환). consume RPC가 INSUFFICIENT_BALANCE 던지면 공고 INSERT까지 롤백. tournament(cost=0)는 차감 skip.';


### PR DESCRIPTION
## Summary

PR #4 위에 stack — **cleanup 단계**. 사용자 게이트에 따라 **M4 (owner_id rename) 는 별도 PR/세션 연기**.

## 적용 사항

### M3 — workspace_id NOT NULL
- 사전 검증: `WHERE workspace_id IS NULL` count 확인 (실패 시 트랜잭션 rollback)
- `ALTER COLUMN workspace_id SET NOT NULL`
- `database.types.ts` regen — `workspace_id: string` (nullable 아님)

### RLS 통합
- **DROP** `jp_update` (owner_id 기반) + `jp_update_workspace_member`
- **CREATE** `jp_update_workspace_member` (workspace member OR admin 통합)
- **DROP** `jp_delete` (admin only) + `jp_delete_workspace_owner`
- **CREATE** `jp_delete_workspace_owner` (workspace owner OR admin 통합)
- supabase advisors `multiple_permissive_policies` WARN 해소

## 연기된 항목 (사용자 게이트 결정)

- **M4** `ALTER TABLE job_postings RENAME COLUMN owner_id TO created_by`
- jp_select / app_select / app_update / qr_select 의 owner_id 참조 정리
- src/types/jobPosting.ts `ownerId` → `createdBy` + 12 files 일괄 rename

이유: production 공유 DB destructive change 는 별도 사용자 게이트 + 코드 일괄 수정 완료 후 적용해야 안전. 본 PR 은 reversible 변경만 포함.

## Test plan

- [x] MCP apply_migration 2건 성공
- [x] DB 사전 검증 (workspace_id NULL = 0)
- [x] 사후 RLS 검증 (jp_update_workspace_member / jp_delete_workspace_owner 단일 정책 확인)
- [x] types regen, schema test NOT NULL 계약으로 갱신
- [x] npm run quality 통과 (typecheck + lint 0 errors + format clean)
- [x] 전체 Jest 3928/3930 통과 (실패 2건은 master 의 사전 결함, 본 PR 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)