### PR TITLE
feat(wallet): 결제 시스템 Phase 1+2 — DB Foundation + RevenueCat Webhook

### DIFF
--- a/docs/superpowers/plans/2026-04-26-monetization.md
+++ b/docs/superpowers/plans/2026-04-26-monetization.md
@@ -1,0 +1,1821 @@
+# Monetization Implementation Plan — Phase 1: DB Foundation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** UNIQN 결제 시스템(하트/다이아 wallet)의 Postgres 기반(테이블 + RLS + RPC + trigger + seed)을 구축한다. Phase 1 종료 시점에 SQL/psql로 purchase/consume/refund 시뮬레이션이 모두 작동해야 한다.
+
+**Architecture:** Append-only `wallet_ledger` + cached `wallets` (trigger 동기화) + FIFO `heart_lots` + 카탈로그 `diamond_products`. 모든 잔액 변동은 `SECURITY DEFINER` RPC를 거치며 RLS는 본인 SELECT만 허용. Idempotency는 `wallet_ledger.revenuecat_transaction_id UNIQUE`로 강제.
+
+**Tech Stack:** Supabase Postgres 15, plpgsql, pg_cron, MCP `apply_migration`, Jest (RPC integration tests via supabase-js).
+
+**Spec:** `docs/superpowers/specs/2026-04-26-monetization-design.md` (Locked, 2026-04-26)
+
+**Out of Scope (별도 후속 plan):**
+- Phase 2: RevenueCat Webhook Edge Function (`docs/superpowers/plans/2026-04-XX-monetization-webhook.md` 예정)
+- Phase 3: Client SDK + Wallet UI
+- Phase 4: jobManagement 차감 통합
+- Phase 5: 하트 적립 흐름 (signup/attendance/referral/review)
+- Phase 6: Feature Flag rollout 전환
+- Phase 7: 환불 정책 RPC 통합 + 모니터링
+
+---
+
+## File Structure (Phase 1)
+
+| 파일 | 책임 |
+|---|---|
+| `uniqn-mobile/supabase/migrations/20260427000000_create_wallet_enums_and_tables.sql` | ENUM 2개 + 테이블 4개 + 인덱스 |
+| `uniqn-mobile/supabase/migrations/20260427000100_create_wallet_rls.sql` | RLS 정책 7개 |
+| `uniqn-mobile/supabase/migrations/20260427000200_create_wallet_balance_trigger.sql` | `tr_wallet_ledger_update_balance` (캐시 sync) |
+| `uniqn-mobile/supabase/migrations/20260427000300_create_consume_diamonds_rpc.sql` | `consume_diamonds_atomically` |
+| `uniqn-mobile/supabase/migrations/20260427000400_create_credit_diamonds_rpc.sql` | `credit_diamonds_atomically` (+첫충전 보너스) |
+| `uniqn-mobile/supabase/migrations/20260427000500_create_grant_heart_rpc.sql` | `grant_heart_atomically` + `get_wallet_summary` |
+| `uniqn-mobile/supabase/migrations/20260427000600_create_create_job_posting_with_payment_rpc.sql` | wrapper RPC (consume + INSERT job_postings 단일 트랜잭션) |
+| `uniqn-mobile/supabase/migrations/20260427000700_create_refund_job_cancellation_rpc.sql` | `refund_job_cancellation_atomically` (24h 100% / 이후 50%) |
+| `uniqn-mobile/supabase/migrations/20260427000800_seed_diamond_products.sql` | 6개 SKU 시드 |
+| `uniqn-mobile/supabase/migrations/20260427000900_seed_app_config_monetization.sql` | Feature flag JSONB 시드 |
+| `uniqn-mobile/supabase/migrations/20260427001000_create_heart_expiry_cron.sql` | pg_cron 매일 KST 자정 만료 처리 |
+| `uniqn-mobile/src/repositories/supabase/WalletRepository.ts` | TypeScript 클라이언트 인터페이스 (Phase 1은 read-only 메서드만) |
+| `uniqn-mobile/src/types/wallet.ts` | TypeScript types + Zod schemas |
+| `uniqn-mobile/src/__tests__/wallet/walletRpcs.integration.test.ts` | RPC 통합 테스트 (Supabase test instance) |
+
+---
+
+## Pre-Flight (Phase 1 시작 전 1회)
+
+- [ ] **Step 0.1: 브랜치 확인**
+  ```bash
+  cd /c/Users/user/Desktop/T-HOLDEM
+  git branch --show-current
+  ```
+  Expected: `design/monetization-system`
+
+- [ ] **Step 0.2: spec 읽기**
+  ```bash
+  ls -la docs/superpowers/specs/2026-04-26-monetization-design.md
+  ```
+  Expected: 파일 존재. 의심나면 §3 (DB 스키마) 다시 읽기.
+
+- [ ] **Step 0.3: Supabase MCP 연결 확인**
+  Tool call: `mcp__supabase__list_tables({ schemas: ["public"], verbose: false })`
+  Expected: 26개 public 테이블, wallets/wallet_ledger/heart_lots/diamond_products **없음** (그린필드 확인).
+
+---
+
+## Task 1: ENUM + 테이블 4개 마이그레이션
+
+**Files:**
+- Create: `uniqn-mobile/supabase/migrations/20260427000000_create_wallet_enums_and_tables.sql`
+
+- [ ] **Step 1.1: 마이그레이션 파일 작성**
+
+```sql
+-- Wallet 시스템 기반: ENUM 2개 + 테이블 4개
+-- Spec: docs/superpowers/specs/2026-04-26-monetization-design.md §3
+
+CREATE TYPE wallet_currency AS ENUM ('heart', 'diamond');
+
+CREATE TYPE wallet_reason AS ENUM (
+  'purchase',
+  'consume_job_posting',
+  'consume_job_extend',
+  'consume_job_upgrade',
+  'refund_purchase',
+  'refund_job_cancelled',
+  'grant_signup',
+  'grant_daily_attendance',
+  'grant_streak_7d',
+  'grant_review',
+  'grant_referral',
+  'grant_admin',
+  'grant_first_purchase_bonus',
+  'expire_heart'
+);
+
+CREATE TABLE public.diamond_products (
+  product_id      TEXT PRIMARY KEY,
+  diamonds        INT  NOT NULL CHECK (diamonds > 0),
+  bonus_diamonds  INT  NOT NULL DEFAULT 0,
+  price_krw       INT  NOT NULL,
+  display_order   INT  NOT NULL DEFAULT 0,
+  active          BOOLEAN NOT NULL DEFAULT true,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE public.wallets (
+  user_id          UUID PRIMARY KEY REFERENCES public.users(id) ON DELETE CASCADE,
+  heart_balance    INT NOT NULL DEFAULT 0 CHECK (heart_balance >= 0),
+  diamond_balance  INT NOT NULL DEFAULT 0 CHECK (diamond_balance >= 0),
+  lifetime_purchased_diamonds INT NOT NULL DEFAULT 0,
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE public.wallet_ledger (
+  id                        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                   UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  currency_type             wallet_currency NOT NULL,
+  delta                     INT NOT NULL,
+  reason                    wallet_reason NOT NULL,
+  ref_id                    UUID,
+  ref_type                  TEXT,
+  balance_after_heart       INT NOT NULL,
+  balance_after_diamond     INT NOT NULL,
+  revenuecat_transaction_id TEXT UNIQUE,
+  metadata                  JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at                TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_wallet_ledger_user_created
+  ON public.wallet_ledger(user_id, created_at DESC);
+
+CREATE INDEX idx_wallet_ledger_ref
+  ON public.wallet_ledger(ref_type, ref_id)
+  WHERE ref_id IS NOT NULL;
+
+CREATE TABLE public.heart_lots (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id          UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  amount_initial   INT NOT NULL CHECK (amount_initial > 0),
+  amount_remaining INT NOT NULL CHECK (amount_remaining >= 0),
+  granted_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at       TIMESTAMPTZ NOT NULL,
+  source           wallet_reason NOT NULL,
+  source_ref_id   UUID,
+  CONSTRAINT chk_amount_remaining_lte_initial
+    CHECK (amount_remaining <= amount_initial)
+);
+
+CREATE INDEX idx_heart_lots_user_expiring
+  ON public.heart_lots(user_id, expires_at)
+  WHERE amount_remaining > 0;
+
+COMMENT ON TABLE public.wallets IS 'Cached balance per user. Updated by tr_wallet_ledger_update_balance trigger from wallet_ledger inserts. Source of truth is wallet_ledger.';
+COMMENT ON TABLE public.wallet_ledger IS 'Append-only ledger. Never UPDATE/DELETE. Refunds are new negative-delta rows. revenuecat_transaction_id UNIQUE provides webhook idempotency.';
+COMMENT ON TABLE public.heart_lots IS 'FIFO consumption units for free hearts (90-day expiry). Soonest-expiring lot consumed first.';
+```
+
+- [ ] **Step 1.2: MCP 적용**
+
+Tool call:
+```
+mcp__supabase__apply_migration({
+  name: "create_wallet_enums_and_tables",
+  query: <위 SQL 전문>
+})
+```
+Expected: success, no error.
+
+- [ ] **Step 1.3: 적용 검증**
+
+Tool call: `mcp__supabase__list_tables({ schemas: ["public"], verbose: false })`
+Expected: `public.wallets`, `public.wallet_ledger`, `public.heart_lots`, `public.diamond_products` 4개 새 테이블 확인.
+
+- [ ] **Step 1.4: ENUM 검증**
+
+Tool call:
+```
+mcp__supabase__execute_sql({
+  query: "SELECT typname, array_agg(enumlabel ORDER BY enumsortorder) FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid WHERE typname IN ('wallet_currency','wallet_reason') GROUP BY typname"
+})
+```
+Expected: `wallet_currency` = `[heart, diamond]`, `wallet_reason` = 14개 enum.
+
+- [ ] **Step 1.5: 마이그레이션 파일도 디스크에 저장 (registry 일치)**
+
+```bash
+cp <MCP가 적용한 내용> uniqn-mobile/supabase/migrations/20260427000000_create_wallet_enums_and_tables.sql
+```
+실제로는 동일 SQL을 Write tool로 직접 디스크에 저장.
+
+- [ ] **Step 1.6: 커밋**
+
+```bash
+git add uniqn-mobile/supabase/migrations/20260427000000_create_wallet_enums_and_tables.sql
+git commit -m "feat(wallet): ENUM + 4개 테이블 (wallet_ledger ledger 모델)"
+```
+
+---
+
+## Task 2: RLS 정책
+
+**Files:**
+- Create: `uniqn-mobile/supabase/migrations/20260427000100_create_wallet_rls.sql`
+
+- [ ] **Step 2.1: 마이그레이션 파일 작성**
+
+```sql
+-- Wallet RLS: 본인 SELECT만, 모든 쓰기는 SECURITY DEFINER RPC 경유
+-- Spec §3.5
+
+ALTER TABLE public.wallets          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.wallet_ledger    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.heart_lots       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.diamond_products ENABLE ROW LEVEL SECURITY;
+
+-- 본인 잔액 조회
+CREATE POLICY wallet_self_select ON public.wallets
+  FOR SELECT TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+-- admin 모든 잔액 접근
+CREATE POLICY wallet_admin_all ON public.wallets
+  FOR ALL TO authenticated
+  USING ((auth.jwt() -> 'app_metadata' ->> 'role') = 'admin')
+  WITH CHECK ((auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');
+
+-- 본인 ledger 조회
+CREATE POLICY ledger_self_select ON public.wallet_ledger
+  FOR SELECT TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+-- admin 전체 ledger
+CREATE POLICY ledger_admin_select ON public.wallet_ledger
+  FOR SELECT TO authenticated
+  USING ((auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');
+
+-- 본인 heart_lots 조회
+CREATE POLICY heart_lots_self_select ON public.heart_lots
+  FOR SELECT TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+-- 다이아 상품 카탈로그 공개 읽기
+CREATE POLICY products_public_read ON public.diamond_products
+  FOR SELECT TO authenticated
+  USING (active = true);
+
+COMMENT ON POLICY wallet_self_select ON public.wallets IS 'Phase 1 RLS — write는 SECURITY DEFINER RPC만 허용 (직접 INSERT/UPDATE 정책 없음)';
+```
+
+- [ ] **Step 2.2: MCP 적용**
+
+Tool call: `mcp__supabase__apply_migration({ name: "create_wallet_rls", query: <SQL> })`
+
+- [ ] **Step 2.3: RLS advisor 검증**
+
+Tool call: `mcp__supabase__get_advisors({ type: "security" })`
+Expected: 신규 wallet/ledger/heart_lots/diamond_products 관련 RLS 경고 없음.
+
+- [ ] **Step 2.4: 직접 INSERT 차단 검증**
+
+Tool call:
+```
+mcp__supabase__execute_sql({
+  query: "SET LOCAL ROLE authenticated; INSERT INTO wallets(user_id) VALUES ('00000000-0000-0000-0000-000000000001');"
+})
+```
+Expected: ERROR — RLS violation (write 정책 없음).
+
+- [ ] **Step 2.5: 디스크 저장 + 커밋**
+
+```bash
+git add uniqn-mobile/supabase/migrations/20260427000100_create_wallet_rls.sql
+git commit -m "feat(wallet): RLS 정책 (본인 SELECT + admin 전체)"
+```
+
+---
+
+## Task 3: 캐시 동기화 trigger
+
+**Files:**
+- Create: `uniqn-mobile/supabase/migrations/20260427000200_create_wallet_balance_trigger.sql`
+
+- [ ] **Step 3.1: 마이그레이션 파일 작성**
+
+```sql
+-- wallet_ledger INSERT 시 wallets 캐시 자동 갱신
+-- Pattern: job_postings.stats trigger (20260421040000)
+-- Spec §4.4
+
+CREATE OR REPLACE FUNCTION public.fn_wallet_ledger_update_balance()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+BEGIN
+  -- balance_after_*는 RPC가 이미 계산해서 ledger row에 기록한 값
+  -- trigger는 그것을 wallets 캐시로 복사만 한다
+  IF NEW.currency_type = 'heart' THEN
+    UPDATE public.wallets SET
+      heart_balance = GREATEST(0, NEW.balance_after_heart),
+      updated_at = now()
+    WHERE user_id = NEW.user_id;
+  ELSIF NEW.currency_type = 'diamond' THEN
+    UPDATE public.wallets SET
+      diamond_balance = GREATEST(0, NEW.balance_after_diamond),
+      updated_at = now()
+    WHERE user_id = NEW.user_id;
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS tr_wallet_ledger_update_balance ON public.wallet_ledger;
+CREATE TRIGGER tr_wallet_ledger_update_balance
+AFTER INSERT ON public.wallet_ledger
+FOR EACH ROW
+EXECUTE FUNCTION public.fn_wallet_ledger_update_balance();
+
+COMMENT ON FUNCTION public.fn_wallet_ledger_update_balance() IS
+  'wallet_ledger INSERT → wallets 캐시 동기화. balance_after_*는 RPC가 미리 계산해서 ledger에 기록한 값을 그대로 복사. GREATEST(0, ...)는 환불 over-cancel 시 음수 ledger row가 들어와도 캐시는 0 floor 유지 (Decision #2).';
+```
+
+- [ ] **Step 3.2: MCP 적용 + 검증**
+
+Apply migration. Then:
+
+```
+mcp__supabase__execute_sql({
+  query: "SELECT tgname, tgrelid::regclass FROM pg_trigger WHERE tgname = 'tr_wallet_ledger_update_balance'"
+})
+```
+Expected: 1 row, table = `public.wallet_ledger`.
+
+- [ ] **Step 3.3: 디스크 저장 + 커밋**
+
+```bash
+git commit -m "feat(wallet): wallet_ledger → wallets 캐시 sync trigger"
+```
+
+---
+
+## Task 4: `consume_diamonds_atomically` RPC + 단위 테스트 (TDD)
+
+**Files:**
+- Create: `uniqn-mobile/supabase/migrations/20260427000300_create_consume_diamonds_rpc.sql`
+- Create: `uniqn-mobile/src/__tests__/wallet/consumeDiamonds.integration.test.ts`
+
+- [ ] **Step 4.1: 실패하는 테스트 먼저 작성**
+
+`uniqn-mobile/src/__tests__/wallet/consumeDiamonds.integration.test.ts`:
+
+```typescript
+import { createClient } from '@supabase/supabase-js';
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+const supa = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+const TEST_USER = '11111111-1111-1111-1111-000000000001';
+
+async function resetUser() {
+  await supa.from('wallet_ledger').delete().eq('user_id', TEST_USER);
+  await supa.from('heart_lots').delete().eq('user_id', TEST_USER);
+  await supa.from('wallets').delete().eq('user_id', TEST_USER);
+  await supa.from('users').upsert({ id: TEST_USER, email: 'test@test.com', is_active: true });
+}
+
+describe('consume_diamonds_atomically', () => {
+  beforeEach(resetUser);
+
+  it('정상 차감 — 다이아 100 보유, 10 차감 → 90 잔여', async () => {
+    // Setup: credit 100 diamonds via direct ledger insert (test helper)
+    await supa.from('wallets').upsert({ user_id: TEST_USER, diamond_balance: 100 });
+
+    const { data, error } = await supa.rpc('consume_diamonds_atomically', {
+      p_user_id: TEST_USER,
+      p_amount: 10,
+      p_reason: 'consume_job_posting',
+      p_ref_id: null,
+      p_ref_type: 'job_posting',
+    });
+
+    expect(error).toBeNull();
+    expect(data.success).toBe(true);
+    expect(data.diamond_consumed).toBe(10);
+    expect(data.heart_consumed).toBe(0);
+    expect(data.new_diamond_balance).toBe(90);
+  });
+
+  it('잔액 부족 → INSUFFICIENT_BALANCE 예외', async () => {
+    await supa.from('wallets').upsert({ user_id: TEST_USER, diamond_balance: 5 });
+
+    const { data, error } = await supa.rpc('consume_diamonds_atomically', {
+      p_user_id: TEST_USER,
+      p_amount: 10,
+      p_reason: 'consume_job_posting',
+      p_ref_id: null,
+      p_ref_type: 'job_posting',
+    });
+
+    expect(error).not.toBeNull();
+    expect(error!.message).toContain('INSUFFICIENT_BALANCE');
+  });
+
+  it('하트 우선 소비 — 하트 7 + 다이아 10 보유, 10 차감 → 하트 0 + 다이아 7', async () => {
+    await supa.from('wallets').upsert({ user_id: TEST_USER, heart_balance: 7, diamond_balance: 10 });
+    // heart_lot 1개로 7 보유
+    await supa.from('heart_lots').insert({
+      user_id: TEST_USER, amount_initial: 7, amount_remaining: 7,
+      expires_at: new Date(Date.now() + 30 * 86400000).toISOString(),
+      source: 'grant_signup',
+    });
+
+    const { data } = await supa.rpc('consume_diamonds_atomically', {
+      p_user_id: TEST_USER, p_amount: 10,
+      p_reason: 'consume_job_posting', p_ref_id: null, p_ref_type: 'job_posting',
+    });
+
+    expect(data.heart_consumed).toBe(7);
+    expect(data.diamond_consumed).toBe(3);
+    expect(data.new_heart_balance).toBe(0);
+    expect(data.new_diamond_balance).toBe(7);
+  });
+
+  it('음수 amount → INVALID_AMOUNT', async () => {
+    const { error } = await supa.rpc('consume_diamonds_atomically', {
+      p_user_id: TEST_USER, p_amount: -5,
+      p_reason: 'consume_job_posting', p_ref_id: null, p_ref_type: 'job_posting',
+    });
+    expect(error!.message).toContain('INVALID_AMOUNT');
+  });
+
+  it('만료된 hart_lot은 소비 안 함', async () => {
+    await supa.from('wallets').upsert({ user_id: TEST_USER, heart_balance: 5, diamond_balance: 5 });
+    await supa.from('heart_lots').insert({
+      user_id: TEST_USER, amount_initial: 5, amount_remaining: 5,
+      expires_at: new Date(Date.now() - 86400000).toISOString(), // 어제 만료
+      source: 'grant_signup',
+    });
+
+    const { data } = await supa.rpc('consume_diamonds_atomically', {
+      p_user_id: TEST_USER, p_amount: 5,
+      p_reason: 'consume_job_posting', p_ref_id: null, p_ref_type: 'job_posting',
+    });
+
+    expect(data.heart_consumed).toBe(0);
+    expect(data.diamond_consumed).toBe(5);
+  });
+});
+```
+
+- [ ] **Step 4.2: 테스트 실패 확인**
+
+```bash
+cd uniqn-mobile
+npm test -- src/__tests__/wallet/consumeDiamonds.integration.test.ts
+```
+Expected: FAIL — RPC `consume_diamonds_atomically` not found.
+
+- [ ] **Step 4.3: RPC 마이그레이션 작성**
+
+`uniqn-mobile/supabase/migrations/20260427000300_create_consume_diamonds_rpc.sql`:
+
+```sql
+-- consume_diamonds_atomically: 하트 FIFO 우선 소비, 부족분 다이아
+-- Pattern: cancel_application_atomically (FOR UPDATE 잠금)
+-- Spec §4.1
+
+CREATE OR REPLACE FUNCTION public.consume_diamonds_atomically(
+  p_user_id  UUID,
+  p_amount   INT,
+  p_reason   wallet_reason,
+  p_ref_id   UUID,
+  p_ref_type TEXT
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_wallet           wallets%ROWTYPE;
+  v_heart_consumed   INT := 0;
+  v_diamond_consumed INT := 0;
+  v_remaining        INT := p_amount;
+  v_lot              RECORD;
+  v_take             INT;
+  v_now              TIMESTAMPTZ := now();
+BEGIN
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'INVALID_AMOUNT: % must be positive', p_amount;
+  END IF;
+
+  -- 지갑 행 잠금 (없으면 생성)
+  INSERT INTO wallets(user_id) VALUES (p_user_id)
+    ON CONFLICT (user_id) DO NOTHING;
+  SELECT * INTO v_wallet FROM wallets WHERE user_id = p_user_id FOR UPDATE;
+
+  -- 총 잔액 검증
+  IF v_wallet.heart_balance + v_wallet.diamond_balance < p_amount THEN
+    RAISE EXCEPTION 'INSUFFICIENT_BALANCE: have %h+%d, need %',
+      v_wallet.heart_balance, v_wallet.diamond_balance, p_amount;
+  END IF;
+
+  -- 하트 우선 소비 (만료 임박순)
+  FOR v_lot IN
+    SELECT * FROM heart_lots
+    WHERE user_id = p_user_id
+      AND amount_remaining > 0
+      AND expires_at > v_now
+    ORDER BY expires_at ASC, granted_at ASC
+    FOR UPDATE
+  LOOP
+    EXIT WHEN v_remaining = 0;
+    v_take := LEAST(v_lot.amount_remaining, v_remaining);
+    UPDATE heart_lots SET amount_remaining = amount_remaining - v_take
+      WHERE id = v_lot.id;
+    v_heart_consumed := v_heart_consumed + v_take;
+    v_remaining := v_remaining - v_take;
+  END LOOP;
+
+  -- 부족분은 다이아
+  IF v_remaining > 0 THEN
+    v_diamond_consumed := v_remaining;
+  END IF;
+
+  -- ledger 기록 (하트/다이아 분리 row)
+  IF v_heart_consumed > 0 THEN
+    INSERT INTO wallet_ledger(
+      user_id, currency_type, delta, reason, ref_id, ref_type,
+      balance_after_heart, balance_after_diamond
+    ) VALUES (
+      p_user_id, 'heart', -v_heart_consumed, p_reason, p_ref_id, p_ref_type,
+      v_wallet.heart_balance - v_heart_consumed,
+      v_wallet.diamond_balance - v_diamond_consumed
+    );
+  END IF;
+  IF v_diamond_consumed > 0 THEN
+    INSERT INTO wallet_ledger(
+      user_id, currency_type, delta, reason, ref_id, ref_type,
+      balance_after_heart, balance_after_diamond
+    ) VALUES (
+      p_user_id, 'diamond', -v_diamond_consumed, p_reason, p_ref_id, p_ref_type,
+      v_wallet.heart_balance - v_heart_consumed,
+      v_wallet.diamond_balance - v_diamond_consumed
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'heart_consumed', v_heart_consumed,
+    'diamond_consumed', v_diamond_consumed,
+    'new_heart_balance', v_wallet.heart_balance - v_heart_consumed,
+    'new_diamond_balance', v_wallet.diamond_balance - v_diamond_consumed
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.consume_diamonds_atomically(UUID, INT, wallet_reason, UUID, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.consume_diamonds_atomically IS
+  '하트→다이아 우선순위로 차감. SECURITY DEFINER + FOR UPDATE로 race-free. 잔액 부족 시 INSUFFICIENT_BALANCE 예외. Spec §4.1';
+```
+
+- [ ] **Step 4.4: MCP 적용 + 테스트 재실행**
+
+Apply migration. Then:
+```bash
+npm test -- src/__tests__/wallet/consumeDiamonds.integration.test.ts
+```
+Expected: 5/5 PASS.
+
+- [ ] **Step 4.5: 디스크 저장 + 커밋**
+
+```bash
+git commit -m "feat(wallet): consume_diamonds_atomically RPC + 5 integration tests"
+```
+
+---
+
+## Task 5: `credit_diamonds_atomically` RPC + 첫충전 보너스 + TDD
+
+**Files:**
+- Create: `uniqn-mobile/supabase/migrations/20260427000400_create_credit_diamonds_rpc.sql`
+- Create: `uniqn-mobile/src/__tests__/wallet/creditDiamonds.integration.test.ts`
+
+- [ ] **Step 5.1: 실패 테스트 작성**
+
+`creditDiamonds.integration.test.ts` (요지):
+
+```typescript
+describe('credit_diamonds_atomically', () => {
+  beforeEach(resetUser);
+
+  it('정상 충전 — 10💎 + first_purchase 보너스 5💎', async () => {
+    const { data } = await supa.rpc('credit_diamonds_atomically', {
+      p_user_id: TEST_USER,
+      p_diamonds: 10,
+      p_revenuecat_transaction_id: 'rc_tx_001',
+      p_product_id: 'uniqn_diamonds_3000',
+    });
+    expect(data.diamonds_credited).toBe(10);
+    expect(data.first_purchase_bonus).toBe(5);
+    expect(data.new_diamond_balance).toBe(15);
+  });
+
+  it('두 번째 충전 — 보너스 없음', async () => {
+    await supa.rpc('credit_diamonds_atomically', { p_user_id: TEST_USER, p_diamonds: 10, p_revenuecat_transaction_id: 'rc_tx_001', p_product_id: 'uniqn_diamonds_3000' });
+    const { data } = await supa.rpc('credit_diamonds_atomically', {
+      p_user_id: TEST_USER, p_diamonds: 33, p_revenuecat_transaction_id: 'rc_tx_002', p_product_id: 'uniqn_diamonds_10000',
+    });
+    expect(data.first_purchase_bonus).toBe(0);
+    expect(data.new_diamond_balance).toBe(48);
+  });
+
+  it('멱등성 — 같은 transaction_id 두 번 호출', async () => {
+    const r1 = await supa.rpc('credit_diamonds_atomically', { p_user_id: TEST_USER, p_diamonds: 10, p_revenuecat_transaction_id: 'rc_dup', p_product_id: 'uniqn_diamonds_3000' });
+    const r2 = await supa.rpc('credit_diamonds_atomically', { p_user_id: TEST_USER, p_diamonds: 10, p_revenuecat_transaction_id: 'rc_dup', p_product_id: 'uniqn_diamonds_3000' });
+    expect(r2.data.idempotent).toBe(true);
+    // 잔액 불변
+    const { data: wallet } = await supa.from('wallets').select('diamond_balance').eq('user_id', TEST_USER).single();
+    expect(wallet!.diamond_balance).toBe(15); // 10 + 5 보너스
+  });
+
+  it('환불 — 음수 다이아', async () => {
+    await supa.rpc('credit_diamonds_atomically', { p_user_id: TEST_USER, p_diamonds: 10, p_revenuecat_transaction_id: 'rc_buy', p_product_id: 'uniqn_diamonds_3000' });
+    const { data } = await supa.rpc('credit_diamonds_atomically', {
+      p_user_id: TEST_USER, p_diamonds: -10,
+      p_revenuecat_transaction_id: 'rc_refund', p_product_id: 'uniqn_diamonds_3000',
+    });
+    expect(data.diamonds_credited).toBe(-10);
+    expect(data.new_diamond_balance).toBe(5); // 15 - 10
+  });
+
+  it('환불이 잔액보다 클 때 — 캐시는 0 floor, ledger는 음수 row 그대로', async () => {
+    await supa.rpc('credit_diamonds_atomically', { p_user_id: TEST_USER, p_diamonds: 10, p_revenuecat_transaction_id: 'rc_buy2', p_product_id: 'uniqn_diamonds_3000' });
+    // 5💎 소비
+    await supa.rpc('consume_diamonds_atomically', { p_user_id: TEST_USER, p_amount: 5, p_reason: 'consume_job_posting', p_ref_id: null, p_ref_type: 'job_posting' });
+    // 잔액 10 (15-5). 15 환불 시도.
+    const { data } = await supa.rpc('credit_diamonds_atomically', {
+      p_user_id: TEST_USER, p_diamonds: -15,
+      p_revenuecat_transaction_id: 'rc_refund_big', p_product_id: 'uniqn_diamonds_3000',
+    });
+    expect(data.diamonds_credited).toBe(-15); // ledger는 그대로
+    const { data: wallet } = await supa.from('wallets').select('diamond_balance').eq('user_id', TEST_USER).single();
+    expect(wallet!.diamond_balance).toBe(0); // GREATEST(0, -5) = 0
+  });
+});
+```
+
+- [ ] **Step 5.2: 테스트 실패 확인**
+
+```bash
+npm test -- src/__tests__/wallet/creditDiamonds.integration.test.ts
+```
+Expected: 5/5 FAIL — RPC 미존재.
+
+- [ ] **Step 5.3: RPC 마이그레이션 작성**
+
+```sql
+-- credit_diamonds_atomically: 충전 + 환불 통합 RPC
+-- 첫 충전 시 +5💎 보너스 자동 추가 (Decision #7)
+-- Spec §4.2
+
+CREATE OR REPLACE FUNCTION public.credit_diamonds_atomically(
+  p_user_id                   UUID,
+  p_diamonds                  INT,
+  p_revenuecat_transaction_id TEXT,
+  p_product_id                TEXT
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_wallet              wallets%ROWTYPE;
+  v_existing            UUID;
+  v_first_purchase      BOOLEAN := false;
+  v_bonus               INT := 0;
+  v_new_diamond_balance INT;
+BEGIN
+  -- 멱등성 체크
+  SELECT id INTO v_existing FROM wallet_ledger
+    WHERE revenuecat_transaction_id = p_revenuecat_transaction_id;
+  IF FOUND THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true);
+  END IF;
+
+  INSERT INTO wallets(user_id) VALUES (p_user_id) ON CONFLICT (user_id) DO NOTHING;
+  SELECT * INTO v_wallet FROM wallets WHERE user_id = p_user_id FOR UPDATE;
+
+  -- 첫 구매 판정 (lifetime_purchased_diamonds == 0 AND p_diamonds > 0)
+  IF p_diamonds > 0 AND v_wallet.lifetime_purchased_diamonds = 0 THEN
+    v_first_purchase := true;
+    v_bonus := 5;
+  END IF;
+
+  v_new_diamond_balance := v_wallet.diamond_balance + p_diamonds + v_bonus;
+
+  -- 메인 ledger row
+  INSERT INTO wallet_ledger(
+    user_id, currency_type, delta, reason, ref_type,
+    balance_after_heart, balance_after_diamond,
+    revenuecat_transaction_id, metadata
+  ) VALUES (
+    p_user_id, 'diamond', p_diamonds,
+    CASE WHEN p_diamonds > 0 THEN 'purchase'::wallet_reason
+         ELSE 'refund_purchase'::wallet_reason END,
+    'revenuecat',
+    v_wallet.heart_balance,
+    v_wallet.diamond_balance + p_diamonds,
+    p_revenuecat_transaction_id,
+    jsonb_build_object('product_id', p_product_id, 'is_first_purchase', v_first_purchase)
+  );
+
+  -- 첫 구매 보너스 row (별도 ledger entry, NULL transaction_id로 구별 가능)
+  IF v_bonus > 0 THEN
+    INSERT INTO wallet_ledger(
+      user_id, currency_type, delta, reason, ref_type,
+      balance_after_heart, balance_after_diamond, metadata
+    ) VALUES (
+      p_user_id, 'diamond', v_bonus, 'grant_first_purchase_bonus', 'revenuecat',
+      v_wallet.heart_balance,
+      v_wallet.diamond_balance + p_diamonds + v_bonus,
+      jsonb_build_object('source_transaction_id', p_revenuecat_transaction_id)
+    );
+  END IF;
+
+  -- lifetime 누계
+  IF p_diamonds > 0 THEN
+    UPDATE wallets SET lifetime_purchased_diamonds = lifetime_purchased_diamonds + p_diamonds
+      WHERE user_id = p_user_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'diamonds_credited', p_diamonds,
+    'first_purchase_bonus', v_bonus,
+    'new_diamond_balance', GREATEST(0, v_new_diamond_balance)
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.credit_diamonds_atomically(UUID, INT, TEXT, TEXT) FROM PUBLIC, authenticated;
+GRANT EXECUTE ON FUNCTION public.credit_diamonds_atomically(UUID, INT, TEXT, TEXT) TO service_role;
+
+COMMENT ON FUNCTION public.credit_diamonds_atomically IS
+  'RevenueCat webhook 전용 (service_role only). p_diamonds 양수=구매, 음수=환불. revenuecat_transaction_id UNIQUE 멱등성. 첫 구매 시 +5💎 보너스 자동. Spec §4.2 + Decision #7';
+```
+
+- [ ] **Step 5.4: MCP 적용 + 테스트 재실행**
+
+Expected: 5/5 PASS.
+
+- [ ] **Step 5.5: 커밋**
+
+```bash
+git commit -m "feat(wallet): credit_diamonds_atomically RPC + 첫충전 +5💎 보너스 + 멱등성"
+```
+
+---
+
+## Task 6: `grant_heart_atomically` + `get_wallet_summary` RPC
+
+**Files:**
+- Create: `uniqn-mobile/supabase/migrations/20260427000500_create_grant_heart_rpc.sql`
+- Create: `uniqn-mobile/src/__tests__/wallet/grantHeart.integration.test.ts`
+
+- [ ] **Step 6.1: 실패 테스트 작성**
+
+```typescript
+describe('grant_heart_atomically + get_wallet_summary', () => {
+  beforeEach(resetUser);
+
+  it('signup 보너스 — 10💖 + 90일 만료', async () => {
+    const { data } = await supa.rpc('grant_heart_atomically', {
+      p_user_id: TEST_USER, p_amount: 10, p_reason: 'grant_signup',
+      p_source_ref_id: null, p_expires_in_days: 90,
+    });
+    expect(data.success).toBe(true);
+    const expires = new Date(data.expires_at);
+    const daysFromNow = (expires.getTime() - Date.now()) / 86400000;
+    expect(daysFromNow).toBeGreaterThan(89);
+    expect(daysFromNow).toBeLessThan(91);
+  });
+
+  it('일일 출석 — 같은 날 두 번 → 두 번째는 already_attended_today', async () => {
+    const r1 = await supa.rpc('grant_heart_atomically', {
+      p_user_id: TEST_USER, p_amount: 1, p_reason: 'grant_daily_attendance',
+      p_source_ref_id: null, p_expires_in_days: 90,
+    });
+    expect(r1.data.success).toBe(true);
+    const r2 = await supa.rpc('grant_heart_atomically', {
+      p_user_id: TEST_USER, p_amount: 1, p_reason: 'grant_daily_attendance',
+      p_source_ref_id: null, p_expires_in_days: 90,
+    });
+    expect(r2.data.success).toBe(false);
+    expect(r2.data.error).toBe('already_attended_today');
+  });
+
+  it('get_wallet_summary — balance + 만료 임박 lots', async () => {
+    await supa.rpc('grant_heart_atomically', {
+      p_user_id: TEST_USER, p_amount: 5, p_reason: 'grant_signup',
+      p_source_ref_id: null, p_expires_in_days: 5,
+    });
+    await supa.rpc('grant_heart_atomically', {
+      p_user_id: TEST_USER, p_amount: 3, p_reason: 'grant_referral',
+      p_source_ref_id: null, p_expires_in_days: 60,
+    });
+
+    const { data } = await supa.rpc('get_wallet_summary', { p_user_id: TEST_USER });
+    expect(data.heart_balance).toBe(8);
+    expect(data.diamond_balance).toBe(0);
+    expect(data.expiring_lots).toHaveLength(1); // 7일 이내 만료 1개
+    expect(data.expiring_lots[0].amount_remaining).toBe(5);
+  });
+});
+```
+
+- [ ] **Step 6.2: 테스트 실패 확인**
+
+```bash
+npm test -- src/__tests__/wallet/grantHeart.integration.test.ts
+```
+Expected: FAIL.
+
+- [ ] **Step 6.3: RPC 마이그레이션 작성**
+
+```sql
+-- grant_heart_atomically: 하트 적립 (lot 생성 + ledger 기록)
+-- daily_attendance는 KST 기준 일일 1회 제한
+-- get_wallet_summary: 잔액 + 만료 임박 lot 조회 (Decision #3 — UI inline 표시용)
+-- Spec §4.3
+
+CREATE OR REPLACE FUNCTION public.grant_heart_atomically(
+  p_user_id          UUID,
+  p_amount           INT,
+  p_reason           wallet_reason,
+  p_source_ref_id    UUID DEFAULT NULL,
+  p_expires_in_days  INT  DEFAULT 90
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_lot_id    UUID;
+  v_expires   TIMESTAMPTZ := now() + (p_expires_in_days || ' days')::interval;
+  v_today_kst DATE := (now() AT TIME ZONE 'Asia/Seoul')::date;
+BEGIN
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'INVALID_AMOUNT: % must be positive', p_amount;
+  END IF;
+
+  -- daily_attendance KST 일일 1회
+  IF p_reason = 'grant_daily_attendance' THEN
+    IF EXISTS (
+      SELECT 1 FROM wallet_ledger
+      WHERE user_id = p_user_id
+        AND reason = 'grant_daily_attendance'
+        AND (created_at AT TIME ZONE 'Asia/Seoul')::date = v_today_kst
+    ) THEN
+      RETURN jsonb_build_object('success', false, 'error', 'already_attended_today');
+    END IF;
+  END IF;
+
+  INSERT INTO wallets(user_id) VALUES (p_user_id) ON CONFLICT (user_id) DO NOTHING;
+
+  INSERT INTO heart_lots(user_id, amount_initial, amount_remaining, expires_at, source, source_ref_id)
+  VALUES (p_user_id, p_amount, p_amount, v_expires, p_reason, p_source_ref_id)
+  RETURNING id INTO v_lot_id;
+
+  INSERT INTO wallet_ledger(
+    user_id, currency_type, delta, reason, ref_id, ref_type,
+    balance_after_heart, balance_after_diamond
+  )
+  SELECT p_user_id, 'heart', p_amount, p_reason,
+         v_lot_id, 'heart_lot',
+         w.heart_balance + p_amount, w.diamond_balance
+  FROM wallets w WHERE w.user_id = p_user_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'lot_id', v_lot_id,
+    'expires_at', v_expires,
+    'amount', p_amount
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.grant_heart_atomically(UUID, INT, wallet_reason, UUID, INT) TO service_role;
+
+-- 클라이언트 호출 가능한 wrapper (daily_attendance 전용, 본인만)
+CREATE OR REPLACE FUNCTION public.claim_daily_attendance() RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE v_uid UUID := (SELECT auth.uid());
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'NOT_AUTHENTICATED'; END IF;
+  RETURN public.grant_heart_atomically(v_uid, 1, 'grant_daily_attendance', NULL, 90);
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.claim_daily_attendance() TO authenticated;
+
+-- get_wallet_summary: 본인 잔액 + 만료 임박 lots (7일 이내) 조회
+CREATE OR REPLACE FUNCTION public.get_wallet_summary(p_user_id UUID DEFAULT NULL)
+RETURNS JSONB
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_uid    UUID := COALESCE(p_user_id, (SELECT auth.uid()));
+  v_wallet wallets%ROWTYPE;
+  v_lots   JSONB;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'NOT_AUTHENTICATED'; END IF;
+  -- admin이 아니면 본인만 조회 가능
+  IF v_uid != (SELECT auth.uid())
+     AND COALESCE((auth.jwt() -> 'app_metadata' ->> 'role'), '') != 'admin' THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED';
+  END IF;
+
+  SELECT * INTO v_wallet FROM wallets WHERE user_id = v_uid;
+  IF NOT FOUND THEN
+    -- 빈 지갑
+    RETURN jsonb_build_object(
+      'heart_balance', 0, 'diamond_balance', 0,
+      'lifetime_purchased_diamonds', 0, 'expiring_lots', '[]'::jsonb
+    );
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+    'lot_id', id, 'amount_remaining', amount_remaining,
+    'expires_at', expires_at, 'source', source
+  ) ORDER BY expires_at ASC), '[]'::jsonb) INTO v_lots
+  FROM heart_lots
+  WHERE user_id = v_uid
+    AND amount_remaining > 0
+    AND expires_at BETWEEN now() AND now() + interval '7 days';
+
+  RETURN jsonb_build_object(
+    'heart_balance', v_wallet.heart_balance,
+    'diamond_balance', v_wallet.diamond_balance,
+    'lifetime_purchased_diamonds', v_wallet.lifetime_purchased_diamonds,
+    'expiring_lots', v_lots
+  );
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.get_wallet_summary(UUID) TO authenticated;
+```
+
+- [ ] **Step 6.4: MCP 적용 + 테스트 재실행**
+
+Expected: 3/3 PASS.
+
+- [ ] **Step 6.5: 커밋**
+
+```bash
+git commit -m "feat(wallet): grant_heart_atomically + claim_daily_attendance + get_wallet_summary"
+```
+
+---
+
+## Task 7: `create_job_posting_with_payment_atomically` (race-free wrapper)
+
+**Files:**
+- Create: `uniqn-mobile/supabase/migrations/20260427000600_create_create_job_posting_with_payment_rpc.sql`
+- Create: `uniqn-mobile/src/__tests__/wallet/createJobPostingWithPayment.integration.test.ts`
+
+- [ ] **Step 7.1: 실패 테스트 작성**
+
+```typescript
+describe('create_job_posting_with_payment_atomically', () => {
+  beforeEach(resetUser);
+
+  it('regular 공고 + 1💎 차감 — 단일 트랜잭션', async () => {
+    await supa.from('wallets').upsert({ user_id: TEST_USER, diamond_balance: 5 });
+    const postingPayload = {
+      title: 'Test Posting',
+      type: 'regular',
+      total_positions: 1,
+      // ... (실제 job_postings 필수 필드는 Phase 4에서 통합 시 spec 검증)
+    };
+    const { data } = await supa.rpc('create_job_posting_with_payment_atomically', {
+      p_owner_id: TEST_USER,
+      p_posting_payload: postingPayload,
+      p_cost_diamonds: 1,
+      p_reason: 'consume_job_posting',
+    });
+
+    expect(data.success).toBe(true);
+    expect(data.posting_id).toBeDefined();
+    expect(data.diamonds_consumed).toBe(1);
+    // ledger ref_id가 즉시 set
+    const { data: ledger } = await supa.from('wallet_ledger').select('ref_id, ref_type')
+      .eq('user_id', TEST_USER).eq('reason', 'consume_job_posting').single();
+    expect(ledger!.ref_id).toBe(data.posting_id);
+  });
+
+  it('잔액 부족 시 공고 INSERT도 롤백', async () => {
+    await supa.from('wallets').upsert({ user_id: TEST_USER, diamond_balance: 0 });
+    const before = await supa.from('job_postings').select('id', { count: 'exact', head: true }).eq('owner_id', TEST_USER);
+    const { error } = await supa.rpc('create_job_posting_with_payment_atomically', {
+      p_owner_id: TEST_USER,
+      p_posting_payload: { title: 'Will Fail', type: 'urgent' },
+      p_cost_diamonds: 10,
+      p_reason: 'consume_job_posting',
+    });
+    expect(error!.message).toContain('INSUFFICIENT_BALANCE');
+    const after = await supa.from('job_postings').select('id', { count: 'exact', head: true }).eq('owner_id', TEST_USER);
+    expect(after.count).toBe(before.count); // 공고 INSERT 안 됨
+  });
+
+  it('cost=0 (tournament) — 차감 skip, 공고만 INSERT', async () => {
+    await supa.from('wallets').upsert({ user_id: TEST_USER, diamond_balance: 0 });
+    const { data } = await supa.rpc('create_job_posting_with_payment_atomically', {
+      p_owner_id: TEST_USER,
+      p_posting_payload: { title: 'Tournament', type: 'tournament' },
+      p_cost_diamonds: 0,
+      p_reason: 'consume_job_posting',
+    });
+    expect(data.success).toBe(true);
+    expect(data.diamonds_consumed).toBe(0);
+    expect(data.posting_id).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 7.2: 테스트 실패 확인**
+
+```bash
+npm test -- src/__tests__/wallet/createJobPostingWithPayment.integration.test.ts
+```
+Expected: FAIL.
+
+- [ ] **Step 7.3: RPC 마이그레이션 작성**
+
+```sql
+-- create_job_posting_with_payment_atomically:
+-- 다이아 차감 + job_postings INSERT를 단일 트랜잭션으로 수행
+-- Spec §6.3 race window 해결
+-- p_posting_payload 는 jobs Service가 만든 jsonb (모든 컬럼)
+-- 검증: cost_diamonds == 0이면 차감 skip (Tournament 케이스 #11)
+
+CREATE OR REPLACE FUNCTION public.create_job_posting_with_payment_atomically(
+  p_owner_id        UUID,
+  p_posting_payload JSONB,
+  p_cost_diamonds   INT,
+  p_reason          wallet_reason
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_posting_id        UUID;
+  v_consume_result    JSONB;
+  v_diamonds_consumed INT := 0;
+  v_heart_consumed    INT := 0;
+BEGIN
+  IF p_cost_diamonds < 0 THEN
+    RAISE EXCEPTION 'INVALID_AMOUNT: cost_diamonds % must be >= 0', p_cost_diamonds;
+  END IF;
+
+  -- 1. 공고 INSERT (jsonb_populate_record로 컬럼 매핑)
+  INSERT INTO job_postings
+  SELECT * FROM jsonb_populate_record(
+    NULL::job_postings,
+    p_posting_payload || jsonb_build_object('owner_id', p_owner_id)
+  )
+  RETURNING id INTO v_posting_id;
+
+  -- 2. cost > 0이면 차감 (실패 시 전체 트랜잭션 롤백)
+  IF p_cost_diamonds > 0 THEN
+    v_consume_result := public.consume_diamonds_atomically(
+      p_owner_id, p_cost_diamonds, p_reason, v_posting_id, 'job_posting'
+    );
+    v_diamonds_consumed := (v_consume_result->>'diamond_consumed')::int;
+    v_heart_consumed := (v_consume_result->>'heart_consumed')::int;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'posting_id', v_posting_id,
+    'diamonds_consumed', v_diamonds_consumed,
+    'hearts_consumed', v_heart_consumed,
+    'total_consumed', v_diamonds_consumed + v_heart_consumed
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.create_job_posting_with_payment_atomically(UUID, JSONB, INT, wallet_reason) TO authenticated;
+
+COMMENT ON FUNCTION public.create_job_posting_with_payment_atomically IS
+  'jobs 작성 + 차감을 단일 트랜잭션으로. consume RPC가 INSUFFICIENT_BALANCE 던지면 공고 INSERT까지 롤백. tournament(cost=0)는 차감 skip. Spec §6.3 race window 해결 + Decision #11';
+```
+
+- [ ] **Step 7.4: MCP 적용 + 테스트 재실행**
+
+Expected: 3/3 PASS.
+
+- [ ] **Step 7.5: 커밋**
+
+```bash
+git commit -m "feat(wallet): create_job_posting_with_payment_atomically (race-free wrapper)"
+```
+
+---
+
+## Task 8: `refund_job_cancellation_atomically` (24h/50% 비율)
+
+**Files:**
+- Create: `uniqn-mobile/supabase/migrations/20260427000700_create_refund_job_cancellation_rpc.sql`
+- Create: `uniqn-mobile/src/__tests__/wallet/refundJobCancellation.integration.test.ts`
+
+- [ ] **Step 8.1: 실패 테스트 작성**
+
+```typescript
+describe('refund_job_cancellation_atomically', () => {
+  beforeEach(resetUser);
+
+  it('24시간 이내 취소 → 100% 환불', async () => {
+    // Setup: 공고 생성 + 차감
+    await supa.from('wallets').upsert({ user_id: TEST_USER, diamond_balance: 10 });
+    const { data: created } = await supa.rpc('create_job_posting_with_payment_atomically', {
+      p_owner_id: TEST_USER,
+      p_posting_payload: { title: 'Recent', type: 'urgent' },
+      p_cost_diamonds: 10,
+      p_reason: 'consume_job_posting',
+    });
+    // 잔액 0 확인
+    let { data: w } = await supa.from('wallets').select('diamond_balance').eq('user_id', TEST_USER).single();
+    expect(w!.diamond_balance).toBe(0);
+
+    // 취소 환불
+    const { data: refund } = await supa.rpc('refund_job_cancellation_atomically', {
+      p_posting_id: created.posting_id,
+      p_owner_id: TEST_USER,
+    });
+    expect(refund.refunded_diamonds).toBe(10);
+    expect(refund.refund_rate).toBe(1.0);
+
+    ({ data: w } = await supa.from('wallets').select('diamond_balance').eq('user_id', TEST_USER).single());
+    expect(w!.diamond_balance).toBe(10);
+  });
+
+  it('25시간 후 취소 → 50% 환불', async () => {
+    await supa.from('wallets').upsert({ user_id: TEST_USER, diamond_balance: 10 });
+    const { data: created } = await supa.rpc('create_job_posting_with_payment_atomically', {
+      p_owner_id: TEST_USER,
+      p_posting_payload: { title: 'Old', type: 'urgent' },
+      p_cost_diamonds: 10,
+      p_reason: 'consume_job_posting',
+    });
+    // ledger created_at 백데이트 (테스트용)
+    await supa.from('wallet_ledger').update({ created_at: new Date(Date.now() - 25 * 3600000).toISOString() })
+      .eq('ref_id', created.posting_id)
+      .eq('reason', 'consume_job_posting');
+
+    const { data: refund } = await supa.rpc('refund_job_cancellation_atomically', {
+      p_posting_id: created.posting_id,
+      p_owner_id: TEST_USER,
+    });
+    expect(refund.refunded_diamonds).toBe(5); // 10 * 0.5, FLOOR
+    expect(refund.refund_rate).toBe(0.5);
+  });
+
+  it('이미 환불된 공고 → idempotent', async () => {
+    await supa.from('wallets').upsert({ user_id: TEST_USER, diamond_balance: 10 });
+    const { data: created } = await supa.rpc('create_job_posting_with_payment_atomically', {
+      p_owner_id: TEST_USER,
+      p_posting_payload: { title: 'X', type: 'urgent' },
+      p_cost_diamonds: 10,
+      p_reason: 'consume_job_posting',
+    });
+    await supa.rpc('refund_job_cancellation_atomically', { p_posting_id: created.posting_id, p_owner_id: TEST_USER });
+    const { data: r2 } = await supa.rpc('refund_job_cancellation_atomically', { p_posting_id: created.posting_id, p_owner_id: TEST_USER });
+    expect(r2.idempotent).toBe(true);
+  });
+
+  it('타인 공고 환불 시도 → unauthorized', async () => {
+    await supa.from('wallets').upsert({ user_id: TEST_USER, diamond_balance: 10 });
+    const { data: created } = await supa.rpc('create_job_posting_with_payment_atomically', {
+      p_owner_id: TEST_USER, p_posting_payload: { title: 'Mine', type: 'urgent' },
+      p_cost_diamonds: 10, p_reason: 'consume_job_posting',
+    });
+    const { data: r } = await supa.rpc('refund_job_cancellation_atomically', {
+      p_posting_id: created.posting_id,
+      p_owner_id: '99999999-9999-9999-9999-999999999999',
+    });
+    expect(r.success).toBe(false);
+    expect(r.error).toBe('unauthorized');
+  });
+});
+```
+
+- [ ] **Step 8.2: 테스트 실패 확인**
+
+```bash
+npm test -- src/__tests__/wallet/refundJobCancellation.integration.test.ts
+```
+Expected: FAIL.
+
+- [ ] **Step 8.3: RPC 마이그레이션 작성**
+
+```sql
+-- refund_job_cancellation_atomically: 24h 이내 100% / 이후 50% (FLOOR)
+-- Decision #1
+-- Spec §11
+
+CREATE OR REPLACE FUNCTION public.refund_job_cancellation_atomically(
+  p_posting_id UUID,
+  p_owner_id   UUID
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_consume_row     wallet_ledger%ROWTYPE;
+  v_existing_refund UUID;
+  v_hours_elapsed   NUMERIC;
+  v_refund_rate     NUMERIC;
+  v_refund_amount   INT;
+  v_diamond_amount  INT;
+  v_heart_amount    INT;
+  v_now             TIMESTAMPTZ := now();
+BEGIN
+  -- 1. 멱등성: 이미 같은 공고에 refund_job_cancelled row가 있는지
+  SELECT id INTO v_existing_refund FROM wallet_ledger
+    WHERE ref_id = p_posting_id AND reason = 'refund_job_cancelled'
+    LIMIT 1;
+  IF FOUND THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true);
+  END IF;
+
+  -- 2. 차감 row 조회 (consume_job_posting / extend / upgrade 모두 합산)
+  SELECT
+    SUM(CASE WHEN currency_type='diamond' THEN -delta ELSE 0 END)::int AS d,
+    SUM(CASE WHEN currency_type='heart' THEN -delta ELSE 0 END)::int AS h,
+    MIN(created_at) AS first_consume_at
+  INTO v_diamond_amount, v_heart_amount, v_consume_row.created_at
+  FROM wallet_ledger
+  WHERE ref_id = p_posting_id
+    AND reason IN ('consume_job_posting','consume_job_extend','consume_job_upgrade');
+
+  IF v_diamond_amount IS NULL OR (v_diamond_amount + v_heart_amount) = 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'no_consumption_found');
+  END IF;
+
+  -- 3. 권한 검증
+  IF NOT EXISTS (
+    SELECT 1 FROM job_postings WHERE id = p_posting_id AND owner_id = p_owner_id
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'unauthorized');
+  END IF;
+
+  -- 4. 비율 계산 (Decision #1)
+  v_hours_elapsed := EXTRACT(EPOCH FROM (v_now - v_consume_row.created_at)) / 3600;
+  v_refund_rate := CASE WHEN v_hours_elapsed < 24 THEN 1.0 ELSE 0.5 END;
+  -- 다이아만 환불 (하트는 만료 정책상 환불 어려움 → 다이아 비례 환불)
+  v_refund_amount := FLOOR((v_diamond_amount + v_heart_amount) * v_refund_rate)::int;
+
+  -- 5. 환불 ledger row (다이아로 환불, balance는 캐시 후 update)
+  INSERT INTO wallet_ledger(
+    user_id, currency_type, delta, reason, ref_id, ref_type,
+    balance_after_heart, balance_after_diamond,
+    metadata
+  )
+  SELECT p_owner_id, 'diamond', v_refund_amount, 'refund_job_cancelled',
+         p_posting_id, 'job_posting',
+         w.heart_balance,
+         w.diamond_balance + v_refund_amount,
+         jsonb_build_object(
+           'original_diamond', v_diamond_amount,
+           'original_heart', v_heart_amount,
+           'refund_rate', v_refund_rate,
+           'hours_elapsed', v_hours_elapsed
+         )
+  FROM wallets w WHERE w.user_id = p_owner_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'refunded_diamonds', v_refund_amount,
+    'refund_rate', v_refund_rate,
+    'hours_elapsed', v_hours_elapsed
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.refund_job_cancellation_atomically(UUID, UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.refund_job_cancellation_atomically IS
+  '공고 취소 환불. 24h 이내 100%, 이후 50% (FLOOR). 하트+다이아 합산을 다이아로 환불. ref_id에 같은 refund row 있으면 idempotent. Decision #1';
+```
+
+- [ ] **Step 8.4: MCP 적용 + 테스트 재실행**
+
+Expected: 4/4 PASS.
+
+- [ ] **Step 8.5: 커밋**
+
+```bash
+git commit -m "feat(wallet): refund_job_cancellation_atomically (24h 100% / 이후 50%)"
+```
+
+---
+
+## Task 9: `diamond_products` 시드
+
+**Files:**
+- Create: `uniqn-mobile/supabase/migrations/20260427000800_seed_diamond_products.sql`
+
+- [ ] **Step 9.1: 시드 마이그레이션 작성**
+
+```sql
+-- 다이아 충전 패키지 6종
+-- BUSINESS_PLAN_2025.md §3.2
+
+INSERT INTO public.diamond_products (product_id, diamonds, bonus_diamonds, price_krw, display_order, active)
+VALUES
+  ('uniqn_diamonds_1000',   3,   0,   1000, 1, true),
+  ('uniqn_diamonds_3000',  10,   0,   3000, 2, true),
+  ('uniqn_diamonds_10000', 33,   2,  10000, 3, true),
+  ('uniqn_diamonds_30000',100,  10,  30000, 4, true),
+  ('uniqn_diamonds_50000',167,  23,  50000, 5, true),
+  ('uniqn_diamonds_100000',333, 67, 100000, 6, true)
+ON CONFLICT (product_id) DO UPDATE SET
+  diamonds       = EXCLUDED.diamonds,
+  bonus_diamonds = EXCLUDED.bonus_diamonds,
+  price_krw      = EXCLUDED.price_krw,
+  display_order  = EXCLUDED.display_order,
+  active         = EXCLUDED.active,
+  updated_at     = now();
+```
+
+- [ ] **Step 9.2: MCP 적용 + 검증**
+
+Apply, then:
+```
+mcp__supabase__execute_sql({
+  query: "SELECT product_id, diamonds, bonus_diamonds, price_krw FROM diamond_products WHERE active = true ORDER BY display_order"
+})
+```
+Expected: 6 rows.
+
+- [ ] **Step 9.3: 커밋**
+
+```bash
+git commit -m "feat(wallet): diamond_products 6종 시드"
+```
+
+---
+
+## Task 10: `app_config` monetization 시드
+
+**Files:**
+- Create: `uniqn-mobile/supabase/migrations/20260427000900_seed_app_config_monetization.sql`
+
+- [ ] **Step 10.1: 시드 마이그레이션 작성**
+
+```sql
+-- Feature Flag: 초기엔 모두 무료, 다이아 충전 UI는 활성화
+-- Decision #6 + Spec §7.1
+
+INSERT INTO public.app_config (key, value, updated_at) VALUES
+  ('monetization', jsonb_build_object(
+    'enabled', true,
+    'paid_types', jsonb_build_object(
+      'regular', false,
+      'urgent', false,
+      'fixed', false,
+      'tournament', false
+    ),
+    'rollout_percentage', 0,
+    'show_purchase_ui', true,
+    'first_purchase_bonus_diamonds', 5
+  ), now())
+ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = now();
+```
+
+- [ ] **Step 10.2: 적용 + 검증**
+
+```
+mcp__supabase__execute_sql({
+  query: "SELECT value FROM app_config WHERE key = 'monetization'"
+})
+```
+Expected: JSONB with enabled=true, all paid_types=false.
+
+- [ ] **Step 10.3: 커밋**
+
+```bash
+git commit -m "feat(wallet): app_config monetization 시드 (모두 false 초기값)"
+```
+
+---
+
+## Task 11: `heart_lots` 만료 cron
+
+**Files:**
+- Create: `uniqn-mobile/supabase/migrations/20260427001000_create_heart_expiry_cron.sql`
+
+- [ ] **Step 11.1: 마이그레이션 작성**
+
+```sql
+-- 매일 KST 자정에 만료된 hart_lots 처리
+-- Decision #3: 알림 없음, 잔량 0 + ledger expire_heart row만
+-- Spec §3.4
+
+CREATE OR REPLACE FUNCTION public.fn_expire_heart_lots()
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_lot         RECORD;
+  v_total       INT := 0;
+  v_users_count INT := 0;
+  v_now         TIMESTAMPTZ := now();
+BEGIN
+  FOR v_lot IN
+    SELECT id, user_id, amount_remaining
+    FROM heart_lots
+    WHERE amount_remaining > 0 AND expires_at <= v_now
+    FOR UPDATE
+  LOOP
+    -- ledger row 먼저 (캐시 trigger가 wallets 갱신)
+    INSERT INTO wallet_ledger(
+      user_id, currency_type, delta, reason, ref_id, ref_type,
+      balance_after_heart, balance_after_diamond, metadata
+    )
+    SELECT v_lot.user_id, 'heart', -v_lot.amount_remaining, 'expire_heart',
+           v_lot.id, 'heart_lot',
+           GREATEST(0, w.heart_balance - v_lot.amount_remaining),
+           w.diamond_balance,
+           jsonb_build_object('expired_at', v_now)
+    FROM wallets w WHERE w.user_id = v_lot.user_id;
+
+    UPDATE heart_lots SET amount_remaining = 0 WHERE id = v_lot.id;
+    v_total := v_total + v_lot.amount_remaining;
+    v_users_count := v_users_count + 1;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'expired_hearts', v_total,
+    'affected_users', v_users_count,
+    'run_at', v_now
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.fn_expire_heart_lots() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.fn_expire_heart_lots() TO service_role;
+
+-- pg_cron: 매일 KST 자정 (UTC 15:00 전일)
+-- pg_cron extension은 이미 활성화돼 있을 가능성 높음 (account_maintenance_cron 참고)
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    PERFORM cron.schedule(
+      'expire_heart_lots_daily',
+      '0 15 * * *',  -- UTC 15:00 = KST 00:00
+      $cmd$SELECT public.fn_expire_heart_lots();$cmd$
+    );
+  END IF;
+END $$;
+```
+
+- [ ] **Step 11.2: 적용 + 검증**
+
+```
+mcp__supabase__execute_sql({
+  query: "SELECT jobname, schedule, command FROM cron.job WHERE jobname = 'expire_heart_lots_daily'"
+})
+```
+Expected: 1 row with schedule `0 15 * * *`.
+
+- [ ] **Step 11.3: 함수 동작 직접 검증 (cron 안 기다리고)**
+
+```typescript
+// uniqn-mobile/src/__tests__/wallet/heartExpiry.integration.test.ts
+it('만료된 lot 처리 → 잔량 0 + ledger row', async () => {
+  await resetUser();
+  await supa.from('wallets').upsert({ user_id: TEST_USER, heart_balance: 5 });
+  await supa.from('heart_lots').insert({
+    user_id: TEST_USER, amount_initial: 5, amount_remaining: 5,
+    expires_at: new Date(Date.now() - 86400000).toISOString(),
+    source: 'grant_signup',
+  });
+
+  const { data } = await supa.rpc('fn_expire_heart_lots');
+  expect(data.expired_hearts).toBeGreaterThanOrEqual(5);
+
+  const { data: w } = await supa.from('wallets').select('heart_balance').eq('user_id', TEST_USER).single();
+  expect(w!.heart_balance).toBe(0);
+
+  const { data: ledger } = await supa.from('wallet_ledger').select('reason')
+    .eq('user_id', TEST_USER).eq('reason', 'expire_heart').single();
+  expect(ledger!.reason).toBe('expire_heart');
+});
+```
+
+```bash
+npm test -- src/__tests__/wallet/heartExpiry.integration.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 11.4: 커밋**
+
+```bash
+git commit -m "feat(wallet): hart_lots 만료 cron (KST 자정, 알림 없음)"
+```
+
+---
+
+## Task 12: WalletRepository (TypeScript read-only)
+
+**Files:**
+- Create: `uniqn-mobile/src/types/wallet.ts`
+- Create: `uniqn-mobile/src/repositories/supabase/WalletRepository.ts`
+- Create: `uniqn-mobile/src/repositories/supabase/__tests__/WalletRepository.test.ts`
+
+- [ ] **Step 12.1: 타입 정의**
+
+`uniqn-mobile/src/types/wallet.ts`:
+
+```typescript
+import { z } from 'zod';
+
+export type WalletCurrency = 'heart' | 'diamond';
+
+export type WalletReason =
+  | 'purchase' | 'consume_job_posting' | 'consume_job_extend' | 'consume_job_upgrade'
+  | 'refund_purchase' | 'refund_job_cancelled'
+  | 'grant_signup' | 'grant_daily_attendance' | 'grant_streak_7d'
+  | 'grant_review' | 'grant_referral' | 'grant_admin'
+  | 'grant_first_purchase_bonus' | 'expire_heart';
+
+export const WalletSummarySchema = z.object({
+  heart_balance: z.number().int().min(0),
+  diamond_balance: z.number().int().min(0),
+  lifetime_purchased_diamonds: z.number().int().min(0),
+  expiring_lots: z.array(z.object({
+    lot_id: z.string().uuid(),
+    amount_remaining: z.number().int().min(0),
+    expires_at: z.string(),
+    source: z.string(),
+  })),
+});
+export type WalletSummary = z.infer<typeof WalletSummarySchema>;
+
+export const DiamondProductSchema = z.object({
+  product_id: z.string(),
+  diamonds: z.number().int().positive(),
+  bonus_diamonds: z.number().int().min(0),
+  price_krw: z.number().int().positive(),
+  display_order: z.number().int(),
+  active: z.boolean(),
+});
+export type DiamondProduct = z.infer<typeof DiamondProductSchema>;
+```
+
+- [ ] **Step 12.2: 실패 테스트 작성**
+
+`uniqn-mobile/src/repositories/supabase/__tests__/WalletRepository.test.ts`:
+
+```typescript
+import { WalletRepository } from '../WalletRepository';
+import { supa } from '@/lib/supabase';
+
+describe('WalletRepository', () => {
+  it('getSummary — 빈 지갑 → 0', async () => {
+    const summary = await WalletRepository.getSummary('00000000-0000-0000-0000-000000000099');
+    expect(summary.heart_balance).toBe(0);
+    expect(summary.diamond_balance).toBe(0);
+    expect(summary.expiring_lots).toEqual([]);
+  });
+
+  it('listProducts — 6개 활성 상품', async () => {
+    const products = await WalletRepository.listProducts();
+    expect(products).toHaveLength(6);
+    expect(products[0].display_order).toBeLessThan(products[5].display_order);
+  });
+});
+```
+
+- [ ] **Step 12.3: 테스트 실패 확인**
+
+```bash
+npm test -- src/repositories/supabase/__tests__/WalletRepository.test.ts
+```
+Expected: FAIL — module not found.
+
+- [ ] **Step 12.4: WalletRepository 구현**
+
+`uniqn-mobile/src/repositories/supabase/WalletRepository.ts`:
+
+```typescript
+import { supa } from '@/lib/supabase';
+import {
+  WalletSummary, WalletSummarySchema,
+  DiamondProduct, DiamondProductSchema,
+} from '@/types/wallet';
+import { logger } from '@/shared/logger';
+
+export const WalletRepository = {
+  async getSummary(userId?: string): Promise<WalletSummary> {
+    const { data, error } = await supa.rpc('get_wallet_summary', { p_user_id: userId ?? null });
+    if (error) {
+      logger.error('wallet.getSummary.failed', error);
+      throw error;
+    }
+    return WalletSummarySchema.parse(data);
+  },
+
+  async listProducts(): Promise<DiamondProduct[]> {
+    const { data, error } = await supa
+      .from('diamond_products')
+      .select('product_id, diamonds, bonus_diamonds, price_krw, display_order, active')
+      .eq('active', true)
+      .order('display_order', { ascending: true });
+    if (error) {
+      logger.error('wallet.listProducts.failed', error);
+      throw error;
+    }
+    return (data ?? []).map((row) => DiamondProductSchema.parse(row));
+  },
+};
+```
+
+- [ ] **Step 12.5: 테스트 통과 확인**
+
+```bash
+npm test -- src/repositories/supabase/__tests__/WalletRepository.test.ts
+```
+Expected: 2/2 PASS.
+
+- [ ] **Step 12.6: TypeScript 타입 재생성 + 빌드 검증**
+
+```bash
+cd uniqn-mobile
+npm run quality
+```
+Expected: type-check + lint + format 모두 통과.
+
+- [ ] **Step 12.7: 커밋**
+
+```bash
+git add uniqn-mobile/src/types/wallet.ts uniqn-mobile/src/repositories/supabase/WalletRepository.ts uniqn-mobile/src/repositories/supabase/__tests__/
+git commit -m "feat(wallet): WalletRepository + types + Zod schemas (read-only)"
+```
+
+---
+
+## Task 13: 종합 통합 시나리오 + Phase 1 종료 체크
+
+**Files:**
+- Create: `uniqn-mobile/src/__tests__/wallet/walletEndToEnd.integration.test.ts`
+
+- [ ] **Step 13.1: E2E 시나리오 테스트**
+
+```typescript
+describe('Wallet E2E — signup → purchase → consume → refund', () => {
+  beforeEach(resetUser);
+
+  it('전체 흐름', async () => {
+    // 1. Signup +10💖
+    await supa.rpc('grant_heart_atomically', {
+      p_user_id: TEST_USER, p_amount: 10, p_reason: 'grant_signup',
+      p_source_ref_id: null, p_expires_in_days: 90,
+    });
+    let s = await supa.rpc('get_wallet_summary', { p_user_id: TEST_USER });
+    expect(s.data.heart_balance).toBe(10);
+
+    // 2. 첫 충전 33💎 → +5💎 보너스
+    await supa.rpc('credit_diamonds_atomically', {
+      p_user_id: TEST_USER, p_diamonds: 33,
+      p_revenuecat_transaction_id: 'rc_e2e_001',
+      p_product_id: 'uniqn_diamonds_10000',
+    });
+    s = await supa.rpc('get_wallet_summary', { p_user_id: TEST_USER });
+    expect(s.data.diamond_balance).toBe(38); // 33 + 5
+
+    // 3. urgent 공고 작성 (10💎 차감, 하트 우선 → 하트 10 + 다이아 0)
+    const { data: created } = await supa.rpc('create_job_posting_with_payment_atomically', {
+      p_owner_id: TEST_USER,
+      p_posting_payload: { title: 'E2E Test', type: 'urgent' },
+      p_cost_diamonds: 10,
+      p_reason: 'consume_job_posting',
+    });
+    s = await supa.rpc('get_wallet_summary', { p_user_id: TEST_USER });
+    expect(s.data.heart_balance).toBe(0);
+    expect(s.data.diamond_balance).toBe(38); // 다이아 손대지 않음
+
+    // 4. 24h 내 취소 환불
+    const { data: refund } = await supa.rpc('refund_job_cancellation_atomically', {
+      p_posting_id: created.posting_id, p_owner_id: TEST_USER,
+    });
+    expect(refund.refunded_diamonds).toBe(10); // 100%
+    s = await supa.rpc('get_wallet_summary', { p_user_id: TEST_USER });
+    expect(s.data.diamond_balance).toBe(48); // 38 + 10 (다이아로 환불)
+    expect(s.data.heart_balance).toBe(0);    // 하트는 환불 안 됨 (정책)
+  });
+});
+```
+
+- [ ] **Step 13.2: 실행**
+
+```bash
+npm test -- src/__tests__/wallet/
+```
+Expected: 모든 wallet 테스트 PASS.
+
+- [ ] **Step 13.3: Supabase advisor 종합 검증**
+
+```
+mcp__supabase__get_advisors({ type: "security" })
+mcp__supabase__get_advisors({ type: "performance" })
+```
+Expected: wallet 관련 신규 critical/high 이슈 없음.
+
+- [ ] **Step 13.4: 마이그레이션 파일 동기화 확인**
+
+```bash
+ls -la uniqn-mobile/supabase/migrations/2026042700*.sql
+```
+Expected: 11개 파일 (000000 ~ 001000).
+
+- [ ] **Step 13.5: 종료 커밋**
+
+```bash
+git commit --allow-empty -m "feat(wallet): Phase 1 DB Foundation 완료 — 11 migrations + 5 RPC + 4 테스트 파일"
+```
+
+- [ ] **Step 13.6: Phase 1 종료 체크리스트 (수동 검증)**
+
+| 검증 항목 | 명령 | 기대 |
+|---|---|---|
+| 4 테이블 존재 | `mcp__supabase__list_tables` | wallets/wallet_ledger/heart_lots/diamond_products |
+| 14 enum 값 | `pg_enum` 쿼리 | wallet_reason 14개 |
+| 5 RPC 작동 | `pg_proc` 쿼리 | consume/credit/grant/get_summary/create_with_payment/refund |
+| trigger 1개 | `pg_trigger` | tr_wallet_ledger_update_balance |
+| cron 1개 | `cron.job` | expire_heart_lots_daily |
+| 6 product 시드 | SELECT | uniqn_diamonds_* 6개 |
+| app_config | SELECT | monetization key 1개 |
+| RLS 활성 | `pg_tables.rowsecurity` | 4 테이블 모두 true |
+| Phase 1 테스트 | `npm test -- wallet` | 모든 테스트 PASS |
+
+---
+
+## Phase 1 Self-Review
+
+### Spec Coverage
+- §3.1 diamond_products → Task 1, 9 ✅
+- §3.2 wallet_ledger → Task 1 ✅
+- §3.3 wallets → Task 1 ✅
+- §3.4 heart_lots + KST cron → Task 1, 11 ✅
+- §3.5 RLS → Task 2 ✅
+- §4.1 consume_diamonds → Task 4 ✅
+- §4.2 credit_diamonds + 첫충전 보너스 → Task 5 ✅
+- §4.3 grant_heart + get_wallet_summary → Task 6 ✅
+- §4.4 cache trigger → Task 3 ✅
+- §6.3 race-free wrapper → Task 7 ✅
+- §11 Decision #1 환불 → Task 8 ✅
+- §11 Decision #11 tournament=0 → Task 7 (cost_diamonds=0 케이스) ✅
+- 클라이언트 Repository (read-only 부분) → Task 12 ✅
+- E2E 검증 → Task 13 ✅
+
+### Out of Scope (후속 plan으로)
+- §5 RevenueCat Webhook Edge Function → Phase 2
+- §6.1, 6.2 클라이언트 SDK + UI 컴포넌트 → Phase 3
+- §6.3 jobManagementService 통합 → Phase 4 (단, RPC는 Task 7에서 준비 완료)
+- §7 Feature Flag rollout 활성화 → Phase 6 (시드는 Task 10에서 false로 준비)
+- §8 STRIDE 위협 대응 (보안 검증) → Phase 7
+- §10 모니터링/대시보드 → Phase 7
+
+### 발견된 문제 + 수정
+- 없음. Type 일관성 OK (currency_type: WalletCurrency, reason: WalletReason).
+
+---
+
+## Execution Handoff
+
+Plan 작성 완료, 저장: `docs/superpowers/plans/2026-04-26-monetization.md`
+
+**Phase 1 (DB Foundation)만 13개 task로 분해됨.** 추정 작업 시간: 8~12시간 (TDD + 디버깅 포함).
+
+**두 가지 실행 옵션:**
+
+1. **Subagent-Driven (권장)**
+   - 각 task를 fresh subagent에게 위임 → 본 에이전트는 task 사이 review만
+   - 빠른 iteration, 본 컨텍스트 보존
+   - REQUIRED SUB-SKILL: `superpowers:subagent-driven-development`
+
+2. **Inline Execution**
+   - 본 세션에서 task 1부터 순차 실행, checkpoint마다 일시정지
+   - 단일 컨텍스트, 더 디버깅 친화적
+   - REQUIRED SUB-SKILL: `superpowers:executing-plans`
+
+**선택해주세요.**
+
+---
+
+## Future Plans (Phase 2~7)
+
+Phase 1 완료 후 다음 plan들을 별도로 작성:
+
+| Phase | 범위 | 예상 task 수 | 의존성 |
+|---|---|---|---|
+| 2 | RevenueCat Webhook Edge Function + RC 계정 설정 | ~8 | Phase 1 완료 |
+| 3 | 클라이언트 SDK 통합 + Wallet UI (BalanceBadge, PurchaseSheet, PaywallModal) | ~15 | Phase 1, 2 |
+| 4 | jobManagementService 통합 (다이아 차감 hook + Tournament 처리) | ~6 | Phase 1, 3 |
+| 5 | 하트 적립 흐름 (signup/daily/streak/review/referral 모두) | ~10 | Phase 1, 3 |
+| 6 | Feature Flag rollout 단계적 활성화 (10→50→100%) | ~4 | Phase 1~5 |
+| 7 | 환불 통합 (cancel_application + refund 연결) + 모니터링 대시보드 | ~8 | Phase 1, 4 |
+
+총 추정: ~64 task, 6주 작업.

--- a/docs/superpowers/plans/2026-04-29-monetization-phase2-revenuecat-setup.md
+++ b/docs/superpowers/plans/2026-04-29-monetization-phase2-revenuecat-setup.md
@@ -1,0 +1,247 @@
+# Phase 2 — RevenueCat Webhook 외부 작업 가이드
+
+> 작성일: 2026-04-29
+> 의존성: Phase 1 DB Foundation 완료 (15 마이그 + 8 RPC)
+> 후속: Phase 3 클라이언트 SDK + UI
+
+이 문서는 **사람이 직접 해야 하는** 작업을 정리합니다. Edge Function 코드는 이미
+`uniqn-mobile/supabase/functions/revenuecat-webhook/index.ts`에 작성·deploy 완료됐고
+(`mcp__supabase__deploy_edge_function`, version 1, ACTIVE), 아래 외부 설정만 끝나면
+Apple/Google IAP → 자동 다이아 적립이 시작됩니다.
+
+---
+
+## 0. 현재 상태 (확인용)
+
+- ✅ Edge Function deploy: `revenuecat-webhook` (verify_jwt=false, RC 자체 Bearer 인증)
+- ✅ DB: `diamond_products` 6 SKU 시드, `credit_diamonds_atomically` RPC 작동
+- ⚠️ `REVENUECAT_WEBHOOK_SECRET` 미설정 → 함수 호출 시 500 server_misconfigured
+- ⚠️ RevenueCat 계정 / 상품 / Offering 미설정
+
+---
+
+## 1. RevenueCat 계정 + 프로젝트 (~30분)
+
+1. https://app.revenuecat.com 회원가입 (무료 tier로 시작 가능)
+2. **Create Project** → 이름: `UNIQN`
+3. 좌측 메뉴 **Project Settings → Apps** → iOS 앱 + Android 앱 등록
+   - iOS Bundle ID: `com.uniqn.app` (실 bundle ID 확인)
+   - Android Package: `com.uniqn.app`
+4. **Project Settings → API Keys** 에서 다음 키 메모:
+   - iOS Public SDK Key (앱 빌드 시 사용)
+   - Android Public SDK Key
+
+---
+
+## 2. App Store Connect — Consumable IAP 6개 등록 (~1시간)
+
+각 SKU를 **Consumable** 타입으로 등록 (Subscription 아님).
+
+| Product ID | 가격 (KRW) | 다이아 + 보너스 표시 |
+|------------|----------|--------------------|
+| `uniqn_diamonds_1000`   | 1,000원   | 3💎 |
+| `uniqn_diamonds_3000`   | 3,000원   | 10💎 |
+| `uniqn_diamonds_10000`  | 10,000원  | 33💎 + 2💎 보너스 |
+| `uniqn_diamonds_30000`  | 30,000원  | 100💎 + 10💎 보너스 |
+| `uniqn_diamonds_50000`  | 50,000원  | 167💎 + 23💎 보너스 |
+| `uniqn_diamonds_100000` | 100,000원 | 333💎 + 67💎 보너스 |
+
+**주의**:
+- Product ID는 **반드시 위와 동일하게** 입력 (DB seed에 등록된 값과 매칭)
+- **Tax Category**: Consumable IAP
+- **Localization**: 한국어 (Korea) 활성화
+- 심사용 스크린샷: 각 패키지의 충전 시트 캡처 (Phase 3 UI 완료 후)
+
+---
+
+## 3. Google Play Console — Managed Product 6개 등록 (~1시간)
+
+각 SKU를 **In-app product** 타입으로 등록 (Subscription 아님).
+
+| Product ID | 동일 (App Store와 같음) |
+| 가격 | 동일 (App Store 가격 미러링) |
+| 활성화 | "활성" 상태로 publish |
+
+**주의**:
+- Play Console의 SKU ID = App Store Product ID (반드시 일치)
+- **결제 라이브러리** v6+ 필요 (`com.android.billingclient:billing:6.x`) — react-native-purchases가 자동 처리
+- 첫 등록 시 **앱 publishing 필수** (internal testing track으로도 충분)
+
+---
+
+## 4. RevenueCat에서 상품 + Offering 연결 (~30분)
+
+1. **Products** 메뉴 → `+ New Product`
+   - 6개 SKU 모두 등록 (App Store / Play Store 양쪽 connect)
+2. **Entitlements** 메뉴
+   - 본 시스템은 consumable이므로 entitlement 불필요 (skip)
+3. **Offerings** 메뉴 → `+ New Offering`
+   - 이름: `default` (RC SDK가 기본 조회)
+   - 6개 product를 packages로 추가:
+     - `$rc_three_month` 등 system identifier 대신 custom identifier 사용 가능
+     - 예: `pkg_1000`, `pkg_3000`, ... (앱에서 매칭)
+   - Display Order: 가격 오름차순
+
+---
+
+## 5. Webhook URL 등록 + Secret 발급 (가장 중요) (~10분)
+
+1. RevenueCat 좌측 **Project Settings → Integrations → Webhooks**
+2. `+ Add new webhook`
+3. URL 입력:
+   ```
+   https://ygfxukhktpqymahfrvbz.supabase.co/functions/v1/revenuecat-webhook
+   ```
+4. **Authorization header value** 입력:
+   - 형식: `Bearer <임의 32자 이상 secret>`
+   - 예: `Bearer rcw_a3f9bdc7f1e442d8b6e0f9c2a4d7e8f1` (임의 생성)
+   - **이 전체 문자열을 메모해두세요. 다음 단계에서 사용.**
+5. **Events** 체크 (받을 이벤트):
+   - ✅ `INITIAL_PURCHASE`
+   - ✅ `NON_RENEWING_PURCHASE`
+   - ✅ `CANCELLATION`
+   - ✅ `BILLING_ISSUE`
+   - ✅ `REFUND`
+   - 나머지는 함수가 ignore 처리
+6. **Save**
+
+---
+
+## 6. Supabase에 Secret 등록 (~5분)
+
+CLI 사용 (권장):
+```bash
+cd C:/Users/user/Desktop/T-HOLDEM/uniqn-mobile
+supabase secrets set REVENUECAT_WEBHOOK_SECRET="rcw_a3f9bdc7f1e442d8b6e0f9c2a4d7e8f1"
+# 위 값은 5단계의 Authorization 헤더 전체 (Bearer 제외한 토큰만)
+```
+
+또는 **Supabase Dashboard** (CLI 미설치 시):
+1. https://supabase.com/dashboard/project/ygfxukhktpqymahfrvbz/settings/functions
+2. **Edge Functions → Manage secrets**
+3. `+ Add new secret`
+   - Name: `REVENUECAT_WEBHOOK_SECRET`
+   - Value: `rcw_a3f9bdc7f1e442d8b6e0f9c2a4d7e8f1` (5단계 Bearer 뒤 토큰만)
+
+---
+
+## 7. 검증 (사용자 액션 후 자동화 가능)
+
+Secret 등록 완료 후 아래 명령으로 즉시 검증 가능:
+
+### 7.1 권한 검증 (잘못된 secret → 401)
+```bash
+curl -i -X POST "https://ygfxukhktpqymahfrvbz.supabase.co/functions/v1/revenuecat-webhook" \
+  -H "Authorization: Bearer wrong_secret" \
+  -H "Content-Type: application/json" \
+  -d '{"event":{"type":"INITIAL_PURCHASE"}}'
+# 기대: HTTP 401 {"error":"unauthorized"}
+```
+
+### 7.2 정상 결제 (INITIAL_PURCHASE → +35💎)
+```bash
+SECRET="<5단계의 Bearer 뒤 토큰>"
+curl -i -X POST "https://ygfxukhktpqymahfrvbz.supabase.co/functions/v1/revenuecat-webhook" \
+  -H "Authorization: Bearer $SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "api_version": "1.0",
+    "event": {
+      "type": "INITIAL_PURCHASE",
+      "id": "rc_test_event_001",
+      "app_user_id": "b2222222-2222-4222-b222-222222222222",
+      "product_id": "uniqn_diamonds_10000",
+      "transaction_id": "store_txn_abc",
+      "purchased_at_ms": 1777665600000,
+      "store": "APP_STORE",
+      "environment": "SANDBOX"
+    }
+  }'
+# 기대: HTTP 200 success=true, diamonds_credited=35, rpc.first_purchase_bonus=5 (lifetime=0이면)
+```
+
+### 7.3 멱등성 (같은 event.id 재호출 → idempotent)
+```bash
+# 7.2와 동일한 명령을 다시 실행
+# 기대: HTTP 200 rpc.idempotent=true (잔액 변화 없음)
+```
+
+### 7.4 환불 (REFUND → -35💎)
+```bash
+curl -i -X POST "https://ygfxukhktpqymahfrvbz.supabase.co/functions/v1/revenuecat-webhook" \
+  -H "Authorization: Bearer $SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "event": {
+      "type": "REFUND",
+      "id": "rc_test_refund_001",
+      "app_user_id": "b2222222-2222-4222-b222-222222222222",
+      "product_id": "uniqn_diamonds_10000",
+      "transaction_id": "store_txn_abc"
+    }
+  }'
+# 기대: HTTP 200 diamonds_credited=-35, refund_purchase ledger row 생성
+```
+
+### 7.5 무시 이벤트 (RENEWAL → 200 ignored)
+```bash
+curl -i -X POST "https://ygfxukhktpqymahfrvbz.supabase.co/functions/v1/revenuecat-webhook" \
+  -H "Authorization: Bearer $SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"event":{"type":"RENEWAL","id":"x","app_user_id":"x","product_id":"x"}}'
+# 기대: HTTP 200 {"ignored":true,"type":"RENEWAL"}
+```
+
+### 7.6 DB 확인
+```sql
+-- 7.2~7.4 후 ledger 흐름 확인
+SELECT reason, currency_type, delta, balance_after_diamond, revenuecat_transaction_id
+FROM public.wallet_ledger
+WHERE user_id = 'b2222222-2222-4222-b222-222222222222'
+ORDER BY created_at DESC
+LIMIT 10;
+```
+
+---
+
+## 8. RC Sandbox로 실제 결제 테스트
+
+코드/설정 검증 후 실제 SDK 흐름 테스트는 **Phase 3** 에서 진행:
+1. `react-native-purchases` SDK 설치
+2. iOS Sandbox tester 계정으로 인앱 결제
+3. RC dashboard에서 webhook 전송 로그 확인
+4. Supabase Edge Function logs에서 호출 기록 확인
+
+---
+
+## 9. 운영 체크리스트 (Phase 6 rollout 시)
+
+- [ ] RC dashboard **Webhooks → Recent events** 모니터링
+- [ ] Supabase Edge Function **Logs** 페이지에서 4xx/5xx 비율 확인
+- [ ] `wallet_ledger` 에서 `revenuecat_transaction_id IS NOT NULL` 거래만 매월 정산
+- [ ] `lifetime_purchased_diamonds` 합계 ≈ RC dashboard MTR과 일치 검증
+- [ ] 환불 발생 시 알림 (Phase 7 Slack/email)
+
+---
+
+## Phase 2 코드 작업 요약 (참고)
+
+| 산출물 | 위치 |
+|--------|------|
+| Edge Function | `uniqn-mobile/supabase/functions/revenuecat-webhook/index.ts` |
+| Deploy 결과 | revenuecat-webhook v1 ACTIVE, verify_jwt=false |
+| 의존 RPC | `credit_diamonds_atomically` (Phase 1 Task 5) |
+| 멱등성 키 | `wallet_ledger.revenuecat_transaction_id` UNIQUE |
+| 처리 이벤트 | INITIAL_PURCHASE / NON_RENEWING_PURCHASE → +diamonds, REFUND/BILLING_ISSUE/CANCELLATION → -diamonds |
+| 무시 이벤트 | RENEWAL / EXPIRATION / PRODUCT_CHANGE / TRANSFER / SUBSCRIBER_ALIAS / TEST |
+| 보안 | Bearer secret 일치 + UUID 검증 + product DB 조회 (클라이언트 신뢰 X) |
+
+---
+
+## Phase 3 예고 (다음 plan)
+
+- `react-native-purchases` 설치 + 초기화
+- `purchasesService.ts` (SDK wrapper)
+- `WalletStore` (Zustand) + `useWalletBalance` (TanStack Query)
+- UI 컴포넌트: `BalanceBadge` / `PurchaseSheet` / `PaywallModal`
+- Sandbox 테스터 결제 → RC webhook → Edge Function → DB 풀스택 검증

--- a/docs/superpowers/specs/2026-04-26-monetization-design.md
+++ b/docs/superpowers/specs/2026-04-26-monetization-design.md
@@ -2,8 +2,8 @@
 
 - 작성일: 2026-04-26
 - 브랜치: `design/monetization-system`
-- 상태: Draft (사용자 검토 대기)
-- 후속: `writing-plans` 스킬로 implementation plan 생성 예정
+- 상태: **Locked** (11개 결정 사용자 승인 완료, 2026-04-26)
+- 후속: `writing-plans` 스킬로 implementation plan 생성 진행
 
 ---
 
@@ -565,10 +565,10 @@ uniqn-mobile/src/
 │   ├── usePurchaseDiamonds.ts     # 구매 mutation
 │   └── useDailyAttendance.ts      # 출석 RPC mutation
 ├── components/wallet/
-│   ├── BalanceBadge.tsx           # 헤더용 잔액 표시
+│   ├── BalanceBadge.tsx           # 헤더용 잔액 표시 + 7일 이내 만료 lot inline (decision #3)
 │   ├── PurchaseSheet.tsx          # 다이아 충전 시트
-│   ├── PaywallModal.tsx           # 잔액 부족 시 표시
-│   └── HeartExpiringBanner.tsx    # 7일 이내 만료 경고
+│   └── PaywallModal.tsx           # 잔액 부족 시 표시
+│   # HeartExpiringBanner.tsx 제거 — decision #3 (알림/배너 없음)
 └── stores/
     └── walletStore.ts             # 잔액 캐시 (optimistic update)
 ```
@@ -617,11 +617,17 @@ export async function purchaseDiamondPackage(pkg: PurchasesPackage) {
 // uniqn-mobile/src/services/jobs/jobManagementService.ts (수정)
 
 async function createJobPosting(input: CreateJobPostingInput) {
-  // 1. 가격 계산
+  // 1. 가격 계산 (decision #11: tournament=0)
   const priceMap = { regular: 1, urgent: 10, fixed: 5, tournament: 0 };
-  const cost = priceMap[input.type];
+  let cost = priceMap[input.type];
 
-  // 2. Feature flag 체크 (부분 유료화)
+  // 2. Tournament는 항상 무료 (admin/주최사 영업용)
+  //    추가 가드: tournament 공고는 admin role에 한정하는 RLS 별도 적용
+  if (input.type === 'tournament') {
+    cost = 0;
+  }
+
+  // 3. Feature flag 체크 (부분 유료화)
   if (cost > 0 && !await isMonetizationEnabledFor(input.type, currentUser.id)) {
     cost = 0;
   }
@@ -782,22 +788,27 @@ $$;
 
 ---
 
-## 11. 미해결 결정 (Open Questions)
+## 11. Locked Decisions (사용자 검토 완료, 2026-04-26)
 
-| 결정 | 옵션 | 권장 |
-|---|---|---|
-| **공고 취소 시 환불 정책** | (a) 전액 환불 (b) 부분 환불 (c) 환불 없음 | (b) 24시간 이내 100%, 이후 50% |
-| **wallets.diamond_balance 음수 허용** | (a) 절대 금지 (b) admin 보정 가능 | (a) — `CHECK >= 0` 강제. 환불이 잔액보다 크면 가능한 만큼만 차감 (§4.2 step 3). 단, ledger row delta는 음수 허용 (감사 추적용) |
-| **하트 만료 알림** | (a) 만료 7일 전 push (b) 앱 내 배너만 (c) 둘 다 | (c) — push 1회 + 영구 배너 |
-| **VIP 등급 시스템** | (a) 이번에 포함 (b) Phase 2 | (b) — 데이터 모이고 결정 |
-| **환불 시 ledger 처리** | (a) 새 row (b) 기존 row update | (a) — immutable 원칙 |
-| **Feature Flag 키** | (a) JSONB single config (b) 개별 row | (a) — 이미 `app_config` 있음 |
-| **첫 충전 보너스** | (a) +5💎 (레거시 v4.0) (b) 없음 | (a) — 전환율 부스터 |
-| **다이아 환불 시 ledger 음수** | (a) 음수 row 허용 (b) 부채 차감 후 0 floor | (a) — 감사 명확성 우선 (사용 가능 잔액은 GREATEST(0, balance) 표시) |
-| **RC webhook 재시도 정책** | (a) 5회 + 지수백오프 (RC 기본) (b) 자체 재처리 큐 | (a) — UNIQUE 제약으로 멱등성 보장되므로 RC 기본 신뢰 |
-| **Apple/Google 직접 환불 vs RC** | RC만 신뢰 vs 양쪽 webhook | RC만 — 단일 소스 |
+| # | 결정 | 채택 | 비고 |
+|---|---|---|---|
+| 1 | 공고 취소 환불 정책 | **24h 내 100% / 이후 50%** | 구현: `wallet_reason='refund_job_cancelled'` + 비율은 cancel RPC에서 계산 |
+| 2 | `wallets.diamond_balance` 음수 | **절대 금지** | `CHECK >= 0`, 환불 초과 시 가능한 만큼만 차감 (§4.2 step 3) |
+| 3 | 하트 만료 알림 | **알림 없음, 유효기간만 설정** | UI에서 `heart_lots.expires_at` 노출은 잔액 화면에 inline 표시만. 푸시/배너 제거 |
+| 4 | VIP 등급 시스템 | **Phase 2로 연기** | `lifetime_purchased_diamonds` 컬럼은 미리 두고 사용은 안 함 |
+| 5 | 환불 ledger 처리 | **새 음수 row** | immutable 원칙 |
+| 6 | Feature Flag 저장 | **`app_config` JSONB single row** | 이미 존재 |
+| 7 | 첫 충전 보너스 +5💎 | **채택** | `metadata.is_first_purchase=true` 시 ledger에 별도 +5 row 추가 |
+| 8 | 다이아 환불이 잔액보다 클 때 | **음수 row 허용 + wallets 캐시는 0 floor** | 감사 명확성 우선 |
+| 9 | RC webhook 재시도 | **RC 기본 (5회 지수백오프)** | UNIQUE 제약으로 멱등성 |
+| 10 | Apple/Google 직접 환불 | **RC만 단일 소스** | 별도 webhook 없음 |
+| 11 | Tournament 공고 가격 | **0원 (admin 영업 미끼)** | priceMap에 `tournament: 0` 유지, `consume_diamonds` 호출 skip |
 
-→ 사용자 검토 단계에서 결정.
+**파급 변경 사항** (이 결정에 따른 spec 수정):
+- §3.4 `heart_lots` — 만료 알림 trigger 제거, expiry cron만 유지
+- §6.1 컴포넌트 — `HeartExpiringBanner.tsx` **삭제**, `BalanceBadge.tsx`에 만료 임박 lot inline 표시로 통합
+- §6.3 priceMap — tournament 처리 명시
+- §10 모니터링 — 만료 손실 KPI는 유지 (UX 신호로)
 
 ---
 
@@ -809,7 +820,9 @@ $$;
 4. `20260427000300_create_wallet_triggers.sql` — 캐시 sync trigger
 5. `20260427000400_seed_diamond_products.sql` — 6개 패키지 시드
 6. `20260427000500_create_app_config_monetization.sql` — Feature flag 시드
-7. `20260427000600_create_heart_expiry_cron.sql` — pg_cron 매일 만료 처리
+7. `20260427000600_create_heart_expiry_cron.sql` — pg_cron 매일 KST 자정 만료 처리 (decision #3: 알림 발송 없음, 잔량 0 + ledger `expire_heart` row만)
+8. `20260427000700_create_first_purchase_bonus.sql` — credit RPC 확장 (decision #7: 첫 충전 시 +5💎 보너스 row)
+9. `20260427000800_create_refund_rpc.sql` — `refund_job_cancellation_atomically` (decision #1: 24h 100% / 이후 50% 비율)
 
 ---
 

--- a/docs/superpowers/specs/2026-04-26-monetization-design.md
+++ b/docs/superpowers/specs/2026-04-26-monetization-design.md
@@ -1,0 +1,863 @@
+# Monetization System (Track A) — Design Spec
+
+- 작성일: 2026-04-26
+- 브랜치: `design/monetization-system`
+- 상태: Draft (사용자 검토 대기)
+- 후속: `writing-plans` 스킬로 implementation plan 생성 예정
+
+---
+
+## 0. Executive Summary
+
+UNIQN의 매출 엔진(하트/다이아 + RevenueCat)을 **그린필드로 처음부터** 구현한다.
+사업계획서(`BUSINESS_PLAN_2025.md`)에 상세 설계가 있고, 코드/DB/패키지는 모두 비어 있는 상태다.
+배포는 **부분 유료화 → 완전 유료화** Feature Flag로 점진 롤아웃 (10% → 50% → 100%).
+
+핵심 의사결정:
+1. **RevenueCat 사용** (직접 IAP 처리 X) — 영수증 검증/플랫폼 추상화/대시보드 제공.
+2. **DB는 ledger 모델** (잔액 컬럼 X) — 모든 변동은 append-only `wallet_ledger`에 기록, 잔액은 trigger로 캐싱.
+3. **다이아 차감은 RPC 단일 트랜잭션** (`consume_diamonds_atomically`) — `cancel_application_atomically` 패턴 그대로 차용.
+4. **하트는 무료, 다이아는 유료** — 둘 다 1포인트=300원. 사용 우선순위: 하트(만료 임박순) → 다이아.
+5. **부분 유료화 우선** — 일반공고 무료 유지, 긴급/고정만 유료로 6개월 PMF 측정 후 완전 유료화.
+
+성공 지표 (M+1 ~ M+6):
+- M+1: 유료 충전 사용자 수 ≥ 30명, ARPPU ≥ 5,000원
+- M+3: 긴급공고 전환율(무료→유료) ≥ 15%
+- M+6: MRR ≥ 50만원, BEP 가시거리
+
+---
+
+## 1. 현재 상태 진단 (Evidence-Based)
+
+| 영역 | 현재 상태 | 근거 |
+|---|---|---|
+| 결제 코드 | **0%** | `Grep "RevenueCat\|react-native-purchases"` → 0 hits |
+| 결제 DB 테이블 | **없음** | `mcp__supabase__list_tables` → wallets/ledger/products 없음 |
+| 결제 패키지 | **미설치** | `package.json` 검증 — `react-native-purchases` 없음 |
+| PortOne SDK | **설치됨** (본인인증 전용) | `@portone/react-native-sdk` (`portOneIdentityService.ts`) — RevenueCat과 충돌 없음 |
+| 가격 설계 | **두 버전 존재** | `BUSINESS_PLAN_2025.md` v1.2 (긴급 10💎) vs 레거시 v4.0 mobile-payment-plan (긴급 8💎) — 본 spec은 v1.2 채택 |
+| 사용 컨텍스트 | **명확** | `jobManagementService.ts`에서 공고 INSERT 직전 차감 hook 필요 |
+
+**진단**: 그린필드 — 레거시 부채 없음. 현재 코드의 trigger/RPC 패턴(`job_postings.stats trigger`, `cancel_application_atomically`)을 그대로 차용 가능.
+
+**레거시 설계 흡수 항목** (mobile-payment-plan v4.0에서):
+- 첫 충전 보너스 +5💎 (Open Question으로 추가)
+- 로그인 streak 추적 (이미 `grant_streak_7d` enum에 반영)
+- HMAC webhook 검증 누락 → 본 spec §5.3에서 강제
+- 음수 잔액 차단 → 본 spec §3.3 `CHECK >= 0` 제약
+- timezone 기준 모호 → 본 spec은 **KST 기준 자정** 명시 (§3.4 cron)
+
+---
+
+## 2. 아키텍처 개요
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                        Client (Expo RN)                          │
+│  ┌──────────────────┐     ┌────────────────────────────────────┐ │
+│  │ react-native-    │     │  WalletStore (Zustand)             │ │
+│  │ purchases SDK    │     │  + useWalletBalance Query          │ │
+│  └─────────┬────────┘     └────────────────┬───────────────────┘ │
+│            │                                │                     │
+│            │ 1. purchasePackage             │ 4. balance refetch  │
+│            ▼                                ▲                     │
+└──────────────────────────────────────────────────────────────────┘
+             │                                │
+             │ 2. RevenueCat SDK → App Store/Play Store
+             │
+             ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                        RevenueCat (SaaS)                         │
+│  - 영수증 검증 (Apple/Google)                                    │
+│  - Customer 관리 (appUserID = Supabase user.id)                 │
+│  - 3. Webhook → Supabase Edge Function                          │
+└─────────────────────────────────────────────────────────────────┘
+             │
+             │ HTTP POST (signed)
+             ▼
+┌─────────────────────────────────────────────────────────────────┐
+│              Supabase Edge Function (Deno)                       │
+│  /functions/revenuecat-webhook/index.ts                          │
+│  - 서명 검증 (RC_WEBHOOK_SECRET)                                 │
+│  - app_user_id → user.id 매핑                                    │
+│  - product_id → diamond amount lookup                            │
+│  - RPC credit_diamonds_atomically 호출                           │
+└─────────────────────────────────────────────────────────────────┘
+             │
+             ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                Supabase Postgres (RLS-enabled)                   │
+│                                                                   │
+│   diamond_products       wallet_ledger     wallets (cached)      │
+│   ─────────────────      ─────────────     ─────────────────     │
+│   product_id (PK)        id (PK)           user_id (PK)          │
+│   diamonds               user_id (FK)      heart_balance         │
+│   bonus_diamonds         currency_type     diamond_balance       │
+│   price_krw              delta             updated_at            │
+│   active                 reason                                  │
+│                          ref_id            heart_lots            │
+│                          ref_type          ─────────────         │
+│                          balance_after     id (PK)               │
+│                          revenuecat_       user_id (FK)          │
+│                            transaction_id  amount_remaining      │
+│                          created_at        granted_at            │
+│                                            expires_at            │
+│                                            source                │
+│                                                                   │
+│   Triggers:                                                       │
+│   - tr_wallet_ledger_update_balance (ledger → wallets cache)     │
+│   - tr_heart_lot_consume (lot 우선 소비)                         │
+│                                                                   │
+│   RPCs:                                                           │
+│   - consume_diamonds_atomically(user_id, amount, reason, ref_id) │
+│   - credit_diamonds_atomically(user_id, amount, reason, ref_id)  │
+│   - grant_heart_atomically(user_id, amount, reason, expires_at)  │
+│   - get_wallet_summary(user_id) → balances + expiring lots       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. DB 스키마
+
+### 3.1 `diamond_products` — 충전 패키지 카탈로그
+
+```sql
+CREATE TABLE public.diamond_products (
+  product_id          TEXT PRIMARY KEY,           -- App Store / Play Store SKU
+  diamonds            INT  NOT NULL CHECK (diamonds > 0),
+  bonus_diamonds      INT  NOT NULL DEFAULT 0,
+  price_krw           INT  NOT NULL,              -- 표시용 (실제 결제는 store 가격)
+  display_order       INT  NOT NULL DEFAULT 0,
+  active              BOOLEAN NOT NULL DEFAULT true,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+초기 시드 (BUSINESS_PLAN §3.2):
+
+| product_id | diamonds | bonus | price_krw |
+|---|---|---|---|
+| `uniqn_diamonds_1000` | 3 | 0 | 1000 |
+| `uniqn_diamonds_3000` | 10 | 0 | 3000 |
+| `uniqn_diamonds_10000` | 33 | 2 | 10000 |
+| `uniqn_diamonds_30000` | 100 | 10 | 30000 |
+| `uniqn_diamonds_50000` | 167 | 23 | 50000 |
+| `uniqn_diamonds_100000` | 333 | 67 | 100000 |
+
+### 3.2 `wallet_ledger` — Append-only 거래 원장
+
+```sql
+CREATE TYPE wallet_currency AS ENUM ('heart', 'diamond');
+CREATE TYPE wallet_reason AS ENUM (
+  'purchase',                -- 다이아 충전 (RevenueCat)
+  'consume_job_posting',     -- 공고 게시 차감
+  'consume_job_extend',      -- 공고 연장 차감
+  'consume_job_upgrade',     -- 일반→긴급 전환 차감
+  'refund_purchase',         -- RevenueCat 환불
+  'refund_job_cancelled',    -- 공고 취소 환불 (정책 결정 필요)
+  'grant_signup',            -- 신규 가입 +10 하트
+  'grant_daily_attendance',  -- 출석 체크 +1
+  'grant_streak_7d',         -- 7일 연속 +3
+  'grant_review',            -- 리뷰 작성 +1
+  'grant_referral',          -- 친구 초대 +5
+  'grant_admin',             -- 관리자 수동 지급
+  'expire_heart'             -- 하트 만료
+);
+
+CREATE TABLE public.wallet_ledger (
+  id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                  UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  currency_type            wallet_currency NOT NULL,
+  delta                    INT NOT NULL,              -- 양수=적립, 음수=차감
+  reason                   wallet_reason NOT NULL,
+  ref_id                   UUID,                       -- job_posting_id 등
+  ref_type                 TEXT,                       -- 'job_posting' / 'application' 등
+  balance_after_heart      INT NOT NULL,               -- 변동 후 잔액 (감사용)
+  balance_after_diamond    INT NOT NULL,
+  revenuecat_transaction_id TEXT UNIQUE,               -- idempotency key (구매/환불)
+  metadata                 JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_wallet_ledger_user_created
+  ON public.wallet_ledger(user_id, created_at DESC);
+CREATE INDEX idx_wallet_ledger_ref
+  ON public.wallet_ledger(ref_type, ref_id);
+```
+
+**핵심 원칙**:
+- 절대 UPDATE/DELETE 금지 (immutable). 환불도 새 row로.
+- `revenuecat_transaction_id` UNIQUE 제약 → webhook 재전송 멱등성 보장.
+
+### 3.3 `wallets` — 잔액 캐시 (trigger 동기화)
+
+```sql
+CREATE TABLE public.wallets (
+  user_id          UUID PRIMARY KEY REFERENCES public.users(id) ON DELETE CASCADE,
+  heart_balance    INT NOT NULL DEFAULT 0 CHECK (heart_balance >= 0),
+  diamond_balance  INT NOT NULL DEFAULT 0 CHECK (diamond_balance >= 0),
+  lifetime_purchased_diamonds INT NOT NULL DEFAULT 0,  -- VIP 등급 산정용
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+**왜 캐시인가**: 잔액 표시는 매 화면에서 일어나므로 ledger SUM은 부담. `job_postings.stats trigger` 패턴 그대로 채택.
+
+### 3.4 `heart_lots` — 만료 단위 (FIFO 소비)
+
+```sql
+CREATE TABLE public.heart_lots (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  amount_initial    INT NOT NULL CHECK (amount_initial > 0),
+  amount_remaining  INT NOT NULL CHECK (amount_remaining >= 0),
+  granted_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at        TIMESTAMPTZ NOT NULL,
+  source            wallet_reason NOT NULL,
+  source_ref_id     UUID,
+  CONSTRAINT chk_amount_remaining_lte_initial
+    CHECK (amount_remaining <= amount_initial)
+);
+
+CREATE INDEX idx_heart_lots_user_expiring
+  ON public.heart_lots(user_id, expires_at)
+  WHERE amount_remaining > 0;
+```
+
+**소비 알고리즘**: `expires_at ASC` (만료 임박 순) → `granted_at ASC` (오래된 것 먼저).
+**만료 처리**: pg_cron으로 **매일 00:00 KST** (UTC 15:00 전일)에 `expires_at < now()` 항목 lot 잔량을 0으로, ledger에 `expire_heart` 기록.
+**timezone 기준**: 모든 만료/streak/일일 출석은 **Asia/Seoul** (UTC+9) 기준. RPC에서 `now() AT TIME ZONE 'Asia/Seoul'` 사용 강제.
+
+### 3.5 RLS 정책
+
+```sql
+ALTER TABLE wallets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE wallet_ledger ENABLE ROW LEVEL SECURITY;
+ALTER TABLE heart_lots ENABLE ROW LEVEL SECURITY;
+ALTER TABLE diamond_products ENABLE ROW LEVEL SECURITY;
+
+-- 본인 잔액만 읽기
+CREATE POLICY wallet_self_select ON wallets
+  FOR SELECT USING ((SELECT auth.uid()) = user_id);
+
+-- ledger 본인 읽기
+CREATE POLICY ledger_self_select ON wallet_ledger
+  FOR SELECT USING ((SELECT auth.uid()) = user_id);
+
+-- 모든 쓰기는 SECURITY DEFINER RPC를 통해서만
+-- (직접 INSERT/UPDATE 차단)
+CREATE POLICY ledger_no_direct_write ON wallet_ledger
+  FOR ALL USING (false) WITH CHECK (false);
+
+-- 다이아 상품은 모두 읽기 가능
+CREATE POLICY products_public_read ON diamond_products
+  FOR SELECT USING (active = true);
+
+-- admin은 전체 접근 (app_metadata.role = 'admin')
+CREATE POLICY wallet_admin_all ON wallets
+  FOR ALL USING ((auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');
+```
+
+---
+
+## 4. RPC 함수
+
+### 4.1 `consume_diamonds_atomically`
+
+```sql
+CREATE OR REPLACE FUNCTION public.consume_diamonds_atomically(
+  p_user_id UUID,
+  p_amount  INT,                  -- 양수
+  p_reason  wallet_reason,
+  p_ref_id  UUID,
+  p_ref_type TEXT
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = 'public'
+AS $$
+DECLARE
+  v_wallet wallets%ROWTYPE;
+  v_heart_consumed INT := 0;
+  v_diamond_consumed INT := 0;
+  v_remaining INT := p_amount;
+  v_lot RECORD;
+  v_now TIMESTAMPTZ := now();
+BEGIN
+  IF p_amount <= 0 THEN
+    RAISE EXCEPTION 'INVALID_AMOUNT: % must be positive', p_amount;
+  END IF;
+
+  -- 1. 지갑 행 잠금 (없으면 생성)
+  INSERT INTO wallets(user_id) VALUES (p_user_id)
+    ON CONFLICT (user_id) DO NOTHING;
+  SELECT * INTO v_wallet FROM wallets WHERE user_id = p_user_id FOR UPDATE;
+
+  -- 2. 총 잔액 검증 (하트+다이아)
+  IF v_wallet.heart_balance + v_wallet.diamond_balance < p_amount THEN
+    RAISE EXCEPTION 'INSUFFICIENT_BALANCE: have %h+%d, need %',
+      v_wallet.heart_balance, v_wallet.diamond_balance, p_amount;
+  END IF;
+
+  -- 3. 하트 우선 소비 (FIFO by expires_at)
+  FOR v_lot IN
+    SELECT * FROM heart_lots
+    WHERE user_id = p_user_id
+      AND amount_remaining > 0
+      AND expires_at > v_now
+    ORDER BY expires_at ASC, granted_at ASC
+    FOR UPDATE
+  LOOP
+    EXIT WHEN v_remaining = 0;
+    DECLARE v_take INT := LEAST(v_lot.amount_remaining, v_remaining);
+    BEGIN
+      UPDATE heart_lots SET amount_remaining = amount_remaining - v_take
+        WHERE id = v_lot.id;
+      v_heart_consumed := v_heart_consumed + v_take;
+      v_remaining := v_remaining - v_take;
+    END;
+  END LOOP;
+
+  -- 4. 부족분은 다이아로
+  IF v_remaining > 0 THEN
+    v_diamond_consumed := v_remaining;
+  END IF;
+
+  -- 5. ledger 기록 (하트/다이아 분리 row)
+  IF v_heart_consumed > 0 THEN
+    INSERT INTO wallet_ledger(user_id, currency_type, delta, reason, ref_id, ref_type,
+                              balance_after_heart, balance_after_diamond)
+    VALUES (p_user_id, 'heart', -v_heart_consumed, p_reason, p_ref_id, p_ref_type,
+            v_wallet.heart_balance - v_heart_consumed,
+            v_wallet.diamond_balance - v_diamond_consumed);
+  END IF;
+  IF v_diamond_consumed > 0 THEN
+    INSERT INTO wallet_ledger(user_id, currency_type, delta, reason, ref_id, ref_type,
+                              balance_after_heart, balance_after_diamond)
+    VALUES (p_user_id, 'diamond', -v_diamond_consumed, p_reason, p_ref_id, p_ref_type,
+            v_wallet.heart_balance - v_heart_consumed,
+            v_wallet.diamond_balance - v_diamond_consumed);
+  END IF;
+
+  -- 6. wallets 캐시 갱신은 trigger 가 담당
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'heart_consumed', v_heart_consumed,
+    'diamond_consumed', v_diamond_consumed,
+    'new_heart_balance', v_wallet.heart_balance - v_heart_consumed,
+    'new_diamond_balance', v_wallet.diamond_balance - v_diamond_consumed
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION consume_diamonds_atomically TO authenticated;
+```
+
+### 4.2 `credit_diamonds_atomically` (구매/환불 webhook용)
+
+```sql
+CREATE OR REPLACE FUNCTION public.credit_diamonds_atomically(
+  p_user_id UUID,
+  p_diamonds INT,                 -- 양수=구매, 음수=환불
+  p_revenuecat_transaction_id TEXT,  -- UNIQUE으로 멱등성
+  p_product_id TEXT
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = 'public'
+AS $$
+DECLARE
+  v_wallet wallets%ROWTYPE;
+  v_existing UUID;
+BEGIN
+  -- 1. 멱등성 체크
+  SELECT id INTO v_existing FROM wallet_ledger
+    WHERE revenuecat_transaction_id = p_revenuecat_transaction_id;
+  IF FOUND THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true);
+  END IF;
+
+  -- 2. 지갑 잠금
+  INSERT INTO wallets(user_id) VALUES (p_user_id)
+    ON CONFLICT (user_id) DO NOTHING;
+  SELECT * INTO v_wallet FROM wallets WHERE user_id = p_user_id FOR UPDATE;
+
+  -- 3. 환불 시 잔액 부족 체크 (음수가 되는 것 허용 정책 결정 필요 — 일단 0 floor)
+  IF p_diamonds < 0 AND v_wallet.diamond_balance < ABS(p_diamonds) THEN
+    -- 음수 잔액 허용 안 함, 가능한 만큼만 차감
+    p_diamonds := -v_wallet.diamond_balance;
+  END IF;
+
+  -- 4. ledger 기록
+  INSERT INTO wallet_ledger(user_id, currency_type, delta,
+                            reason, ref_type,
+                            balance_after_heart, balance_after_diamond,
+                            revenuecat_transaction_id,
+                            metadata)
+  VALUES (p_user_id, 'diamond', p_diamonds,
+          CASE WHEN p_diamonds > 0 THEN 'purchase'::wallet_reason
+               ELSE 'refund_purchase'::wallet_reason END,
+          'revenuecat',
+          v_wallet.heart_balance,
+          v_wallet.diamond_balance + p_diamonds,
+          p_revenuecat_transaction_id,
+          jsonb_build_object('product_id', p_product_id));
+
+  -- 5. lifetime 누계
+  IF p_diamonds > 0 THEN
+    UPDATE wallets SET lifetime_purchased_diamonds = lifetime_purchased_diamonds + p_diamonds
+      WHERE user_id = p_user_id;
+  END IF;
+
+  RETURN jsonb_build_object('success', true, 'diamonds_credited', p_diamonds);
+END;
+$$;
+
+-- service_role만 실행 가능 (webhook 전용)
+REVOKE EXECUTE ON FUNCTION credit_diamonds_atomically FROM PUBLIC, authenticated;
+GRANT EXECUTE ON FUNCTION credit_diamonds_atomically TO service_role;
+```
+
+### 4.3 `grant_heart_atomically` (하트 지급)
+
+```sql
+CREATE OR REPLACE FUNCTION public.grant_heart_atomically(
+  p_user_id UUID,
+  p_amount  INT,
+  p_reason  wallet_reason,
+  p_source_ref_id UUID DEFAULT NULL,
+  p_expires_in_days INT DEFAULT 90
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = 'public'
+AS $$
+DECLARE
+  v_lot_id UUID;
+  v_expires TIMESTAMPTZ := now() + (p_expires_in_days || ' days')::interval;
+BEGIN
+  IF p_amount <= 0 THEN RAISE EXCEPTION 'INVALID_AMOUNT'; END IF;
+
+  -- daily_attendance 일일 1회 제한
+  IF p_reason = 'grant_daily_attendance' THEN
+    IF EXISTS (
+      SELECT 1 FROM wallet_ledger
+      WHERE user_id = p_user_id
+        AND reason = 'grant_daily_attendance'
+        AND created_at::date = current_date
+    ) THEN
+      RETURN jsonb_build_object('success', false, 'error', 'already_attended_today');
+    END IF;
+  END IF;
+
+  INSERT INTO wallets(user_id) VALUES (p_user_id) ON CONFLICT DO NOTHING;
+
+  INSERT INTO heart_lots(user_id, amount_initial, amount_remaining,
+                          expires_at, source, source_ref_id)
+  VALUES (p_user_id, p_amount, p_amount, v_expires, p_reason, p_source_ref_id)
+  RETURNING id INTO v_lot_id;
+
+  INSERT INTO wallet_ledger(user_id, currency_type, delta, reason,
+                            ref_id, ref_type,
+                            balance_after_heart, balance_after_diamond)
+  SELECT p_user_id, 'heart', p_amount, p_reason,
+         v_lot_id, 'heart_lot',
+         w.heart_balance + p_amount, w.diamond_balance
+  FROM wallets w WHERE w.user_id = p_user_id;
+
+  RETURN jsonb_build_object('success', true, 'lot_id', v_lot_id, 'expires_at', v_expires);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION grant_heart_atomically TO service_role;
+-- daily_attendance만 클라이언트 호출 가능 (별도 wrapper RPC로 노출)
+```
+
+### 4.4 `tr_wallet_ledger_update_balance` (캐시 trigger)
+
+```sql
+CREATE OR REPLACE FUNCTION public.fn_wallet_ledger_update_balance()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = 'public'
+AS $$
+BEGIN
+  IF NEW.currency_type = 'heart' THEN
+    UPDATE wallets SET
+      heart_balance = NEW.balance_after_heart,
+      updated_at = now()
+    WHERE user_id = NEW.user_id;
+  ELSIF NEW.currency_type = 'diamond' THEN
+    UPDATE wallets SET
+      diamond_balance = NEW.balance_after_diamond,
+      updated_at = now()
+    WHERE user_id = NEW.user_id;
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER tr_wallet_ledger_update_balance
+AFTER INSERT ON public.wallet_ledger
+FOR EACH ROW EXECUTE FUNCTION fn_wallet_ledger_update_balance();
+```
+
+---
+
+## 5. RevenueCat Webhook Edge Function
+
+### 5.1 파일 구조
+
+`uniqn-mobile/supabase/functions/revenuecat-webhook/index.ts`
+
+### 5.2 처리 이벤트
+
+| RC Event | 액션 |
+|---|---|
+| `INITIAL_PURCHASE` | `credit_diamonds_atomically(+diamonds)` |
+| `RENEWAL` | (구독 사용 안 함) — 무시 |
+| `NON_RENEWING_PURCHASE` | `credit_diamonds_atomically(+diamonds)` (consumable) |
+| `CANCELLATION` | (구독 아니어서) — 무시 |
+| `EXPIRATION` | (구독 아니어서) — 무시 |
+| `REFUND` / `BILLING_ISSUE` | `credit_diamonds_atomically(-diamonds)` |
+| `PRODUCT_CHANGE` | 무시 |
+| `TRANSFER` | (한 user_id로 transfer) — 로그만 |
+
+### 5.3 보안 가드
+
+```typescript
+// 1. Authorization header 검증
+const authHeader = req.headers.get('Authorization');
+const expectedSecret = Deno.env.get('REVENUECAT_WEBHOOK_SECRET');
+if (authHeader !== `Bearer ${expectedSecret}`) {
+  return new Response('Unauthorized', { status: 401 });
+}
+
+// 2. event.id 멱등성 (RC가 retry할 때 중복 처리 방지)
+//    → wallet_ledger.revenuecat_transaction_id UNIQUE로 강제
+
+// 3. app_user_id 검증 (Supabase user.id 형식인지)
+if (!UUID_REGEX.test(event.app_user_id)) {
+  return new Response('Invalid app_user_id', { status: 400 });
+}
+
+// 4. product_id → diamond amount는 DB에서 조회 (클라이언트 신뢰 X)
+const { data: product } = await supa.from('diamond_products')
+  .select('diamonds, bonus_diamonds').eq('product_id', event.product_id).single();
+```
+
+### 5.4 환경변수
+
+- `REVENUECAT_WEBHOOK_SECRET` — RC 대시보드에서 생성, Supabase secrets에 저장
+- `SUPABASE_SERVICE_ROLE_KEY` — webhook이 SECURITY DEFINER RPC 호출용
+
+---
+
+## 6. 클라이언트 구조
+
+### 6.1 디렉토리
+
+```
+uniqn-mobile/src/
+├── services/wallet/
+│   ├── purchasesService.ts        # RevenueCat SDK wrapper
+│   ├── walletService.ts           # 잔액 조회, 차감 hook
+│   └── __tests__/
+├── repositories/supabase/
+│   └── WalletRepository.ts        # wallet_ledger / wallets 조회
+├── hooks/
+│   ├── useWalletBalance.ts        # TanStack Query
+│   ├── usePurchaseDiamonds.ts     # 구매 mutation
+│   └── useDailyAttendance.ts      # 출석 RPC mutation
+├── components/wallet/
+│   ├── BalanceBadge.tsx           # 헤더용 잔액 표시
+│   ├── PurchaseSheet.tsx          # 다이아 충전 시트
+│   ├── PaywallModal.tsx           # 잔액 부족 시 표시
+│   └── HeartExpiringBanner.tsx    # 7일 이내 만료 경고
+└── stores/
+    └── walletStore.ts             # 잔액 캐시 (optimistic update)
+```
+
+### 6.2 RevenueCat 초기화
+
+`src/services/wallet/purchasesService.ts`:
+
+```typescript
+import Purchases, { LOG_LEVEL } from 'react-native-purchases';
+import { logger } from '@/shared/logger';
+
+export async function initializePurchases(supabaseUserId: string) {
+  if (__DEV__) Purchases.setLogLevel(LOG_LEVEL.DEBUG);
+
+  Purchases.configure({
+    apiKey: Platform.select({
+      ios: process.env.EXPO_PUBLIC_REVENUECAT_IOS_KEY!,
+      android: process.env.EXPO_PUBLIC_REVENUECAT_ANDROID_KEY!,
+    })!,
+    appUserID: supabaseUserId,  // 핵심: Supabase user.id와 동기화
+  });
+}
+
+export async function getDiamondPackages() {
+  const offerings = await Purchases.getOfferings();
+  return offerings.current?.availablePackages ?? [];
+}
+
+export async function purchaseDiamondPackage(pkg: PurchasesPackage) {
+  try {
+    const { customerInfo, productIdentifier } = await Purchases.purchasePackage(pkg);
+    // webhook이 잔액 갱신 처리. 클라이언트는 refetch만.
+    return { success: true, productIdentifier };
+  } catch (error) {
+    if (error.userCancelled) return { success: false, cancelled: true };
+    logger.error('purchase_failed', error);
+    throw error;
+  }
+}
+```
+
+### 6.3 차감 호출 (jobManagementService 통합)
+
+```typescript
+// uniqn-mobile/src/services/jobs/jobManagementService.ts (수정)
+
+async function createJobPosting(input: CreateJobPostingInput) {
+  // 1. 가격 계산
+  const priceMap = { regular: 1, urgent: 10, fixed: 5, tournament: 0 };
+  const cost = priceMap[input.type];
+
+  // 2. Feature flag 체크 (부분 유료화)
+  if (cost > 0 && !await isMonetizationEnabledFor(input.type, currentUser.id)) {
+    cost = 0;
+  }
+
+  // 3. 차감 (cost > 0인 경우만)
+  if (cost > 0) {
+    const { data, error } = await supa.rpc('consume_diamonds_atomically', {
+      p_user_id: currentUser.id,
+      p_amount: cost,
+      p_reason: 'consume_job_posting',
+      p_ref_id: null,           // INSERT 후 update
+      p_ref_type: 'job_posting',
+    });
+    if (error || !data.success) throw new InsufficientBalanceError(data?.error);
+  }
+
+  // 4. 공고 INSERT
+  const { data: posting } = await supa.from('job_postings').insert({...}).select().single();
+
+  // 5. ledger의 ref_id 업데이트 (선택사항 — 감사용)
+  if (cost > 0) {
+    await supa.from('wallet_ledger')
+      .update({ ref_id: posting.id })
+      .eq('user_id', currentUser.id)
+      .is('ref_id', null)
+      .order('created_at', { ascending: false })
+      .limit(1);
+  }
+
+  return posting;
+}
+```
+
+**Race window 결정 (Open Question 해결)**: 4와 5 사이는 다른 트랜잭션이 끼어들 수 있음. **결정: 단일 RPC `create_job_posting_with_payment_atomically`로 묶기**. 이 RPC가 `consume_diamonds_atomically` 로직 + `INSERT job_postings` + ledger ref_id 즉시 set을 한 트랜잭션 내에서 수행. 구현은 implementation plan 단계에서 wrapper RPC로 추가.
+
+---
+
+## 7. Feature Flag 롤아웃
+
+### 7.1 `app_config` 테이블 활용 (이미 존재)
+
+```sql
+INSERT INTO app_config(key, value) VALUES
+  ('monetization.enabled', '{"enabled": false}'::jsonb),
+  ('monetization.paid_types', '{"regular": false, "urgent": false, "fixed": false}'::jsonb),
+  ('monetization.rollout_percentage', '{"value": 0}'::jsonb);
+```
+
+### 7.2 단계별 전환
+
+| Phase | 기간 | 설정 |
+|---|---|---|
+| Beta | M+0~1 | `enabled=true`, 모두 무료, 다이아 충전만 활성화 |
+| 부분 유료화 (긴급) | M+2 | `paid_types.urgent=true`, `rollout=10%` |
+| 부분 유료화 확대 | M+3 | `urgent=100%, fixed=10%` |
+| 부분 유료화 (고정 포함) | M+4 | `urgent=100%, fixed=100%` |
+| 완전 유료화 | M+6 | `regular=100%` |
+
+### 7.3 Rollout 결정 함수
+
+**결정**: `userId` 기반 deterministic hash로 same user → same bucket 보장 (사용자가 갑자기 무료↔유료 사이 흔들리지 않게).
+
+```typescript
+import { createHash } from 'crypto';
+// 또는 RN 환경: 'react-native-quick-crypto' 또는 expo-crypto
+
+function userBucket(userId: string): number {
+  // userId(UUID)의 SHA-256 첫 4바이트 → uint32 → % 100
+  const hash = createHash('sha256').update(userId).digest();
+  const uint32 = hash.readUInt32BE(0);
+  return uint32 % 100;
+}
+
+function isMonetizationEnabledFor(jobType: string, userId: string): boolean {
+  const config = useAppConfig('monetization');
+  if (!config.enabled) return false;
+  if (!config.paid_types[jobType]) return false;
+  return userBucket(userId) < config.rollout_percentage;
+}
+```
+
+서버 측 동일 hash가 필요하면 SQL 함수로 대응:
+```sql
+CREATE OR REPLACE FUNCTION user_bucket(p_user_id UUID) RETURNS INT
+LANGUAGE SQL IMMUTABLE AS $$
+  SELECT ('x' || substr(encode(digest(p_user_id::text, 'sha256'), 'hex'), 1, 8))::bit(32)::int % 100;
+$$;
+```
+
+---
+
+## 8. 보안 위협 모델 (STRIDE)
+
+| 위협 | 시나리오 | 완화 |
+|---|---|---|
+| **Spoofing** | 가짜 webhook | RC_WEBHOOK_SECRET 검증 + Edge Function의 IP allowlist (옵션) |
+| **Tampering** | 클라이언트가 가격 변조 | 가격은 DB(`diamond_products`)에서만 조회, 클라이언트 입력 무시 |
+| **Repudiation** | "안 받았다" 클레임 | `wallet_ledger` immutable + `revenuecat_transaction_id` 유일 |
+| **Info Disclosure** | 다른 사용자 잔액 조회 | RLS `auth.uid() = user_id` |
+| **DoS** | 충전 무한 호출 | RC가 1차 방어 + Edge Function rate limit (Supabase 플랜) |
+| **Elevation** | 일반 사용자가 credit RPC 호출 | `REVOKE FROM authenticated`, service_role만 |
+| **Double-spend** | 같은 영수증 2회 처리 | `revenuecat_transaction_id UNIQUE` 제약 |
+| **Negative balance** | race condition으로 잔액 < 0 | `SELECT FOR UPDATE` + `CHECK >= 0` 제약 |
+| **Price drift** | RC 대시보드와 DB 가격 불일치 | `diamond_products` seed migration + RC sync 절차 문서화 |
+
+---
+
+## 9. 테스트 전략 (TDD)
+
+### 9.1 RPC 단위 테스트 (PL/pgSQL)
+
+`uniqn-mobile/supabase/tests/wallet_rpcs.spec.sql`:
+
+- `consume_diamonds_atomically` 정상 차감 (하트만, 다이아만, 혼합)
+- 잔액 부족 → INSUFFICIENT_BALANCE
+- 음수 amount → INVALID_AMOUNT
+- 동시 호출 race (FOR UPDATE 검증) — pg_isolation 또는 통합 테스트
+- `credit_diamonds_atomically` 멱등성 (같은 transaction_id 2회)
+- `grant_heart_atomically` daily_attendance 중복 방지
+- `tr_wallet_ledger_update_balance` 캐시 동기화
+
+### 9.2 Service 통합 테스트 (Jest)
+
+- `walletService.purchase` → mock RC SDK + Supabase
+- 차감 실패 시 공고 INSERT 롤백
+- Feature flag off → 차감 skip
+- Feature flag rollout 10% → 동일 user는 항상 같은 결과
+
+### 9.3 Webhook 테스트
+
+- RC 시뮬레이터로 INITIAL_PURCHASE 이벤트 → ledger row 생성 확인
+- 같은 event 2회 → idempotent 응답
+- Authorization header 누락 → 401
+- 잘못된 product_id → 422
+
+### 9.4 E2E (Playwright + sandbox 결제)
+
+- 첫 충전 → 잔액 표시 → 공고 작성 → 차감 → 잔액 갱신
+- Restore purchases → 잔액 회복 (devices 변경 시)
+
+---
+
+## 10. 모니터링 / KPI
+
+### 10.1 대시보드 (Supabase + 자체)
+
+- **MRR**: `SUM(price_krw)` for `purchase` reason in current month
+- **ARPPU**: MRR / 결제자 수
+- **전환율**: `users with purchase` / `users with attempted_purchase`
+- **하트→다이아 전환**: 잔액 부족 paywall 노출 → 충전 완료 funnel
+- **만료 손실**: `expire_heart` 합계 (UX 개선 신호)
+
+### 10.2 알람
+
+- webhook 실패율 > 1% → Slack
+- ledger 음수 잔액 발생 (불가능해야 함) → 즉시 page
+- diamond_products 가격 vs RC 대시보드 drift → 매일 체크 cron
+
+---
+
+## 11. 미해결 결정 (Open Questions)
+
+| 결정 | 옵션 | 권장 |
+|---|---|---|
+| **공고 취소 시 환불 정책** | (a) 전액 환불 (b) 부분 환불 (c) 환불 없음 | (b) 24시간 이내 100%, 이후 50% |
+| **wallets.diamond_balance 음수 허용** | (a) 절대 금지 (b) admin 보정 가능 | (a) — `CHECK >= 0` 강제. 환불이 잔액보다 크면 가능한 만큼만 차감 (§4.2 step 3). 단, ledger row delta는 음수 허용 (감사 추적용) |
+| **하트 만료 알림** | (a) 만료 7일 전 push (b) 앱 내 배너만 (c) 둘 다 | (c) — push 1회 + 영구 배너 |
+| **VIP 등급 시스템** | (a) 이번에 포함 (b) Phase 2 | (b) — 데이터 모이고 결정 |
+| **환불 시 ledger 처리** | (a) 새 row (b) 기존 row update | (a) — immutable 원칙 |
+| **Feature Flag 키** | (a) JSONB single config (b) 개별 row | (a) — 이미 `app_config` 있음 |
+| **첫 충전 보너스** | (a) +5💎 (레거시 v4.0) (b) 없음 | (a) — 전환율 부스터 |
+| **다이아 환불 시 ledger 음수** | (a) 음수 row 허용 (b) 부채 차감 후 0 floor | (a) — 감사 명확성 우선 (사용 가능 잔액은 GREATEST(0, balance) 표시) |
+| **RC webhook 재시도 정책** | (a) 5회 + 지수백오프 (RC 기본) (b) 자체 재처리 큐 | (a) — UNIQUE 제약으로 멱등성 보장되므로 RC 기본 신뢰 |
+| **Apple/Google 직접 환불 vs RC** | RC만 신뢰 vs 양쪽 webhook | RC만 — 단일 소스 |
+
+→ 사용자 검토 단계에서 결정.
+
+---
+
+## 12. 마이그레이션 순서
+
+1. `20260427000000_create_wallet_tables.sql` — 4개 테이블 + ENUM + 인덱스
+2. `20260427000100_create_wallet_rls.sql` — RLS 정책
+3. `20260427000200_create_wallet_rpcs.sql` — 4개 RPC
+4. `20260427000300_create_wallet_triggers.sql` — 캐시 sync trigger
+5. `20260427000400_seed_diamond_products.sql` — 6개 패키지 시드
+6. `20260427000500_create_app_config_monetization.sql` — Feature flag 시드
+7. `20260427000600_create_heart_expiry_cron.sql` — pg_cron 매일 만료 처리
+
+---
+
+## 13. 외부 작업 (코드 외)
+
+1. **RevenueCat 계정 생성** + 앱 등록 (iOS/Android)
+2. **App Store Connect** consumable IAP 6개 등록 (`uniqn_diamonds_*`)
+3. **Google Play Console** managed product 6개 등록
+4. **RevenueCat Offering** 생성 + 6개 product 연결
+5. **RC Webhook URL** 등록 → `https://<project>.supabase.co/functions/v1/revenuecat-webhook`
+6. **법무 검토**: 환불 정책 약관 추가 (`src/constants/legal/terms-employer.ts` 업데이트)
+7. **앱스토어 약관 업데이트**: 환불 정책 + 인앱결제 가이드라인
+
+---
+
+## 14. 다음 단계 (이 spec 승인 후)
+
+1. **Spec self-review** — placeholder, contradiction, ambiguity 체크
+2. **사용자 검토** — 11장 Open Questions 결정
+3. **`writing-plans` 스킬 호출** — 13장의 14개 마이그레이션 단계를 implementation plan으로 변환
+4. **Plan 승인 후 구현** — TDD로 RPC부터 → service → UI 순서
+
+---
+
+## 부록 A — 비즈니스 가정
+
+- 사업계획서(`BUSINESS_PLAN_2025.md` v1.2) 가격/수량 그대로 채택
+- BEP: 470건/월, M9 도달 가정
+- 앱스토어 수수료 15% (소규모 사업자 프로그램)
+- 무료 기간 6개월 후 부분 유료화 시작
+
+## 부록 B — 패턴 차용
+
+| 본 spec 요소 | 차용 출처 |
+|---|---|
+| ledger trigger → cache | `20260421040000_add_job_posting_stats_trigger.sql` |
+| 원자성 RPC + FOR UPDATE | `20260414120100_add_cancel_application_atomically.sql` |
+| Edge Function 보안 + idempotency | `supabase/functions/send-push-notification/index.ts` |
+| Feature Flag 구조 | `app_config` table (이미 존재) |
+| RLS app_metadata.role | `.claude/rules/supabase-patterns.md` |
+
+## 부록 C — 참고 라이브러리 / 문서
+
+- `react-native-purchases` (RevenueCat SDK) — context7 ID: `/revenuecat/react-native-purchases`
+- RevenueCat Webhooks: <https://www.revenuecat.com/docs/integrations/webhooks>
+- App Store IAP types: Consumable
+- Google Play managed products
+
+---
+
+*Spec 종료. 사용자 검토 대기.*

--- a/uniqn-mobile/src/repositories/supabase/WalletRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/WalletRepository.ts
@@ -1,0 +1,63 @@
+/**
+ * UNIQN Mobile - Wallet Repository (read-only)
+ *
+ * @description 결제 시스템 wallet 잔액/제품 조회 전용
+ *   - 차감/적립/환불은 RPC 직접 호출 (Service 계층에서)
+ *   - get_wallet_summary RPC + diamond_products 테이블 조회만 제공
+ * @version 1.0.0
+ * @see docs/superpowers/specs/2026-04-26-monetization-design.md §3, §6.1
+ */
+
+import { supabase } from '@/lib/supabase';
+import { logger } from '@/utils/logger';
+import {
+  DiamondProductSchema,
+  WalletSummarySchema,
+  type DiamondProduct,
+  type WalletSummary,
+} from '@/types/wallet';
+
+const TABLES = {
+  DIAMOND_PRODUCTS: 'diamond_products',
+} as const;
+
+const DIAMOND_PRODUCT_COLUMNS =
+  'product_id, diamonds, bonus_diamonds, price_krw, display_order, active' as const;
+
+export const WalletRepository = {
+  /**
+   * 현재 사용자(또는 지정 사용자)의 지갑 요약 조회.
+   *
+   * @param userId 미지정 시 RPC가 auth.uid() 사용. admin/service_role만 타인 조회 가능.
+   * @returns heart/diamond 잔액 + lifetime 누적 + 만료 임박(7일) lot 목록.
+   * @throws Supabase RPC 에러 그대로 throw — 호출자가 처리.
+   */
+  async getSummary(userId?: string): Promise<WalletSummary> {
+    const { data, error } = await supabase.rpc('get_wallet_summary', {
+      p_user_id: userId ?? null,
+    });
+    if (error) {
+      logger.error('wallet.getSummary.failed', error, { userId });
+      throw error;
+    }
+    return WalletSummarySchema.parse(data);
+  },
+
+  /**
+   * 활성 다이아 충전 상품 목록 (display_order 오름차순).
+   *
+   * @returns active=true 상품만, 시드 6종 기준.
+   */
+  async listProducts(): Promise<DiamondProduct[]> {
+    const { data, error } = await supabase
+      .from(TABLES.DIAMOND_PRODUCTS)
+      .select(DIAMOND_PRODUCT_COLUMNS)
+      .eq('active', true)
+      .order('display_order', { ascending: true });
+    if (error) {
+      logger.error('wallet.listProducts.failed', error);
+      throw error;
+    }
+    return (data ?? []).map((row) => DiamondProductSchema.parse(row));
+  },
+};

--- a/uniqn-mobile/src/types/supabase.ts
+++ b/uniqn-mobile/src/types/supabase.ts
@@ -646,6 +646,39 @@ export type Database = {
           },
         ];
       };
+      diamond_products: {
+        Row: {
+          active: boolean;
+          bonus_diamonds: number;
+          created_at: string;
+          diamonds: number;
+          display_order: number;
+          price_krw: number;
+          product_id: string;
+          updated_at: string;
+        };
+        Insert: {
+          active?: boolean;
+          bonus_diamonds?: number;
+          created_at?: string;
+          diamonds: number;
+          display_order?: number;
+          price_krw: number;
+          product_id: string;
+          updated_at?: string;
+        };
+        Update: {
+          active?: boolean;
+          bonus_diamonds?: number;
+          created_at?: string;
+          diamonds?: number;
+          display_order?: number;
+          price_krw?: number;
+          product_id?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       employer_applications: {
         Row: {
           agreements_snapshot: Json;
@@ -795,6 +828,47 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: 'fcm_tokens_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      heart_lots: {
+        Row: {
+          amount_initial: number;
+          amount_remaining: number;
+          expires_at: string;
+          granted_at: string;
+          id: string;
+          source: Database['public']['Enums']['wallet_reason'];
+          source_ref_id: string | null;
+          user_id: string;
+        };
+        Insert: {
+          amount_initial: number;
+          amount_remaining: number;
+          expires_at: string;
+          granted_at?: string;
+          id?: string;
+          source: Database['public']['Enums']['wallet_reason'];
+          source_ref_id?: string | null;
+          user_id: string;
+        };
+        Update: {
+          amount_initial?: number;
+          amount_remaining?: number;
+          expires_at?: string;
+          granted_at?: string;
+          id?: string;
+          source?: Database['public']['Enums']['wallet_reason'];
+          source_ref_id?: string | null;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'heart_lots_user_id_fkey';
             columns: ['user_id'];
             isOneToOne: false;
             referencedRelation: 'users';
@@ -1525,6 +1599,91 @@ export type Database = {
         };
         Relationships: [];
       };
+      wallet_ledger: {
+        Row: {
+          balance_after_diamond: number;
+          balance_after_heart: number;
+          created_at: string;
+          currency_type: Database['public']['Enums']['wallet_currency'];
+          delta: number;
+          id: string;
+          metadata: Json;
+          reason: Database['public']['Enums']['wallet_reason'];
+          ref_id: string | null;
+          ref_type: string | null;
+          revenuecat_transaction_id: string | null;
+          user_id: string;
+        };
+        Insert: {
+          balance_after_diamond: number;
+          balance_after_heart: number;
+          created_at?: string;
+          currency_type: Database['public']['Enums']['wallet_currency'];
+          delta: number;
+          id?: string;
+          metadata?: Json;
+          reason: Database['public']['Enums']['wallet_reason'];
+          ref_id?: string | null;
+          ref_type?: string | null;
+          revenuecat_transaction_id?: string | null;
+          user_id: string;
+        };
+        Update: {
+          balance_after_diamond?: number;
+          balance_after_heart?: number;
+          created_at?: string;
+          currency_type?: Database['public']['Enums']['wallet_currency'];
+          delta?: number;
+          id?: string;
+          metadata?: Json;
+          reason?: Database['public']['Enums']['wallet_reason'];
+          ref_id?: string | null;
+          ref_type?: string | null;
+          revenuecat_transaction_id?: string | null;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'wallet_ledger_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      wallets: {
+        Row: {
+          diamond_balance: number;
+          heart_balance: number;
+          lifetime_purchased_diamonds: number;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          diamond_balance?: number;
+          heart_balance?: number;
+          lifetime_purchased_diamonds?: number;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          diamond_balance?: number;
+          heart_balance?: number;
+          lifetime_purchased_diamonds?: number;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'wallets_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       work_logs: {
         Row: {
           application_id: string | null;
@@ -1747,6 +1906,7 @@ export type Database = {
         };
         Returns: Json;
       };
+      claim_daily_attendance: { Args: never; Returns: Json };
       confirm_application: {
         Args: {
           p_application_id: string;
@@ -1757,6 +1917,25 @@ export type Database = {
           p_notes?: string;
           p_original_application?: Json;
           p_owner_id: string;
+        };
+        Returns: Json;
+      };
+      consume_diamonds_atomically: {
+        Args: {
+          p_amount: number;
+          p_reason: Database['public']['Enums']['wallet_reason'];
+          p_ref_id: string;
+          p_ref_type: string;
+          p_user_id: string;
+        };
+        Returns: Json;
+      };
+      create_job_posting_with_payment_atomically: {
+        Args: {
+          p_cost_diamonds: number;
+          p_owner_id: string;
+          p_posting_payload: Json;
+          p_reason: Database['public']['Enums']['wallet_reason'];
         };
         Returns: Json;
       };
@@ -1778,6 +1957,15 @@ export type Database = {
         };
         Returns: Json;
       };
+      credit_diamonds_atomically: {
+        Args: {
+          p_diamonds: number;
+          p_product_id: string;
+          p_revenuecat_transaction_id: string;
+          p_user_id: string;
+        };
+        Returns: Json;
+      };
       decrement_unread_counter:
         | { Args: { p_notification_id: string }; Returns: undefined }
         | { Args: { p_delta?: number; p_user_id: string }; Returns: undefined };
@@ -1785,6 +1973,7 @@ export type Database = {
       fn_cleanup_rate_limits: { Args: never; Returns: number };
       fn_expire_by_last_work_date: { Args: never; Returns: number };
       fn_expire_fixed_postings_batch: { Args: never; Returns: number };
+      fn_expire_heart_lots: { Args: never; Returns: Json };
       fn_send_review_reminders: { Args: never; Returns: number };
       get_job_posting_stats: {
         Args: { p_owner_id: string };
@@ -1813,6 +2002,17 @@ export type Database = {
         Args: { p_user_id: string };
         Returns: number;
       };
+      get_wallet_summary: { Args: { p_user_id?: string }; Returns: Json };
+      grant_heart_atomically: {
+        Args: {
+          p_amount: number;
+          p_expires_in_days?: number;
+          p_reason: Database['public']['Enums']['wallet_reason'];
+          p_source_ref_id?: string;
+          p_user_id: string;
+        };
+        Returns: Json;
+      };
       increment_announcement_view_count: {
         Args: { p_announcement_id: string };
         Returns: undefined;
@@ -1838,6 +2038,10 @@ export type Database = {
           p_staff_id: string;
           p_work_log_id: string;
         };
+        Returns: Json;
+      };
+      refund_job_cancellation_atomically: {
+        Args: { p_owner_id: string; p_posting_id: string };
         Returns: Json;
       };
       register_as_employer: {
@@ -1912,6 +2116,22 @@ export type Database = {
       review_sentiment: 'positive' | 'neutral' | 'negative';
       staff_role: 'dealer' | 'floor' | 'serving' | 'manager' | 'staff' | 'other';
       user_role: 'admin' | 'employer' | 'staff';
+      wallet_currency: 'heart' | 'diamond';
+      wallet_reason:
+        | 'purchase'
+        | 'consume_job_posting'
+        | 'consume_job_extend'
+        | 'consume_job_upgrade'
+        | 'refund_purchase'
+        | 'refund_job_cancelled'
+        | 'grant_signup'
+        | 'grant_daily_attendance'
+        | 'grant_streak_7d'
+        | 'grant_review'
+        | 'grant_referral'
+        | 'grant_admin'
+        | 'grant_first_purchase_bonus'
+        | 'expire_heart';
       work_log_status:
         | 'scheduled'
         | 'checked_in'
@@ -2081,6 +2301,23 @@ export const Constants = {
       review_sentiment: ['positive', 'neutral', 'negative'],
       staff_role: ['dealer', 'floor', 'serving', 'manager', 'staff', 'other'],
       user_role: ['admin', 'employer', 'staff'],
+      wallet_currency: ['heart', 'diamond'],
+      wallet_reason: [
+        'purchase',
+        'consume_job_posting',
+        'consume_job_extend',
+        'consume_job_upgrade',
+        'refund_purchase',
+        'refund_job_cancelled',
+        'grant_signup',
+        'grant_daily_attendance',
+        'grant_streak_7d',
+        'grant_review',
+        'grant_referral',
+        'grant_admin',
+        'grant_first_purchase_bonus',
+        'expire_heart',
+      ],
       work_log_status: [
         'scheduled',
         'checked_in',

--- a/uniqn-mobile/src/types/wallet.ts
+++ b/uniqn-mobile/src/types/wallet.ts
@@ -1,0 +1,62 @@
+/**
+ * UNIQN Mobile - Wallet 도메인 타입
+ *
+ * @description 결제 시스템 wallet/diamond_products 타입 + Zod 스키마
+ *   - 마이그 20260427000000~001000 매핑
+ *   - Phase 1 Task 12 read-only Repository용
+ * @see docs/superpowers/specs/2026-04-26-monetization-design.md §3
+ */
+
+import { z } from 'zod';
+
+export type WalletCurrency = 'heart' | 'diamond';
+
+export type WalletReason =
+  | 'purchase'
+  | 'consume_job_posting'
+  | 'consume_job_extend'
+  | 'consume_job_upgrade'
+  | 'refund_purchase'
+  | 'refund_job_cancelled'
+  | 'grant_signup'
+  | 'grant_daily_attendance'
+  | 'grant_streak_7d'
+  | 'grant_review'
+  | 'grant_referral'
+  | 'grant_admin'
+  | 'grant_first_purchase_bonus'
+  | 'expire_heart';
+
+// ============================================================================
+// get_wallet_summary RPC 응답
+// ============================================================================
+
+export const ExpiringLotSchema = z.object({
+  lot_id: z.string().uuid(),
+  amount_remaining: z.number().int().min(0),
+  expires_at: z.string(),
+  source: z.string(),
+});
+export type ExpiringLot = z.infer<typeof ExpiringLotSchema>;
+
+export const WalletSummarySchema = z.object({
+  heart_balance: z.number().int().min(0),
+  diamond_balance: z.number().int().min(0),
+  lifetime_purchased_diamonds: z.number().int().min(0),
+  expiring_lots: z.array(ExpiringLotSchema),
+});
+export type WalletSummary = z.infer<typeof WalletSummarySchema>;
+
+// ============================================================================
+// diamond_products 행
+// ============================================================================
+
+export const DiamondProductSchema = z.object({
+  product_id: z.string(),
+  diamonds: z.number().int().positive(),
+  bonus_diamonds: z.number().int().min(0),
+  price_krw: z.number().int().positive(),
+  display_order: z.number().int(),
+  active: z.boolean(),
+});
+export type DiamondProduct = z.infer<typeof DiamondProductSchema>;

--- a/uniqn-mobile/supabase/functions/revenuecat-webhook/index.ts
+++ b/uniqn-mobile/supabase/functions/revenuecat-webhook/index.ts
@@ -1,0 +1,222 @@
+// =============================================================================
+// revenuecat-webhook Edge Function
+// =============================================================================
+// 목적: RevenueCat이 결제/환불 이벤트를 우리에게 통보. 본 함수가 받아서
+//   credit_diamonds_atomically RPC를 호출해 wallet_ledger를 갱신한다.
+//
+// 호출 방식:
+//   POST https://<project>.supabase.co/functions/v1/revenuecat-webhook
+//   Headers:
+//     Authorization: Bearer <REVENUECAT_WEBHOOK_SECRET>
+//     Content-Type: application/json
+//   Body: RevenueCat webhook payload (api_version + event)
+//
+// 인증: REVENUECAT_WEBHOOK_SECRET 일치만 허용 (RC 대시보드에서 설정)
+//
+// 멱등성: event.id를 wallet_ledger.revenuecat_transaction_id에 저장 (UNIQUE).
+//   RC가 재시도해도 RPC가 idempotent 응답.
+//
+// 환불: REFUND/BILLING_ISSUE/CANCELLATION 이벤트는 음수 diamonds로 RPC 호출.
+//   별도 event.id이므로 새로운 ledger row (refund_purchase reason)가 생성됨.
+//
+// Spec §5, Plan Phase 2
+// =============================================================================
+
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+
+const responseHeaders = {
+  'Content-Type': 'application/json',
+};
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+// 잔액 증가 이벤트
+const CREDIT_TYPES = new Set<string>(['INITIAL_PURCHASE', 'NON_RENEWING_PURCHASE']);
+
+// 잔액 감소 이벤트 (환불 / 결제 실패 / 사용자 취소)
+const REFUND_TYPES = new Set<string>(['REFUND', 'BILLING_ISSUE', 'CANCELLATION']);
+
+// 무시할 이벤트 (구독 미사용 / 단순 정보)
+const IGNORE_TYPES = new Set<string>([
+  'RENEWAL',
+  'EXPIRATION',
+  'PRODUCT_CHANGE',
+  'TRANSFER',
+  'SUBSCRIBER_ALIAS',
+  'NON_SUBSCRIPTION_PURCHASE', // 일부 RC 버전 별칭
+  'TEST',
+]);
+
+interface RevenueCatEvent {
+  type: string;
+  id: string;
+  app_user_id: string;
+  product_id: string;
+  transaction_id?: string;
+  original_transaction_id?: string;
+  environment?: 'PRODUCTION' | 'SANDBOX';
+  store?: 'APP_STORE' | 'PLAY_STORE' | 'AMAZON' | 'STRIPE';
+  cancel_reason?: string | null;
+  expiration_at_ms?: number | null;
+  purchased_at_ms?: number | null;
+}
+
+interface RevenueCatPayload {
+  api_version?: string;
+  event: RevenueCatEvent;
+}
+
+function badRequest(message: string, extra?: Record<string, unknown>): Response {
+  return new Response(JSON.stringify({ error: message, ...(extra ?? {}) }), {
+    status: 400,
+    headers: responseHeaders,
+  });
+}
+
+function unauthorized(): Response {
+  return new Response(JSON.stringify({ error: 'unauthorized' }), {
+    status: 401,
+    headers: responseHeaders,
+  });
+}
+
+function ok(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: responseHeaders });
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'method_not_allowed' }), {
+      status: 405,
+      headers: responseHeaders,
+    });
+  }
+
+  // 1) 인증: Authorization Bearer <REVENUECAT_WEBHOOK_SECRET>
+  const expectedSecret = Deno.env.get('REVENUECAT_WEBHOOK_SECRET');
+  if (!expectedSecret) {
+    console.error('REVENUECAT_WEBHOOK_SECRET env not configured');
+    return new Response(JSON.stringify({ error: 'server_misconfigured' }), {
+      status: 500,
+      headers: responseHeaders,
+    });
+  }
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader || authHeader !== `Bearer ${expectedSecret}`) {
+    return unauthorized();
+  }
+
+  // 2) 페이로드 파싱
+  let payload: RevenueCatPayload;
+  try {
+    payload = (await req.json()) as RevenueCatPayload;
+  } catch {
+    return badRequest('invalid_json');
+  }
+
+  if (!payload || typeof payload !== 'object' || !payload.event) {
+    return badRequest('missing_event');
+  }
+
+  const event = payload.event;
+  const eventType = event.type;
+
+  // 3) 무시 이벤트는 200으로 OK 응답 (RC가 retry 안 하도록)
+  if (IGNORE_TYPES.has(eventType)) {
+    return ok({ ignored: true, type: eventType });
+  }
+
+  // 4) 알려지지 않은 이벤트도 200 (RC retry 폭주 방지) + 로그
+  if (!CREDIT_TYPES.has(eventType) && !REFUND_TYPES.has(eventType)) {
+    console.warn(`unknown_event_type: ${eventType}`);
+    return ok({ ignored: true, type: eventType, reason: 'unknown_type' });
+  }
+
+  // 5) 필수 필드 검증
+  if (!event.id || typeof event.id !== 'string') {
+    return badRequest('missing_event_id');
+  }
+  if (!event.app_user_id || !UUID_REGEX.test(event.app_user_id)) {
+    return badRequest('invalid_app_user_id', { app_user_id: event.app_user_id });
+  }
+  if (!event.product_id || typeof event.product_id !== 'string') {
+    return badRequest('missing_product_id');
+  }
+
+  // 6) Supabase 클라이언트 (service_role)
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.error('SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not configured');
+    return new Response(JSON.stringify({ error: 'server_misconfigured' }), {
+      status: 500,
+      headers: responseHeaders,
+    });
+  }
+  const client = createClient(supabaseUrl, serviceRoleKey);
+
+  // 7) product_id → diamonds + bonus_diamonds 조회 (DB 신뢰)
+  const { data: product, error: productError } = await client
+    .from('diamond_products')
+    .select('diamonds, bonus_diamonds, active')
+    .eq('product_id', event.product_id)
+    .maybeSingle();
+
+  if (productError) {
+    console.error('product_query_failed', productError);
+    return new Response(JSON.stringify({ error: 'product_query_failed' }), {
+      status: 500,
+      headers: responseHeaders,
+    });
+  }
+  if (!product) {
+    console.error(`product_not_found: ${event.product_id}`);
+    return badRequest('product_not_found', { product_id: event.product_id });
+  }
+  if (product.active === false) {
+    return badRequest('product_inactive', { product_id: event.product_id });
+  }
+
+  const totalDiamonds = (product.diamonds ?? 0) + (product.bonus_diamonds ?? 0);
+  if (totalDiamonds <= 0) {
+    return badRequest('invalid_product_amount', { product_id: event.product_id });
+  }
+
+  const isRefund = REFUND_TYPES.has(eventType);
+  const diamondsToCredit = isRefund ? -totalDiamonds : totalDiamonds;
+
+  // 8) credit_diamonds_atomically 호출 (음수=환불, 양수=구매)
+  //    revenuecat_transaction_id = event.id (멱등성 키)
+  const { data: rpcData, error: rpcError } = await client.rpc('credit_diamonds_atomically', {
+    p_user_id: event.app_user_id,
+    p_diamonds: diamondsToCredit,
+    p_revenuecat_transaction_id: event.id,
+    p_product_id: event.product_id,
+  });
+
+  if (rpcError) {
+    console.error('credit_rpc_failed', {
+      message: rpcError.message,
+      code: rpcError.code,
+      event_id: event.id,
+      event_type: eventType,
+    });
+    // 5xx로 응답하면 RC가 재시도하므로, 멱등성 위반 등 영구 에러는 200으로 swallow
+    // 단, 실제 RPC 에러는 retry가 필요할 수 있으니 500
+    return new Response(JSON.stringify({ error: 'rpc_failed', detail: rpcError.message }), {
+      status: 500,
+      headers: responseHeaders,
+    });
+  }
+
+  return ok({
+    success: true,
+    event_type: eventType,
+    event_id: event.id,
+    app_user_id: event.app_user_id,
+    product_id: event.product_id,
+    diamonds_credited: diamondsToCredit,
+    rpc: rpcData ?? null,
+  });
+});

--- a/uniqn-mobile/supabase/migrations/20260427000000_create_wallet_enums_and_tables.sql
+++ b/uniqn-mobile/supabase/migrations/20260427000000_create_wallet_enums_and_tables.sql
@@ -1,5 +1,8 @@
--- Wallet 시스템 기반: ENUM 2개 + 테이블 4개
--- Spec: docs/superpowers/specs/2026-04-26-monetization-design.md §3
+-- 목적: UNIQN 결제 시스템 wallet 기반 (Phase 1 Task 1)
+-- 배경: 그린필드 — 결제/포인트 코드 0%, 신규 ledger 모델 도입
+-- 스펙: docs/superpowers/specs/2026-04-26-monetization-design.md §3
+-- 패턴 차용: job_postings.stats trigger / cancel_application_atomically
+-- 후속: 20260427000001 (CHECK 보강), 20260427000100 (RLS), 20260427000200 (cache trigger)
 
 CREATE TYPE wallet_currency AS ENUM ('heart', 'diamond');
 

--- a/uniqn-mobile/supabase/migrations/20260427000000_create_wallet_enums_and_tables.sql
+++ b/uniqn-mobile/supabase/migrations/20260427000000_create_wallet_enums_and_tables.sql
@@ -1,0 +1,83 @@
+-- Wallet 시스템 기반: ENUM 2개 + 테이블 4개
+-- Spec: docs/superpowers/specs/2026-04-26-monetization-design.md §3
+
+CREATE TYPE wallet_currency AS ENUM ('heart', 'diamond');
+
+CREATE TYPE wallet_reason AS ENUM (
+  'purchase',
+  'consume_job_posting',
+  'consume_job_extend',
+  'consume_job_upgrade',
+  'refund_purchase',
+  'refund_job_cancelled',
+  'grant_signup',
+  'grant_daily_attendance',
+  'grant_streak_7d',
+  'grant_review',
+  'grant_referral',
+  'grant_admin',
+  'grant_first_purchase_bonus',
+  'expire_heart'
+);
+
+CREATE TABLE public.diamond_products (
+  product_id      TEXT PRIMARY KEY,
+  diamonds        INT  NOT NULL CHECK (diamonds > 0),
+  bonus_diamonds  INT  NOT NULL DEFAULT 0,
+  price_krw       INT  NOT NULL,
+  display_order   INT  NOT NULL DEFAULT 0,
+  active          BOOLEAN NOT NULL DEFAULT true,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE public.wallets (
+  user_id          UUID PRIMARY KEY REFERENCES public.users(id) ON DELETE CASCADE,
+  heart_balance    INT NOT NULL DEFAULT 0 CHECK (heart_balance >= 0),
+  diamond_balance  INT NOT NULL DEFAULT 0 CHECK (diamond_balance >= 0),
+  lifetime_purchased_diamonds INT NOT NULL DEFAULT 0,
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE public.wallet_ledger (
+  id                        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                   UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  currency_type             wallet_currency NOT NULL,
+  delta                     INT NOT NULL,
+  reason                    wallet_reason NOT NULL,
+  ref_id                    UUID,
+  ref_type                  TEXT,
+  balance_after_heart       INT NOT NULL,
+  balance_after_diamond     INT NOT NULL,
+  revenuecat_transaction_id TEXT UNIQUE,
+  metadata                  JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at                TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_wallet_ledger_user_created
+  ON public.wallet_ledger(user_id, created_at DESC);
+
+CREATE INDEX idx_wallet_ledger_ref
+  ON public.wallet_ledger(ref_type, ref_id)
+  WHERE ref_id IS NOT NULL;
+
+CREATE TABLE public.heart_lots (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id          UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  amount_initial   INT NOT NULL CHECK (amount_initial > 0),
+  amount_remaining INT NOT NULL CHECK (amount_remaining >= 0),
+  granted_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at       TIMESTAMPTZ NOT NULL,
+  source           wallet_reason NOT NULL,
+  source_ref_id   UUID,
+  CONSTRAINT chk_amount_remaining_lte_initial
+    CHECK (amount_remaining <= amount_initial)
+);
+
+CREATE INDEX idx_heart_lots_user_expiring
+  ON public.heart_lots(user_id, expires_at)
+  WHERE amount_remaining > 0;
+
+COMMENT ON TABLE public.wallets IS 'Cached balance per user. Updated by tr_wallet_ledger_update_balance trigger from wallet_ledger inserts. Source of truth is wallet_ledger.';
+COMMENT ON TABLE public.wallet_ledger IS 'Append-only ledger. Never UPDATE/DELETE. Refunds are new negative-delta rows. revenuecat_transaction_id UNIQUE provides webhook idempotency.';
+COMMENT ON TABLE public.heart_lots IS 'FIFO consumption units for free hearts (90-day expiry). Soonest-expiring lot consumed first.';

--- a/uniqn-mobile/supabase/migrations/20260427000001_add_wallet_check_constraints.sql
+++ b/uniqn-mobile/supabase/migrations/20260427000001_add_wallet_check_constraints.sql
@@ -1,0 +1,16 @@
+-- 후속 보강: 코드 리뷰 피드백 반영 CHECK 제약 추가
+-- 목적: 음수/0 가격 product 방지 + heart_lots 거꾸로 된 만료일 방지
+-- 배경: 20260427000000 마이그레이션의 누락 invariant 후속 보완
+-- 스펙 참조: docs/superpowers/specs/2026-04-26-monetization-design.md §3.1, §3.4
+
+ALTER TABLE public.diamond_products
+  ADD CONSTRAINT chk_price_krw_positive CHECK (price_krw > 0);
+
+ALTER TABLE public.heart_lots
+  ADD CONSTRAINT chk_expires_after_granted CHECK (expires_at > granted_at);
+
+COMMENT ON CONSTRAINT chk_price_krw_positive ON public.diamond_products IS
+  '유료 product는 양수 가격 필수 (무료 free tier는 별도 시스템).';
+
+COMMENT ON CONSTRAINT chk_expires_after_granted ON public.heart_lots IS
+  '만료일은 적립 시점 이후여야 함. 백데이트 lot 방지.';

--- a/uniqn-mobile/supabase/migrations/20260427000100_create_wallet_rls.sql
+++ b/uniqn-mobile/supabase/migrations/20260427000100_create_wallet_rls.sql
@@ -1,0 +1,43 @@
+-- 목적: wallet 4 테이블 RLS — 본인 SELECT + admin 전체
+-- 배경: SECURITY DEFINER RPC만 쓰기 허용 (직접 INSERT/UPDATE 차단)
+-- 스펙: docs/superpowers/specs/2026-04-26-monetization-design.md §3.5
+-- 패턴: (SELECT auth.uid()) 래핑 + app_metadata.role 체크
+
+ALTER TABLE public.wallets          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.wallet_ledger    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.heart_lots       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.diamond_products ENABLE ROW LEVEL SECURITY;
+
+-- 본인 잔액 조회
+CREATE POLICY wallet_self_select ON public.wallets
+  FOR SELECT TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+-- admin 모든 잔액 접근
+CREATE POLICY wallet_admin_all ON public.wallets
+  FOR ALL TO authenticated
+  USING ((auth.jwt() -> 'app_metadata' ->> 'role') = 'admin')
+  WITH CHECK ((auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');
+
+-- 본인 ledger 조회
+CREATE POLICY ledger_self_select ON public.wallet_ledger
+  FOR SELECT TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+-- admin 전체 ledger
+CREATE POLICY ledger_admin_select ON public.wallet_ledger
+  FOR SELECT TO authenticated
+  USING ((auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');
+
+-- 본인 heart_lots 조회
+CREATE POLICY heart_lots_self_select ON public.heart_lots
+  FOR SELECT TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+-- 다이아 상품 카탈로그 공개 읽기
+CREATE POLICY products_public_read ON public.diamond_products
+  FOR SELECT TO authenticated
+  USING (active = true);
+
+COMMENT ON POLICY wallet_self_select ON public.wallets IS
+  'Phase 1 RLS — write는 SECURITY DEFINER RPC만 허용 (직접 INSERT/UPDATE 정책 없음)';

--- a/uniqn-mobile/supabase/migrations/20260427000200_create_wallet_balance_trigger.sql
+++ b/uniqn-mobile/supabase/migrations/20260427000200_create_wallet_balance_trigger.sql
@@ -1,0 +1,37 @@
+-- 목적: wallet_ledger INSERT 시 wallets 캐시 자동 갱신
+-- 배경: ledger는 source of truth, wallets는 매 화면 표시용 캐시
+-- 패턴: job_postings.stats trigger (20260421040000) 차용
+-- 스펙: docs/superpowers/specs/2026-04-26-monetization-design.md §4.4
+
+CREATE OR REPLACE FUNCTION public.fn_wallet_ledger_update_balance()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+BEGIN
+  -- balance_after_*는 RPC가 이미 계산해서 ledger row에 기록한 값
+  -- trigger는 그것을 wallets 캐시로 복사만 한다 (재계산 X)
+  IF NEW.currency_type = 'heart' THEN
+    UPDATE public.wallets SET
+      heart_balance = GREATEST(0, NEW.balance_after_heart),
+      updated_at = now()
+    WHERE user_id = NEW.user_id;
+  ELSIF NEW.currency_type = 'diamond' THEN
+    UPDATE public.wallets SET
+      diamond_balance = GREATEST(0, NEW.balance_after_diamond),
+      updated_at = now()
+    WHERE user_id = NEW.user_id;
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS tr_wallet_ledger_update_balance ON public.wallet_ledger;
+CREATE TRIGGER tr_wallet_ledger_update_balance
+AFTER INSERT ON public.wallet_ledger
+FOR EACH ROW
+EXECUTE FUNCTION public.fn_wallet_ledger_update_balance();
+
+COMMENT ON FUNCTION public.fn_wallet_ledger_update_balance() IS
+  'wallet_ledger INSERT → wallets 캐시 동기화. balance_after_*는 RPC가 미리 계산해서 ledger에 기록한 값을 그대로 복사. GREATEST(0, ...)는 환불 over-cancel 시 음수 ledger row가 들어와도 캐시는 0 floor 유지 (Decision #2).';

--- a/uniqn-mobile/supabase/migrations/20260427000300_create_consume_diamonds_rpc.sql
+++ b/uniqn-mobile/supabase/migrations/20260427000300_create_consume_diamonds_rpc.sql
@@ -1,0 +1,126 @@
+-- 목적: 하트 FIFO 우선 소비 + 부족분 다이아 차감 RPC
+-- 패턴: cancel_application_atomically (FOR UPDATE 잠금)
+-- 스펙: docs/superpowers/specs/2026-04-26-monetization-design.md §4.1
+
+CREATE OR REPLACE FUNCTION public.consume_diamonds_atomically(
+  p_user_id  UUID,
+  p_amount   INT,
+  p_reason   wallet_reason,
+  p_ref_id   UUID,
+  p_ref_type TEXT
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_wallet           wallets%ROWTYPE;
+  v_heart_consumed   INT := 0;
+  v_diamond_consumed INT := 0;
+  v_remaining        INT := p_amount;
+  v_lot              RECORD;
+  v_take             INT;
+  v_now              TIMESTAMPTZ := now();
+BEGIN
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'INVALID_AMOUNT: % must be positive', p_amount;
+  END IF;
+
+  INSERT INTO wallets(user_id) VALUES (p_user_id)
+    ON CONFLICT (user_id) DO NOTHING;
+  SELECT * INTO v_wallet FROM wallets WHERE user_id = p_user_id FOR UPDATE;
+
+  IF v_wallet.heart_balance + v_wallet.diamond_balance < p_amount THEN
+    RAISE EXCEPTION 'INSUFFICIENT_BALANCE: have %h+%d, need %',
+      v_wallet.heart_balance, v_wallet.diamond_balance, p_amount;
+  END IF;
+
+  FOR v_lot IN
+    SELECT * FROM heart_lots
+    WHERE user_id = p_user_id
+      AND amount_remaining > 0
+      AND expires_at > v_now
+    ORDER BY expires_at ASC, granted_at ASC
+    FOR UPDATE
+  LOOP
+    EXIT WHEN v_remaining = 0;
+    v_take := LEAST(v_lot.amount_remaining, v_remaining);
+    UPDATE heart_lots SET amount_remaining = amount_remaining - v_take
+      WHERE id = v_lot.id;
+    v_heart_consumed := v_heart_consumed + v_take;
+    v_remaining := v_remaining - v_take;
+  END LOOP;
+
+  IF v_remaining > 0 THEN
+    v_diamond_consumed := v_remaining;
+  END IF;
+
+  IF v_heart_consumed > 0 THEN
+    INSERT INTO wallet_ledger(
+      user_id, currency_type, delta, reason, ref_id, ref_type,
+      balance_after_heart, balance_after_diamond
+    ) VALUES (
+      p_user_id, 'heart', -v_heart_consumed, p_reason, p_ref_id, p_ref_type,
+      v_wallet.heart_balance - v_heart_consumed,
+      v_wallet.diamond_balance - v_diamond_consumed
+    );
+  END IF;
+  IF v_diamond_consumed > 0 THEN
+    INSERT INTO wallet_ledger(
+      user_id, currency_type, delta, reason, ref_id, ref_type,
+      balance_after_heart, balance_after_diamond
+    ) VALUES (
+      p_user_id, 'diamond', -v_diamond_consumed, p_reason, p_ref_id, p_ref_type,
+      v_wallet.heart_balance - v_heart_consumed,
+      v_wallet.diamond_balance - v_diamond_consumed
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'heart_consumed', v_heart_consumed,
+    'diamond_consumed', v_diamond_consumed,
+    'new_heart_balance', v_wallet.heart_balance - v_heart_consumed,
+    'new_diamond_balance', v_wallet.diamond_balance - v_diamond_consumed
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.consume_diamonds_atomically(UUID, INT, wallet_reason, UUID, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.consume_diamonds_atomically IS
+  '하트→다이아 우선순위로 차감. SECURITY DEFINER + FOR UPDATE로 race-free. 잔액 부족 시 INSUFFICIENT_BALANCE 예외. Spec §4.1';
+
+-- ============================================================================
+-- TEST SCENARIOS (executed via mcp__supabase__execute_sql 2026-04-26)
+-- ============================================================================
+-- Test user: b2222222-2222-4222-b222-222222222222
+-- All 5 scenarios passed. See task report for evidence.
+--
+-- Scenario 1: 정상 차감 (다이아만)
+--   Setup: wallet (0h, 100d)
+--   Call:  consume(10, 'consume_job_posting', task4_test_1)
+--   Expect: heart_consumed=0, diamond_consumed=10, new_h=0, new_d=90
+--
+-- Scenario 2: 잔액 부족
+--   Setup: wallet (5h, 0d)  (no active lots)
+--   Call:  consume(10)
+--   Expect: EXCEPTION 'INSUFFICIENT_BALANCE: have 5h+0d, need 10'
+--
+-- Scenario 3: 하트 우선 소비
+--   Setup: wallet (7h, 10d) + heart_lot(7, expires +30d)
+--   Call:  consume(10)
+--   Expect: heart_consumed=7, diamond_consumed=3, new_h=0, new_d=7
+--
+-- Scenario 4: 음수 amount
+--   Call:  consume(-5)
+--   Expect: EXCEPTION 'INVALID_AMOUNT: -5 must be positive'
+--
+-- Scenario 5: 만료 lot 무시
+--   Setup: wallet (5h, 5d) + heart_lot(5, expires_at = now() - 1d)
+--   Call:  consume(5)
+--   Expect: heart_consumed=0 (만료 lot skip), diamond_consumed=5, new_h=5, new_d=0
+--
+-- Cleanup: DELETE FROM wallet_ledger WHERE ref_type LIKE 'task4_test%';
+--          DELETE FROM heart_lots WHERE source_ref_id IN (...);
+--          UPDATE wallets SET heart_balance=0, diamond_balance=0 WHERE user_id=...;

--- a/uniqn-mobile/supabase/migrations/20260427000301_fix_consume_diamonds_drift_guard.sql
+++ b/uniqn-mobile/supabase/migrations/20260427000301_fix_consume_diamonds_drift_guard.sql
@@ -1,0 +1,110 @@
+-- 후속 보강 (코드 리뷰 HIGH 이슈): cache drift over-debit 방어
+-- 배경: heart_lots 실제 합과 wallets.heart_balance 캐시가 drift할 수 있음.
+-- 그 경우 lot 소비 후 다이아 차감 분이 실제 diamond_balance를 초과할 위험.
+-- 해결: lot loop 종료 후 v_remaining 을 v_wallet.diamond_balance와 재비교.
+-- 참조: pitfall_denormalized_counter_drift.md (cached counter for write-gating 금지)
+
+CREATE OR REPLACE FUNCTION public.consume_diamonds_atomically(
+  p_user_id  UUID,
+  p_amount   INT,
+  p_reason   wallet_reason,
+  p_ref_id   UUID,
+  p_ref_type TEXT
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_wallet           wallets%ROWTYPE;
+  v_heart_consumed   INT := 0;
+  v_diamond_consumed INT := 0;
+  v_remaining        INT := p_amount;
+  v_lot              RECORD;
+  v_take             INT;
+  v_now              TIMESTAMPTZ := now();
+BEGIN
+  -- p_user_id NULL 가드 (이전 review LOW 이슈)
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'INVALID_USER_ID: user_id required';
+  END IF;
+
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'INVALID_AMOUNT: % must be positive', p_amount;
+  END IF;
+
+  INSERT INTO wallets(user_id) VALUES (p_user_id)
+    ON CONFLICT (user_id) DO NOTHING;
+  SELECT * INTO v_wallet FROM wallets WHERE user_id = p_user_id FOR UPDATE;
+
+  -- 사전 캐시 검증 (빠른 reject용)
+  IF v_wallet.heart_balance + v_wallet.diamond_balance < p_amount THEN
+    RAISE EXCEPTION 'INSUFFICIENT_BALANCE: have %h+%d, need %',
+      v_wallet.heart_balance, v_wallet.diamond_balance, p_amount;
+  END IF;
+
+  -- 하트 FIFO 소비
+  FOR v_lot IN
+    SELECT * FROM heart_lots
+    WHERE user_id = p_user_id
+      AND amount_remaining > 0
+      AND expires_at > v_now
+    ORDER BY expires_at ASC, granted_at ASC
+    FOR UPDATE
+  LOOP
+    EXIT WHEN v_remaining = 0;
+    v_take := LEAST(v_lot.amount_remaining, v_remaining);
+    UPDATE heart_lots SET amount_remaining = amount_remaining - v_take
+      WHERE id = v_lot.id;
+    v_heart_consumed := v_heart_consumed + v_take;
+    v_remaining := v_remaining - v_take;
+  END LOOP;
+
+  -- *** NEW: drift guard — lot 합계가 cache보다 적었을 때 ***
+  -- v_remaining이 실제 다이아 잔액보다 크면 over-debit 위험 → 거부
+  IF v_remaining > v_wallet.diamond_balance THEN
+    RAISE EXCEPTION 'INSUFFICIENT_BALANCE: lot drift detected, real heart=%, real diamond=%, remaining need=%',
+      v_heart_consumed, v_wallet.diamond_balance, v_remaining;
+  END IF;
+
+  IF v_remaining > 0 THEN
+    v_diamond_consumed := v_remaining;
+  END IF;
+
+  -- ledger 기록
+  IF v_heart_consumed > 0 THEN
+    INSERT INTO wallet_ledger(
+      user_id, currency_type, delta, reason, ref_id, ref_type,
+      balance_after_heart, balance_after_diamond
+    ) VALUES (
+      p_user_id, 'heart', -v_heart_consumed, p_reason, p_ref_id, p_ref_type,
+      v_wallet.heart_balance - v_heart_consumed,
+      v_wallet.diamond_balance - v_diamond_consumed
+    );
+  END IF;
+  IF v_diamond_consumed > 0 THEN
+    INSERT INTO wallet_ledger(
+      user_id, currency_type, delta, reason, ref_id, ref_type,
+      balance_after_heart, balance_after_diamond
+    ) VALUES (
+      p_user_id, 'diamond', -v_diamond_consumed, p_reason, p_ref_id, p_ref_type,
+      v_wallet.heart_balance - v_heart_consumed,
+      v_wallet.diamond_balance - v_diamond_consumed
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'heart_consumed', v_heart_consumed,
+    'diamond_consumed', v_diamond_consumed,
+    'new_heart_balance', v_wallet.heart_balance - v_heart_consumed,
+    'new_diamond_balance', v_wallet.diamond_balance - v_diamond_consumed
+  );
+END;
+$$;
+
+-- GRANT는 OR REPLACE로 보존되지만 명시적으로 재선언 (defense in depth)
+GRANT EXECUTE ON FUNCTION public.consume_diamonds_atomically(UUID, INT, wallet_reason, UUID, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.consume_diamonds_atomically IS
+  '하트→다이아 우선순위 차감. SECURITY DEFINER + FOR UPDATE race-free. INSUFFICIENT_BALANCE / INVALID_AMOUNT / INVALID_USER_ID 예외. 사전 캐시 + 사후 lot 합계 양쪽 검증으로 drift over-debit 방지. Spec §4.1 + 코드 리뷰 보강 (drift guard, NULL 가드).';

--- a/uniqn-mobile/supabase/migrations/20260427000400_create_credit_diamonds_rpc.sql
+++ b/uniqn-mobile/supabase/migrations/20260427000400_create_credit_diamonds_rpc.sql
@@ -1,0 +1,106 @@
+-- credit_diamonds_atomically: 충전 + 환불 통합 RPC
+-- RevenueCat webhook 전용 (service_role only)
+-- p_diamonds 양수=구매, 음수=환불
+-- revenuecat_transaction_id UNIQUE 멱등성
+-- 첫 구매 시 +5💎 보너스 자동 (Decision #7)
+-- Spec §4.2, Plan Task 5
+
+CREATE OR REPLACE FUNCTION public.credit_diamonds_atomically(
+  p_user_id                   UUID,
+  p_diamonds                  INT,
+  p_revenuecat_transaction_id TEXT,
+  p_product_id                TEXT
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_wallet              wallets%ROWTYPE;
+  v_existing            UUID;
+  v_first_purchase      BOOLEAN := false;
+  v_bonus               INT := 0;
+  v_new_diamond_balance INT;
+BEGIN
+  -- 0) NULL 가드
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'INVALID_USER_ID: cannot be NULL';
+  END IF;
+  IF p_diamonds = 0 THEN
+    RAISE EXCEPTION 'INVALID_AMOUNT: p_diamonds must be non-zero';
+  END IF;
+  IF p_revenuecat_transaction_id IS NULL OR p_revenuecat_transaction_id = '' THEN
+    RAISE EXCEPTION 'INVALID_TRANSACTION_ID: required for idempotency';
+  END IF;
+
+  -- 1) 멱등성 체크 (같은 transaction_id 재호출 방지)
+  SELECT id INTO v_existing FROM public.wallet_ledger
+    WHERE revenuecat_transaction_id = p_revenuecat_transaction_id;
+  IF FOUND THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true);
+  END IF;
+
+  -- 2) wallet 행 잠금 (없으면 생성)
+  INSERT INTO public.wallets(user_id) VALUES (p_user_id)
+    ON CONFLICT (user_id) DO NOTHING;
+  SELECT * INTO v_wallet FROM public.wallets
+    WHERE user_id = p_user_id FOR UPDATE;
+
+  -- 3) 첫 구매 판정 (lifetime_purchased_diamonds = 0 AND p_diamonds > 0)
+  IF p_diamonds > 0 AND v_wallet.lifetime_purchased_diamonds = 0 THEN
+    v_first_purchase := true;
+    v_bonus := 5;
+  END IF;
+
+  v_new_diamond_balance := v_wallet.diamond_balance + p_diamonds + v_bonus;
+
+  -- 4) 메인 ledger row (구매 또는 환불)
+  INSERT INTO public.wallet_ledger(
+    user_id, currency_type, delta, reason, ref_type,
+    balance_after_heart, balance_after_diamond,
+    revenuecat_transaction_id, metadata
+  ) VALUES (
+    p_user_id, 'diamond', p_diamonds,
+    CASE WHEN p_diamonds > 0 THEN 'purchase'::wallet_reason
+         ELSE 'refund_purchase'::wallet_reason END,
+    'revenuecat',
+    v_wallet.heart_balance,
+    v_wallet.diamond_balance + p_diamonds,
+    p_revenuecat_transaction_id,
+    jsonb_build_object('product_id', p_product_id, 'is_first_purchase', v_first_purchase)
+  );
+
+  -- 5) 첫 구매 보너스 row (별도 ledger entry, transaction_id NULL로 구별)
+  IF v_bonus > 0 THEN
+    INSERT INTO public.wallet_ledger(
+      user_id, currency_type, delta, reason, ref_type,
+      balance_after_heart, balance_after_diamond, metadata
+    ) VALUES (
+      p_user_id, 'diamond', v_bonus, 'grant_first_purchase_bonus', 'revenuecat',
+      v_wallet.heart_balance,
+      v_wallet.diamond_balance + p_diamonds + v_bonus,
+      jsonb_build_object('source_transaction_id', p_revenuecat_transaction_id)
+    );
+  END IF;
+
+  -- 6) lifetime 누계 (구매만 누적, 환불 음수는 누적 안 함)
+  IF p_diamonds > 0 THEN
+    UPDATE public.wallets
+       SET lifetime_purchased_diamonds = lifetime_purchased_diamonds + p_diamonds
+     WHERE user_id = p_user_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'diamonds_credited', p_diamonds,
+    'first_purchase_bonus', v_bonus,
+    'new_diamond_balance', GREATEST(0, v_new_diamond_balance)
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.credit_diamonds_atomically(UUID, INT, TEXT, TEXT) FROM PUBLIC, authenticated;
+GRANT EXECUTE ON FUNCTION public.credit_diamonds_atomically(UUID, INT, TEXT, TEXT) TO service_role;
+
+COMMENT ON FUNCTION public.credit_diamonds_atomically IS
+  'RevenueCat webhook 전용 (service_role only). p_diamonds 양수=구매, 음수=환불. revenuecat_transaction_id UNIQUE 멱등성. 첫 구매 시 +5💎 보너스 자동. Spec §4.2 + Decision #7';

--- a/uniqn-mobile/supabase/migrations/20260427000500_create_grant_heart_rpc.sql
+++ b/uniqn-mobile/supabase/migrations/20260427000500_create_grant_heart_rpc.sql
@@ -1,0 +1,175 @@
+-- grant_heart_atomically: 하트 적립 (lot 생성 + ledger 기록)
+-- daily_attendance는 KST 기준 일일 1회 제한
+-- claim_daily_attendance: 클라이언트 호출용 wrapper (본인만)
+-- get_wallet_summary: 잔액 + 만료 임박(7일 이내) lot 조회
+-- Spec §4.3, Plan Task 6
+
+CREATE OR REPLACE FUNCTION public.grant_heart_atomically(
+  p_user_id          UUID,
+  p_amount           INT,
+  p_reason           wallet_reason,
+  p_source_ref_id    UUID DEFAULT NULL,
+  p_expires_in_days  INT  DEFAULT 90
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_lot_id    UUID;
+  v_expires   TIMESTAMPTZ := now() + (p_expires_in_days || ' days')::interval;
+  v_today_kst DATE := (now() AT TIME ZONE 'Asia/Seoul')::date;
+BEGIN
+  -- 0) NULL 가드 + amount 검증
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'INVALID_USER_ID: cannot be NULL';
+  END IF;
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'INVALID_AMOUNT: % must be positive', p_amount;
+  END IF;
+  IF p_expires_in_days IS NULL OR p_expires_in_days <= 0 THEN
+    RAISE EXCEPTION 'INVALID_EXPIRES_IN_DAYS: % must be positive', p_expires_in_days;
+  END IF;
+
+  -- 1) daily_attendance KST 일일 1회 제한
+  IF p_reason = 'grant_daily_attendance' THEN
+    IF EXISTS (
+      SELECT 1 FROM public.wallet_ledger
+      WHERE user_id = p_user_id
+        AND reason = 'grant_daily_attendance'
+        AND (created_at AT TIME ZONE 'Asia/Seoul')::date = v_today_kst
+    ) THEN
+      RETURN jsonb_build_object('success', false, 'error', 'already_attended_today');
+    END IF;
+  END IF;
+
+  -- 2) wallet 행 보장
+  INSERT INTO public.wallets(user_id) VALUES (p_user_id)
+    ON CONFLICT (user_id) DO NOTHING;
+
+  -- 3) lot 생성 (만료 단위)
+  INSERT INTO public.heart_lots(
+    user_id, amount_initial, amount_remaining, expires_at, source, source_ref_id
+  )
+  VALUES (p_user_id, p_amount, p_amount, v_expires, p_reason, p_source_ref_id)
+  RETURNING id INTO v_lot_id;
+
+  -- 4) ledger row (trigger가 wallets 캐시 sync 처리)
+  INSERT INTO public.wallet_ledger(
+    user_id, currency_type, delta, reason, ref_id, ref_type,
+    balance_after_heart, balance_after_diamond
+  )
+  SELECT p_user_id, 'heart', p_amount, p_reason,
+         v_lot_id, 'heart_lot',
+         w.heart_balance + p_amount, w.diamond_balance
+    FROM public.wallets w
+   WHERE w.user_id = p_user_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'lot_id', v_lot_id,
+    'expires_at', v_expires,
+    'amount', p_amount
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.grant_heart_atomically(UUID, INT, wallet_reason, UUID, INT) FROM PUBLIC, authenticated;
+GRANT EXECUTE ON FUNCTION public.grant_heart_atomically(UUID, INT, wallet_reason, UUID, INT) TO service_role;
+
+COMMENT ON FUNCTION public.grant_heart_atomically IS
+  '하트 적립 (lot + ledger). service_role only. daily_attendance는 KST 기준 일일 1회. Spec §4.3';
+
+-- ──────────────────────────────────────────────────────────────────
+-- claim_daily_attendance: 본인 출석 체크 (authenticated 호출용)
+-- ──────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.claim_daily_attendance()
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_uid UUID := (SELECT auth.uid());
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'NOT_AUTHENTICATED';
+  END IF;
+  RETURN public.grant_heart_atomically(v_uid, 1, 'grant_daily_attendance'::wallet_reason, NULL, 90);
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.claim_daily_attendance() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.claim_daily_attendance() TO authenticated;
+
+COMMENT ON FUNCTION public.claim_daily_attendance IS
+  '본인 출석 체크 wrapper — 1💖, 90일 만료. KST 기준 일일 1회.';
+
+-- ──────────────────────────────────────────────────────────────────
+-- get_wallet_summary: 잔액 + 만료 임박(7일 이내) lot 조회
+-- p_user_id 미지정 시 auth.uid() 사용. 타인 조회는 admin만.
+-- Decision #3: 만료 임박 lot inline 표시용 (별도 푸시/배너 없음)
+-- ──────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.get_wallet_summary(p_user_id UUID DEFAULT NULL)
+RETURNS JSONB
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_uid    UUID := COALESCE(p_user_id, (SELECT auth.uid()));
+  v_caller UUID := (SELECT auth.uid());
+  v_role   TEXT := COALESCE((auth.jwt() -> 'app_metadata' ->> 'role'), '');
+  v_wallet public.wallets%ROWTYPE;
+  v_lots   JSONB;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'NOT_AUTHENTICATED';
+  END IF;
+
+  -- 본인 조회만 허용 (admin 또는 service_role 우회)
+  -- v_caller가 NULL이면 service_role 호출 (MCP 등) — 통과
+  IF v_caller IS NOT NULL AND v_uid <> v_caller AND v_role <> 'admin' THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED';
+  END IF;
+
+  SELECT * INTO v_wallet FROM public.wallets WHERE user_id = v_uid;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'heart_balance', 0,
+      'diamond_balance', 0,
+      'lifetime_purchased_diamonds', 0,
+      'expiring_lots', '[]'::jsonb
+    );
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'lot_id', id,
+      'amount_remaining', amount_remaining,
+      'expires_at', expires_at,
+      'source', source
+    ) ORDER BY expires_at ASC
+  ), '[]'::jsonb) INTO v_lots
+  FROM public.heart_lots
+  WHERE user_id = v_uid
+    AND amount_remaining > 0
+    AND expires_at BETWEEN now() AND now() + interval '7 days';
+
+  RETURN jsonb_build_object(
+    'heart_balance', v_wallet.heart_balance,
+    'diamond_balance', v_wallet.diamond_balance,
+    'lifetime_purchased_diamonds', v_wallet.lifetime_purchased_diamonds,
+    'expiring_lots', v_lots
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_wallet_summary(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_wallet_summary(UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_wallet_summary(UUID) TO service_role;
+
+COMMENT ON FUNCTION public.get_wallet_summary IS
+  '본인 잔액 + 7일 이내 만료 lot 조회. UI inline 표시용 (Decision #3 — 푸시/배너 없음).';

--- a/uniqn-mobile/supabase/migrations/20260427000600_create_create_job_posting_with_payment_rpc.sql
+++ b/uniqn-mobile/supabase/migrations/20260427000600_create_create_job_posting_with_payment_rpc.sql
@@ -1,0 +1,104 @@
+-- create_job_posting_with_payment_atomically:
+-- 다이아 차감 + job_postings INSERT를 단일 트랜잭션으로 수행
+-- consume RPC가 INSUFFICIENT_BALANCE 던지면 공고 INSERT까지 롤백
+-- tournament(cost=0)는 차감 skip (Decision #11)
+-- Spec §6.3 race window 해결, Plan Task 7
+--
+-- 페이로드 규약: 호출자는 job_postings 컬럼 키를 그대로 jsonb로 전달.
+-- 누락 필드는 RPC가 SQL DEFAULT 값으로 보강. owner_id는 RPC가 강제 override.
+-- 보강 대상: id, status, posting_type, schema_version, created_at, updated_at,
+--           location, schedule, role_catalog, compensation, questions, stats,
+--           total_positions, filled_positions, view_count, is_featured
+
+CREATE OR REPLACE FUNCTION public.create_job_posting_with_payment_atomically(
+  p_owner_id        UUID,
+  p_posting_payload JSONB,
+  p_cost_diamonds   INT,
+  p_reason          wallet_reason
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_posting_id        UUID;
+  v_consume_result    JSONB;
+  v_diamonds_consumed INT := 0;
+  v_heart_consumed    INT := 0;
+  v_defaults          JSONB;
+  v_final_payload     JSONB;
+BEGIN
+  -- 0) NULL/범위 가드
+  IF p_owner_id IS NULL THEN
+    RAISE EXCEPTION 'INVALID_OWNER_ID: cannot be NULL';
+  END IF;
+  IF p_posting_payload IS NULL THEN
+    RAISE EXCEPTION 'INVALID_PAYLOAD: cannot be NULL';
+  END IF;
+  IF p_cost_diamonds < 0 THEN
+    RAISE EXCEPTION 'INVALID_AMOUNT: cost_diamonds % must be >= 0', p_cost_diamonds;
+  END IF;
+
+  -- 1) NOT NULL/default 컬럼 보강 (jsonb_populate_record는 누락 키를 NULL로 채워 default 적용 안 됨)
+  v_defaults := jsonb_build_object(
+    'id',                gen_random_uuid(),
+    'schema_version',    3,
+    'status',            'draft',
+    'posting_type',      'regular',
+    'created_at',        now(),
+    'updated_at',        now(),
+    'location',          '{}'::jsonb,
+    'schedule',          '{}'::jsonb,
+    'role_catalog',      '[]'::jsonb,
+    'compensation',      '{}'::jsonb,
+    'questions',         jsonb_build_object('items', '[]'::jsonb),
+    'stats',             jsonb_build_object(
+                           'filledPositions', 0,
+                           'totalApplicants', 0,
+                           'activeApplicants', 0,
+                           'confirmedApplicants', 0,
+                           'cancellationPendingApplicants', 0
+                         ),
+    'total_positions',   0,
+    'filled_positions',  0,
+    'view_count',        0,
+    'is_featured',       false
+  );
+
+  -- 호출자 페이로드가 default를 override, owner_id는 RPC가 마지막 강제
+  v_final_payload := v_defaults || p_posting_payload || jsonb_build_object('owner_id', p_owner_id);
+
+  -- 2) 공고 INSERT
+  INSERT INTO public.job_postings
+  SELECT * FROM jsonb_populate_record(NULL::public.job_postings, v_final_payload)
+  RETURNING id INTO v_posting_id;
+
+  -- 3) cost > 0이면 차감 (실패 시 전체 트랜잭션 롤백)
+  IF p_cost_diamonds > 0 THEN
+    v_consume_result := public.consume_diamonds_atomically(
+      p_owner_id,
+      p_cost_diamonds,
+      p_reason,
+      v_posting_id,
+      'job_posting'
+    );
+    v_diamonds_consumed := COALESCE((v_consume_result->>'diamond_consumed')::int, 0);
+    v_heart_consumed    := COALESCE((v_consume_result->>'heart_consumed')::int, 0);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'posting_id', v_posting_id,
+    'diamonds_consumed', v_diamonds_consumed,
+    'hearts_consumed', v_heart_consumed,
+    'total_consumed', v_diamonds_consumed + v_heart_consumed
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.create_job_posting_with_payment_atomically(UUID, JSONB, INT, wallet_reason) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.create_job_posting_with_payment_atomically(UUID, JSONB, INT, wallet_reason) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.create_job_posting_with_payment_atomically(UUID, JSONB, INT, wallet_reason) TO service_role;
+
+COMMENT ON FUNCTION public.create_job_posting_with_payment_atomically IS
+  'job_postings INSERT + 다이아 차감을 단일 트랜잭션으로. consume RPC가 INSUFFICIENT_BALANCE 던지면 공고 INSERT까지 롤백. tournament(cost=0)는 차감 skip. NOT NULL 컬럼은 RPC가 SQL DEFAULT로 보강. Spec §6.3 + Decision #11';

--- a/uniqn-mobile/supabase/migrations/20260427000601_fix_create_job_posting_default_padding.sql
+++ b/uniqn-mobile/supabase/migrations/20260427000601_fix_create_job_posting_default_padding.sql
@@ -1,0 +1,87 @@
+-- Fix: jsonb_populate_record가 누락 키를 NULL로 채워 SQL DEFAULT가 적용 안 되는 문제.
+-- RPC 내부에서 NOT NULL 컬럼의 default 값을 v_defaults JSONB로 미리 채워 보강.
+-- Spec §6.3, Plan Task 7 (검증 1차에서 id NULL violation 발견)
+
+CREATE OR REPLACE FUNCTION public.create_job_posting_with_payment_atomically(
+  p_owner_id        UUID,
+  p_posting_payload JSONB,
+  p_cost_diamonds   INT,
+  p_reason          wallet_reason
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_posting_id        UUID;
+  v_consume_result    JSONB;
+  v_diamonds_consumed INT := 0;
+  v_heart_consumed    INT := 0;
+  v_defaults          JSONB;
+  v_final_payload     JSONB;
+BEGIN
+  IF p_owner_id IS NULL THEN
+    RAISE EXCEPTION 'INVALID_OWNER_ID: cannot be NULL';
+  END IF;
+  IF p_posting_payload IS NULL THEN
+    RAISE EXCEPTION 'INVALID_PAYLOAD: cannot be NULL';
+  END IF;
+  IF p_cost_diamonds < 0 THEN
+    RAISE EXCEPTION 'INVALID_AMOUNT: cost_diamonds % must be >= 0', p_cost_diamonds;
+  END IF;
+
+  v_defaults := jsonb_build_object(
+    'id',                gen_random_uuid(),
+    'schema_version',    3,
+    'status',            'draft',
+    'posting_type',      'regular',
+    'created_at',        now(),
+    'updated_at',        now(),
+    'location',          '{}'::jsonb,
+    'schedule',          '{}'::jsonb,
+    'role_catalog',      '[]'::jsonb,
+    'compensation',      '{}'::jsonb,
+    'questions',         jsonb_build_object('items', '[]'::jsonb),
+    'stats',             jsonb_build_object(
+                           'filledPositions', 0,
+                           'totalApplicants', 0,
+                           'activeApplicants', 0,
+                           'confirmedApplicants', 0,
+                           'cancellationPendingApplicants', 0
+                         ),
+    'total_positions',   0,
+    'filled_positions',  0,
+    'view_count',        0,
+    'is_featured',       false
+  );
+
+  v_final_payload := v_defaults || p_posting_payload || jsonb_build_object('owner_id', p_owner_id);
+
+  INSERT INTO public.job_postings
+  SELECT * FROM jsonb_populate_record(NULL::public.job_postings, v_final_payload)
+  RETURNING id INTO v_posting_id;
+
+  IF p_cost_diamonds > 0 THEN
+    v_consume_result := public.consume_diamonds_atomically(
+      p_owner_id,
+      p_cost_diamonds,
+      p_reason,
+      v_posting_id,
+      'job_posting'
+    );
+    v_diamonds_consumed := COALESCE((v_consume_result->>'diamond_consumed')::int, 0);
+    v_heart_consumed    := COALESCE((v_consume_result->>'heart_consumed')::int, 0);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'posting_id', v_posting_id,
+    'diamonds_consumed', v_diamonds_consumed,
+    'hearts_consumed', v_heart_consumed,
+    'total_consumed', v_diamonds_consumed + v_heart_consumed
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.create_job_posting_with_payment_atomically IS
+  'job_postings INSERT + 다이아 차감을 단일 트랜잭션으로. consume RPC가 INSUFFICIENT_BALANCE 던지면 공고 INSERT까지 롤백. tournament(cost=0)는 차감 skip. NOT NULL 컬럼은 RPC가 SQL DEFAULT로 보강. Spec §6.3 + Decision #11';

--- a/uniqn-mobile/supabase/migrations/20260427000700_create_refund_job_cancellation_rpc.sql
+++ b/uniqn-mobile/supabase/migrations/20260427000700_create_refund_job_cancellation_rpc.sql
@@ -1,0 +1,103 @@
+-- refund_job_cancellation_atomically:
+-- 공고 취소 시 다이아 환불을 단일 트랜잭션으로 수행
+-- 24h 이내 100% / 이후 50% (FLOOR) — Decision #1
+-- 하트+다이아 합산을 다이아로 환불 (하트 만료 정책상 다이아 비례 환불)
+-- 같은 ref_id에 refund_job_cancelled row 있으면 idempotent
+-- Spec §11, Plan Task 8
+
+CREATE OR REPLACE FUNCTION public.refund_job_cancellation_atomically(
+  p_posting_id UUID,
+  p_owner_id   UUID
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_existing_refund   UUID;
+  v_first_consume_at  TIMESTAMPTZ;
+  v_hours_elapsed     NUMERIC;
+  v_refund_rate       NUMERIC;
+  v_refund_amount     INT;
+  v_diamond_amount    INT;
+  v_heart_amount      INT;
+  v_now               TIMESTAMPTZ := now();
+BEGIN
+  -- 0) NULL 가드
+  IF p_posting_id IS NULL OR p_owner_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'invalid_args');
+  END IF;
+
+  -- 1) 멱등성: 이미 같은 공고에 refund_job_cancelled row가 있는지
+  SELECT id INTO v_existing_refund FROM public.wallet_ledger
+    WHERE ref_id = p_posting_id
+      AND user_id = p_owner_id
+      AND reason = 'refund_job_cancelled'
+    LIMIT 1;
+  IF v_existing_refund IS NOT NULL THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true);
+  END IF;
+
+  -- 2) 차감 row 합산 (consume_job_posting / extend / upgrade 모두)
+  SELECT
+    COALESCE(SUM(CASE WHEN currency_type='diamond' THEN -delta ELSE 0 END), 0)::int,
+    COALESCE(SUM(CASE WHEN currency_type='heart'   THEN -delta ELSE 0 END), 0)::int,
+    MIN(created_at)
+  INTO v_diamond_amount, v_heart_amount, v_first_consume_at
+  FROM public.wallet_ledger
+  WHERE ref_id = p_posting_id
+    AND user_id = p_owner_id
+    AND reason IN ('consume_job_posting','consume_job_extend','consume_job_upgrade');
+
+  IF v_first_consume_at IS NULL OR (v_diamond_amount + v_heart_amount) <= 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'no_consumption_found');
+  END IF;
+
+  -- 3) 권한 검증 (posting 소유주 일치)
+  IF NOT EXISTS (
+    SELECT 1 FROM public.job_postings WHERE id = p_posting_id AND owner_id = p_owner_id
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'unauthorized');
+  END IF;
+
+  -- 4) 환불 비율 계산 (Decision #1)
+  v_hours_elapsed := EXTRACT(EPOCH FROM (v_now - v_first_consume_at)) / 3600;
+  v_refund_rate := CASE WHEN v_hours_elapsed < 24 THEN 1.0 ELSE 0.5 END;
+  -- 다이아만 환불 (하트는 만료 정책상 환불 어려움 → 다이아 비례 환불)
+  v_refund_amount := FLOOR((v_diamond_amount + v_heart_amount) * v_refund_rate)::int;
+
+  -- 5) 환불 ledger row (다이아로 환불, balance는 캐시 trigger가 동기화)
+  INSERT INTO public.wallet_ledger(
+    user_id, currency_type, delta, reason, ref_id, ref_type,
+    balance_after_heart, balance_after_diamond,
+    metadata
+  )
+  SELECT p_owner_id, 'diamond', v_refund_amount, 'refund_job_cancelled',
+         p_posting_id, 'job_posting',
+         w.heart_balance,
+         w.diamond_balance + v_refund_amount,
+         jsonb_build_object(
+           'original_diamond', v_diamond_amount,
+           'original_heart', v_heart_amount,
+           'refund_rate', v_refund_rate,
+           'hours_elapsed', v_hours_elapsed
+         )
+  FROM public.wallets w WHERE w.user_id = p_owner_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'refunded_diamonds', v_refund_amount,
+    'refund_rate', v_refund_rate,
+    'hours_elapsed', v_hours_elapsed,
+    'original_diamond', v_diamond_amount,
+    'original_heart', v_heart_amount
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.refund_job_cancellation_atomically(UUID, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.refund_job_cancellation_atomically(UUID, UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.refund_job_cancellation_atomically(UUID, UUID) TO service_role;
+
+COMMENT ON FUNCTION public.refund_job_cancellation_atomically IS
+  '공고 취소 환불. 24h 이내 100%, 이후 50% (FLOOR). 하트+다이아 합산을 다이아로 환불. ref_id에 같은 refund row 있으면 idempotent. Decision #1, Spec §11.';

--- a/uniqn-mobile/supabase/migrations/20260427000701_fix_refund_auth_order.sql
+++ b/uniqn-mobile/supabase/migrations/20260427000701_fix_refund_auth_order.sql
@@ -1,0 +1,93 @@
+-- 후속 보강: refund_job_cancellation_atomically 권한 체크 순서 조정
+-- 배경: 타인이 호출 시 user_id 필터 때문에 no_consumption_found가 먼저 응답됨.
+--   보안상 deny는 동일하나 spec(Plan Task 8)은 unauthorized 응답 기대.
+--   posting 존재 + 소유주 일치 검증을 consumption 합산 전으로 이동한다.
+-- 멱등성 → 권한 → 합산 → 환불 순서로 명확화.
+
+CREATE OR REPLACE FUNCTION public.refund_job_cancellation_atomically(
+  p_posting_id UUID,
+  p_owner_id   UUID
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_existing_refund   UUID;
+  v_first_consume_at  TIMESTAMPTZ;
+  v_hours_elapsed     NUMERIC;
+  v_refund_rate       NUMERIC;
+  v_refund_amount     INT;
+  v_diamond_amount    INT;
+  v_heart_amount      INT;
+  v_now               TIMESTAMPTZ := now();
+BEGIN
+  IF p_posting_id IS NULL OR p_owner_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'invalid_args');
+  END IF;
+
+  -- 1) 멱등성 (자기 자신의 refund row만 조회 — 타인 row 침범 금지)
+  SELECT id INTO v_existing_refund FROM public.wallet_ledger
+    WHERE ref_id = p_posting_id
+      AND user_id = p_owner_id
+      AND reason = 'refund_job_cancelled'
+    LIMIT 1;
+  IF v_existing_refund IS NOT NULL THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true);
+  END IF;
+
+  -- 2) 권한: posting 존재 + 소유주 일치 (consumption 합산 이전에)
+  IF NOT EXISTS (
+    SELECT 1 FROM public.job_postings WHERE id = p_posting_id AND owner_id = p_owner_id
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'unauthorized');
+  END IF;
+
+  -- 3) 차감 row 합산
+  SELECT
+    COALESCE(SUM(CASE WHEN currency_type='diamond' THEN -delta ELSE 0 END), 0)::int,
+    COALESCE(SUM(CASE WHEN currency_type='heart'   THEN -delta ELSE 0 END), 0)::int,
+    MIN(created_at)
+  INTO v_diamond_amount, v_heart_amount, v_first_consume_at
+  FROM public.wallet_ledger
+  WHERE ref_id = p_posting_id
+    AND user_id = p_owner_id
+    AND reason IN ('consume_job_posting','consume_job_extend','consume_job_upgrade');
+
+  IF v_first_consume_at IS NULL OR (v_diamond_amount + v_heart_amount) <= 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'no_consumption_found');
+  END IF;
+
+  -- 4) 환불 비율 계산 (Decision #1)
+  v_hours_elapsed := EXTRACT(EPOCH FROM (v_now - v_first_consume_at)) / 3600;
+  v_refund_rate := CASE WHEN v_hours_elapsed < 24 THEN 1.0 ELSE 0.5 END;
+  v_refund_amount := FLOOR((v_diamond_amount + v_heart_amount) * v_refund_rate)::int;
+
+  -- 5) 환불 ledger row
+  INSERT INTO public.wallet_ledger(
+    user_id, currency_type, delta, reason, ref_id, ref_type,
+    balance_after_heart, balance_after_diamond,
+    metadata
+  )
+  SELECT p_owner_id, 'diamond', v_refund_amount, 'refund_job_cancelled',
+         p_posting_id, 'job_posting',
+         w.heart_balance,
+         w.diamond_balance + v_refund_amount,
+         jsonb_build_object(
+           'original_diamond', v_diamond_amount,
+           'original_heart', v_heart_amount,
+           'refund_rate', v_refund_rate,
+           'hours_elapsed', v_hours_elapsed
+         )
+  FROM public.wallets w WHERE w.user_id = p_owner_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'refunded_diamonds', v_refund_amount,
+    'refund_rate', v_refund_rate,
+    'hours_elapsed', v_hours_elapsed,
+    'original_diamond', v_diamond_amount,
+    'original_heart', v_heart_amount
+  );
+END;
+$$;

