### PR TITLE
feat(workspace): 워크스페이스 진입로 추가 (settings + employer tab header)

### DIFF
--- a/uniqn-mobile/app/(app)/(tabs)/employer.tsx
+++ b/uniqn-mobile/app/(app)/(tabs)/employer.tsx
@@ -9,7 +9,8 @@ import { Button, ConfirmModal, PostingSurfaceState } from '@/components';
 import { EventQRModal } from '@/components/employer/qr/EventQRModal';
 import { JobPostingCard, NonEmployerView } from '@/components/employer';
 import { TabHeader } from '@/components/headers';
-import { BriefcaseIcon, PlusIcon } from '@/components/icons';
+import { BriefcaseIcon, PlusIcon, UsersIcon } from '@/components/icons';
+import { getIconColor } from '@/constants';
 import { buildPostingFacts } from '@/domains/job-posting';
 import {
   useCloseJobPosting,
@@ -118,6 +119,7 @@ function EmployerView() {
   const { data: postings, isLoading, error, refetch, isRefetching } = useMyJobPostings();
   const closeMutation = useCloseJobPosting();
   const reopenMutation = useReopenJobPosting();
+  const isDarkMode = useThemeStore((s) => s.isDarkMode);
   const [filter, setFilter] = useState<FilterStatus>('all');
   const [closeTargetId, setCloseTargetId] = useState<string | null>(null);
   const [reopenTargetId, setReopenTargetId] = useState<string | null>(null);
@@ -221,7 +223,20 @@ function EmployerView() {
   if (isLoading) {
     return (
       <SafeAreaView className="flex-1 bg-surface-page dark:bg-surface" edges={['top']}>
-        <TabHeader title="내 공고" />
+        <TabHeader
+          title="내 공고"
+          rightAction={
+            <Pressable
+              onPress={() => router.push('/(employer)/workspace')}
+              className="rounded-sm p-2"
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel="워크스페이스"
+            >
+              <UsersIcon size={22} color={getIconColor(isDarkMode, 'primary')} />
+            </Pressable>
+          }
+        />
         <PostingSurfaceState mode="loading" scope="detail" message="공고 목록을 불러오는 중..." />
       </SafeAreaView>
     );
@@ -230,7 +245,20 @@ function EmployerView() {
   if (error) {
     return (
       <SafeAreaView className="flex-1 bg-surface-page dark:bg-surface" edges={['top']}>
-        <TabHeader title="내 공고" />
+        <TabHeader
+          title="내 공고"
+          rightAction={
+            <Pressable
+              onPress={() => router.push('/(employer)/workspace')}
+              className="rounded-sm p-2"
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel="워크스페이스"
+            >
+              <UsersIcon size={22} color={getIconColor(isDarkMode, 'primary')} />
+            </Pressable>
+          }
+        />
         <PostingSurfaceState
           mode="error"
           scope="detail"
@@ -245,7 +273,20 @@ function EmployerView() {
 
   return (
     <SafeAreaView className="flex-1 bg-surface-page dark:bg-surface" edges={['top']}>
-      <TabHeader title="내 공고" />
+      <TabHeader
+        title="내 공고"
+        rightAction={
+          <Pressable
+            onPress={() => router.push('/(employer)/workspace')}
+            className="rounded-sm p-2"
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel="워크스페이스"
+          >
+            <UsersIcon size={22} color={getIconColor(isDarkMode, 'primary')} />
+          </Pressable>
+        }
+      />
 
       <View className="px-4 py-3">
         <Button

--- a/uniqn-mobile/app/(app)/settings/index.tsx
+++ b/uniqn-mobile/app/(app)/settings/index.tsx
@@ -27,11 +27,14 @@ import {
   LogOutIcon,
   ChevronRightIcon,
   TrashIcon,
+  BriefcaseIcon,
+  InboxIcon,
 } from '@/components/icons';
+import { useReceivedWorkspaceInvitations } from '@/hooks/workspace';
 import { pushNotificationService } from '@/services/notifications/pushNotificationService';
 import { useThemeStore } from '@/stores/themeStore';
 import { useModalStore } from '@/stores/modalStore';
-import { useAuthStore } from '@/stores/authStore';
+import { useAuthStore, useHasRole } from '@/stores/authStore';
 import { useToastStore } from '@/stores/toastStore';
 import {
   useNotificationSettingsQuery,
@@ -102,6 +105,11 @@ function SettingItem({ icon, label, value, onPress, rightElement }: SettingItemP
 
 export default function SettingsScreen() {
   const { isAuthenticated, profile, user } = useAuth();
+
+  // 워크스페이스 협업 — employer 만 진입 (라우트 가드와 일치)
+  const isEmployer = useHasRole('employer');
+  const { invitations: pendingInvitations } = useReceivedWorkspaceInvitations();
+  const pendingInvitationsCount = pendingInvitations?.length ?? 0;
 
   // 테마 설정
   const { isDarkMode, setTheme } = useThemeStore();
@@ -299,6 +307,27 @@ export default function SettingsScreen() {
             }
           />
         </Card>
+
+        {/* 공고 협업 (워크스페이스) — employer 전용 */}
+        {isAuthenticated && isEmployer && (
+          <Card className="mb-4">
+            <Text className="text-[10px] uppercase tracking-wider text-content-muted font-sans-bold mb-2">
+              공고 협업
+            </Text>
+            <SettingItem
+              icon={<BriefcaseIcon size={22} color={SECONDARY_PALETTE[500]} />}
+              label="워크스페이스"
+              onPress={() => router.push('/(employer)/workspace')}
+            />
+            <Divider spacing="sm" />
+            <SettingItem
+              icon={<InboxIcon size={22} color={SECONDARY_PALETTE[500]} />}
+              label="받은 초대"
+              value={pendingInvitationsCount > 0 ? `${pendingInvitationsCount}건` : undefined}
+              onPress={() => router.push('/(employer)/workspace/invitations')}
+            />
+          </Card>
+        )}
 
         {/* 계정 설정 */}
         <Card className="mb-4">


### PR DESCRIPTION
## Summary

PR #48~52 머지 후 워크스페이스 화면이 push 알림 외에는 도달 불가능했던 chicken-and-egg 문제 해소.

## 진입로 2개

1. **(app)/settings 의 "공고 협업" Card** (employer 만 노출)
   - "워크스페이스" → `/(employer)/workspace`
   - "받은 초대" → `/(employer)/workspace/invitations`
   - pending 초대 N건 시 우측 badge 자동 표시

2. **(app)/(tabs)/employer "내 공고" 탭의 TabHeader rightAction**
   - UsersIcon 한 번 탭으로 워크스페이스 진입
   - 모든 분기 (loading / error / success) 모두 동일하게 노출

## 권한 일관성

employer 외 사용자(staff/admin)는 (employer) 라우트 가드에 막혀 직접 접근 불가 — 진입로도 노출 안 함.

## Test plan

- [x] npm run quality 통과 (typecheck + lint 0 errors + format clean)
- [x] employer/staff/admin 역할 분기 코드 리뷰
- [x] pending invitations badge 조건부 렌더링 (count > 0 일 때만)
- [ ] EAS 빌드 후 실기기 검증 — 다음 빌드 사이클에서

🤖 Generated with [Claude Code](https://claude.com/claude-code)