--- a/uniqn-mobile/supabase/migrations/20260427000800_seed_diamond_products.sql
+++ b/uniqn-mobile/supabase/migrations/20260427000800_seed_diamond_products.sql
@@ -1,0 +1,19 @@
+-- 다이아 충전 패키지 6종 시드
+-- BUSINESS_PLAN_2025.md §3.2, Plan Task 9
+-- ON CONFLICT update — re-run 안전
+
+INSERT INTO public.diamond_products (product_id, diamonds, bonus_diamonds, price_krw, display_order, active)
+VALUES
+  ('uniqn_diamonds_1000',     3,   0,   1000, 1, true),
+  ('uniqn_diamonds_3000',    10,   0,   3000, 2, true),
+  ('uniqn_diamonds_10000',   33,   2,  10000, 3, true),
+  ('uniqn_diamonds_30000',  100,  10,  30000, 4, true),
+  ('uniqn_diamonds_50000',  167,  23,  50000, 5, true),
+  ('uniqn_diamonds_100000', 333,  67, 100000, 6, true)
+ON CONFLICT (product_id) DO UPDATE SET
+  diamonds       = EXCLUDED.diamonds,
+  bonus_diamonds = EXCLUDED.bonus_diamonds,
+  price_krw      = EXCLUDED.price_krw,
+  display_order  = EXCLUDED.display_order,
+  active         = EXCLUDED.active,
+  updated_at     = now();

--- a/uniqn-mobile/supabase/migrations/20260427000900_seed_app_config_monetization.sql
+++ b/uniqn-mobile/supabase/migrations/20260427000900_seed_app_config_monetization.sql
@@ -1,0 +1,28 @@
+-- Feature Flag: monetization 초기 시드
+-- Decision #6 + Spec §7.1
+-- 초기 정책: 시스템은 enabled, 4종 paid_types는 모두 false (무료 운영),
+--   다이아 충전 UI(show_purchase_ui)는 활성, 첫 충전 보너스 5💎 적용.
+-- Plan Task 10
+
+INSERT INTO public.app_config (key, value, description, updated_at)
+VALUES (
+  'monetization',
+  jsonb_build_object(
+    'enabled', true,
+    'paid_types', jsonb_build_object(
+      'regular', false,
+      'urgent', false,
+      'fixed', false,
+      'tournament', false
+    ),
+    'rollout_percentage', 0,
+    'show_purchase_ui', true,
+    'first_purchase_bonus_diamonds', 5
+  ),
+  '결제 시스템 Feature Flag. paid_types 모두 false = 전부 무료 운영. show_purchase_ui = 충전 UI 노출. rollout_percentage = 단계 배포 비율. Spec §7.1, Decision #6.',
+  now()
+)
+ON CONFLICT (key) DO UPDATE SET
+  value = EXCLUDED.value,
+  description = EXCLUDED.description,
+  updated_at = now();

--- a/uniqn-mobile/supabase/migrations/20260427001000_create_heart_expiry_cron.sql
+++ b/uniqn-mobile/supabase/migrations/20260427001000_create_heart_expiry_cron.sql
@@ -1,0 +1,74 @@
+-- heart_lots 만료 처리 함수 + pg_cron 등록
+-- Decision #3: 알림 없음, 잔량 0 + ledger expire_heart row만
+-- Spec §3.4, Plan Task 11
+-- 실행 시점: 매일 KST 자정 (UTC 15:00 전일)
+-- 작동: amount_remaining > 0 AND expires_at <= now() lot을 모두 처리하여
+--   ledger expire_heart row 생성 + lot.amount_remaining = 0 set.
+--   wallets 캐시는 ledger insert trigger가 GREATEST(0, ...)로 안전 갱신.
+
+CREATE OR REPLACE FUNCTION public.fn_expire_heart_lots()
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_lot         RECORD;
+  v_total       INT := 0;
+  v_users_count INT := 0;
+  v_now         TIMESTAMPTZ := now();
+BEGIN
+  FOR v_lot IN
+    SELECT id, user_id, amount_remaining
+    FROM public.heart_lots
+    WHERE amount_remaining > 0 AND expires_at <= v_now
+    FOR UPDATE
+  LOOP
+    -- ledger row (cache trigger가 wallets 갱신)
+    INSERT INTO public.wallet_ledger(
+      user_id, currency_type, delta, reason, ref_id, ref_type,
+      balance_after_heart, balance_after_diamond, metadata
+    )
+    SELECT v_lot.user_id, 'heart', -v_lot.amount_remaining, 'expire_heart',
+           v_lot.id, 'heart_lot',
+           GREATEST(0, w.heart_balance - v_lot.amount_remaining),
+           w.diamond_balance,
+           jsonb_build_object('expired_at', v_now)
+    FROM public.wallets w WHERE w.user_id = v_lot.user_id;
+
+    UPDATE public.heart_lots SET amount_remaining = 0 WHERE id = v_lot.id;
+    v_total := v_total + v_lot.amount_remaining;
+    v_users_count := v_users_count + 1;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'expired_hearts', v_total,
+    'affected_users', v_users_count,
+    'run_at', v_now
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.fn_expire_heart_lots() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.fn_expire_heart_lots() TO service_role;
+GRANT EXECUTE ON FUNCTION public.fn_expire_heart_lots() TO postgres;
+
+COMMENT ON FUNCTION public.fn_expire_heart_lots() IS
+  'heart_lots FIFO 만료 처리. amount_remaining=0 + expire_heart ledger row. wallets 캐시는 trigger GREATEST(0,...) 안전. Decision #3 (알림 없음). Spec §3.4.';
+
+-- pg_cron 등록 (매일 KST 자정 = UTC 15:00 전일)
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    -- 기존 등록 idempotent 제거 후 재등록
+    PERFORM cron.unschedule('expire_heart_lots_daily')
+    WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'expire_heart_lots_daily');
+
+    PERFORM cron.schedule(
+      'expire_heart_lots_daily',
+      '0 15 * * *',
+      $cmd$SELECT public.fn_expire_heart_lots();$cmd$
+    );
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

UNIQN 결제 시스템 (하트💖 + 다이아💎 wallet)의 **DB 인프라 + RevenueCat webhook**을 그린필드로 구축.

**Phase 1 (DB Foundation, 13 task)**: 4 테이블 + 14 enum + 6 RLS + 1 trigger + 8 RPC + 6 product 시드 + 1 cron + TypeScript Repository
**Phase 2 (RevenueCat Webhook, 1 task + 외부 가이드)**: Edge Function deploy + 9 단계 RC 설정 가이드

## 무엇을 만드나

- 💖 하트 (무료 적립) + 💎 다이아 (유료 충전) 양 통화
- 1 포인트 = 300원, 소비 우선순위: 하트(만료 임박순) → 다이아
- 충전 6 SKU (1k원~100k원) via Apple/Google IAP + RevenueCat
- 첫 충전 +5💎 보너스, 90일 하트 만료, 24h 100% / 이후 50% 환불

## 핵심 산출물

### 마이그 15개 (`uniqn-mobile/supabase/migrations/2026042700*.sql`)
- 4 테이블 (`wallets` / `wallet_ledger` / `heart_lots` / `diamond_products`) + 14 enum
- 6 RLS 정책 (본인 SELECT + admin 전체)
- 캐시 sync trigger (`tr_wallet_ledger_update_balance`)
- 8 RPC (`consume` / `credit` / `grant_heart` / `get_summary` / `create_with_payment` / `refund` / `expire_heart` / `claim_daily`)
- pg_cron `expire_heart_lots_daily` (KST 자정)
- 6 product 시드 + monetization Feature flag (모두 false 초기값)

### Edge Function
- `uniqn-mobile/supabase/functions/revenuecat-webhook/index.ts` (Deno, verify_jwt=false)
- INITIAL_PURCHASE/NON_RENEWING_PURCHASE → +diamonds, REFUND/BILLING_ISSUE/CANCELLATION → -diamonds
- Bearer secret + UUID 검증 + product DB 조회 (클라이언트 신뢰 X)
- 멱등성: event.id → `revenuecat_transaction_id` UNIQUE

### TypeScript
- `src/types/wallet.ts` (Zod schemas)
- `src/repositories/supabase/WalletRepository.ts` (read-only: `getSummary` / `listProducts`)
- `src/types/supabase.ts` 재생성 (wallet 테이블 + 8 RPC 타입 포함)

### 문서
- `docs/superpowers/specs/2026-04-26-monetization-design.md` (Locked spec)
- `docs/superpowers/plans/2026-04-26-monetization.md` (Phase 1 13-task plan)
- `docs/superpowers/plans/2026-04-29-monetization-phase2-revenuecat-setup.md` (외부 작업 9 단계 가이드)

## 검증

- ✅ Phase 1: 25+ 시나리오 검증 (MCP execute_sql), E2E 풀 시퀀스 (signup→첫충전→공고→환불) 통과
- ✅ Phase 2: Edge Function deploy v1 ACTIVE, 코드 실행 정상 확인
- ✅ `npm run quality` EXIT=0 (type-check + lint + format)
- ✅ Supabase advisor: critical/high 0건 (wallet 신규 이슈 없음)

## 외부 작업 필요 (머지 후)

1. RevenueCat 계정 + 프로젝트 생성
2. App Store Connect Consumable IAP 6개 등록
3. Google Play Console Managed Product 6개 등록
4. RC Products + Offering + Webhook URL 등록
5. Supabase에 `REVENUECAT_WEBHOOK_SECRET` 등록

→ 가이드: `docs/superpowers/plans/2026-04-29-monetization-phase2-revenuecat-setup.md`

## Test plan

- [x] DB 마이그 15개 모두 적용 + advisor 통과
- [x] 8 RPC 시나리오 검증 (consume/credit/grant/refund/expire/wrapper)
- [x] E2E 시퀀스 (signup→충전→공고→환불) 5 ledger row 일관성
- [x] Edge Function deploy + 호출 정상
- [x] WalletRepository tsc/lint/prettier 통과
- [ ] (머지 후) RC secret 등록 + curl 5 시나리오 검증 (가이드 §7)
- [ ] (Phase 3) sandbox tester 실 결제 → webhook → DB 풀스택

## 후속 Phase (다음 PR)

- Phase 3: 클라이언트 SDK + Wallet UI (~15 task)
- Phase 4: jobManagementService 통합 (~6 task)
- Phase 5: 하트 적립 흐름 (~10 task)
- Phase 6: Feature Flag rollout (~4 task)
- Phase 7: 환불 통합 + 모니터링 (~8 task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)