### PR TITLE
feat(workspace): 다중 워크스페이스 전환 UI — Phase 1B

### DIFF
--- a/uniqn-mobile/app/(app)/(tabs)/employer.tsx
+++ b/uniqn-mobile/app/(app)/(tabs)/employer.tsx
@@ -9,6 +9,7 @@ import { Button, ConfirmModal, PostingSurfaceState } from '@/components';
 import { EventQRModal } from '@/components/employer/qr/EventQRModal';
 import { JobPostingCard, NonEmployerView } from '@/components/employer';
 import { TabHeader } from '@/components/headers';
+import { WorkspaceContextBar } from '@/components/workspace';
 import { BriefcaseIcon, PlusIcon, UsersIcon } from '@/components/icons';
 import { getIconColor } from '@/constants';
 import { buildPostingFacts } from '@/domains/job-posting';
@@ -287,6 +288,7 @@ function EmployerView() {
           </Pressable>
         }
       />
+      <WorkspaceContextBar />
 
       <View className="px-4 py-3">
         <Button

--- a/uniqn-mobile/app/(employer)/workspace/index.tsx
+++ b/uniqn-mobile/app/(employer)/workspace/index.tsx
@@ -16,24 +16,27 @@ import { Avatar, Badge, Button, EmptyState, ErrorState, Input } from '@/componen
 import { useAuthStore } from '@/stores/authStore';
 import { useToastStore } from '@/stores/toastStore';
 import {
-  useWorkspaces,
+  useActiveWorkspace,
   useWorkspaceMembers,
   useWorkspaceOwnerProfile,
   useUpdateWorkspaceName,
   useRemoveWorkspaceMember,
   useCreateWorkspace,
+  useWorkspaces,
 } from '@/hooks/workspace';
+import { WorkspaceContextBar } from '@/components/workspace';
 import { logger } from '@/utils/logger';
 import { isAppError } from '@/errors';
-import type { Workspace, WorkspaceMemberWithUser } from '@/types/workspace';
+import type { WorkspaceMemberWithUser } from '@/types/workspace';
 
 export default function WorkspaceSettingsScreen() {
   const { user } = useAuthStore();
   const { addToast } = useToastStore();
-  const { workspaces, isLoading, error } = useWorkspaces();
+  // useActiveWorkspace 가 내부에서 useWorkspaces 를 호출 — TanStack Query 가 동일 키로
+  // 중복 조회 dedup. error 만 별도로 노출되지 않으므로 useWorkspaces 한 번 더 호출.
+  const { error } = useWorkspaces();
+  const { activeWorkspace, isLoading } = useActiveWorkspace();
 
-  // 첫 로그인 후 워크스페이스가 없으면 자동 안내, 1+ 있으면 첫 번째를 활성으로 표시
-  const activeWorkspace: Workspace | undefined = workspaces[0];
   const isOwner = !!user?.uid && activeWorkspace?.ownerId === user.uid;
 
   const {
@@ -158,6 +161,7 @@ export default function WorkspaceSettingsScreen() {
   return (
     <SafeAreaView className="flex-1 bg-surface-page dark:bg-surface" edges={['top', 'bottom']}>
       <StackHeader title="워크스페이스" />
+      <WorkspaceContextBar />
       <ScrollView contentContainerClassName="pb-8">
         {/* 워크스페이스 헤더 */}
         <View className="border-b border-secondary-200 bg-white px-4 py-5 dark:border-surface-overlay dark:bg-surface">

--- a/uniqn-mobile/src/components/workspace/WorkspaceContextBar.tsx
+++ b/uniqn-mobile/src/components/workspace/WorkspaceContextBar.tsx
@@ -1,0 +1,35 @@
+/**
+ * UNIQN Mobile - WorkspaceContextBar
+ *
+ * @description 다중 워크스페이스 사용자에게만 표시되는 컨텍스트 바.
+ *              TabHeader/StackHeader 바로 아래에 배치하여 "지금 어느 워크스페이스를
+ *              보고 있는지" 시각적 단서를 제공.
+ *              (Phase 1B — workspace collaboration)
+ *
+ *              workspaces.length <= 1 이면 자동으로 렌더하지 않아 1개 사용자에게는
+ *              UI 노이즈가 없다.
+ * @version 1.0.0
+ */
+
+import { View } from 'react-native';
+import { useActiveWorkspace } from '@/hooks/workspace/useActiveWorkspace';
+import { WorkspaceSwitcher } from './WorkspaceSwitcher';
+
+interface WorkspaceContextBarProps {
+  /** 활성 워크스페이스 변경 시 호출. 화면 데이터 invalidate 등에 사용. */
+  onChange?: (workspaceId: string) => void;
+}
+
+export function WorkspaceContextBar({ onChange }: WorkspaceContextBarProps) {
+  const { workspaces } = useActiveWorkspace();
+
+  if (workspaces.length <= 1) return null;
+
+  return (
+    <View className="border-b border-secondary-200 bg-white px-2 py-1 dark:border-surface-overlay dark:bg-surface">
+      <WorkspaceSwitcher onChange={onChange} />
+    </View>
+  );
+}
+
+export default WorkspaceContextBar;

--- a/uniqn-mobile/src/components/workspace/WorkspaceSwitcher.tsx
+++ b/uniqn-mobile/src/components/workspace/WorkspaceSwitcher.tsx
@@ -1,0 +1,177 @@
+/**
+ * UNIQN Mobile - WorkspaceSwitcher
+ *
+ * @description 다중 워크스페이스 사용자가 활성 워크스페이스를 전환하는 BottomSheet.
+ *              단일 워크스페이스 사용자는 텍스트만 표시 (전환 불가능 → BottomSheet 비활성).
+ *              (Phase 1B — workspace collaboration)
+ *
+ * 디자인:
+ *   - 최소 터치 타깃 44px (impeccable §5)
+ *   - Pressed 피드백 다크/라이트 반대 방향 (impeccable §21)
+ *   - Focus ring Info 블루 #2563EB 2px (impeccable §22)
+ *   - 골드 사용 0회 (active 표시는 CheckIcon 만)
+ * @version 1.0.0
+ */
+
+import { useState, useCallback } from 'react';
+import { Modal, Pressable, Text, View, ScrollView } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { ChevronDownIcon, CheckIcon, XMarkIcon } from '@/components/icons';
+import { Badge } from '@/components/ui';
+import { useAuthStore } from '@/stores/authStore';
+import { useActiveWorkspace } from '@/hooks/workspace/useActiveWorkspace';
+import { triggerHaptic } from '@/utils/haptics';
+import type { Workspace } from '@/types/workspace';
+
+interface WorkspaceSwitcherProps {
+  /** 외부에서 활성 워크스페이스 변경을 알아야 할 때 콜백 */
+  onChange?: (workspaceId: string) => void;
+}
+
+export function WorkspaceSwitcher({ onChange }: WorkspaceSwitcherProps) {
+  const { user } = useAuthStore();
+  const { activeWorkspace, workspaces, setActiveWorkspaceId } = useActiveWorkspace();
+  const [open, setOpen] = useState(false);
+  const insets = useSafeAreaInsets();
+
+  const isOwnerOf = useCallback(
+    (w: Workspace) => Boolean(user?.uid) && w.ownerId === user!.uid,
+    [user?.uid]
+  );
+
+  const handleSelect = useCallback(
+    (workspaceId: string) => {
+      triggerHaptic('light');
+      setActiveWorkspaceId(workspaceId);
+      onChange?.(workspaceId);
+      setOpen(false);
+    },
+    [setActiveWorkspaceId, onChange]
+  );
+
+  // 0개: 표시 안 함 (이 화면 진입 자체가 안내 화면으로 막힘)
+  if (workspaces.length === 0) return null;
+
+  // 1개: 텍스트만 (BottomSheet 불필요)
+  if (workspaces.length === 1) {
+    return (
+      <View
+        className="min-h-[44px] flex-row items-center px-2 py-2"
+        accessibilityRole="text"
+        accessibilityLabel={`현재 워크스페이스 ${activeWorkspace?.name ?? ''}`}
+      >
+        <Text
+          className="text-base font-sans-medium text-content-primary"
+          numberOfLines={1}
+          maxFontSizeMultiplier={1.5}
+        >
+          {activeWorkspace?.name ?? ''}
+        </Text>
+      </View>
+    );
+  }
+
+  // 2개+: 전환 가능 dropdown
+  return (
+    <>
+      <Pressable
+        onPress={() => {
+          triggerHaptic('light');
+          setOpen(true);
+        }}
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel={`현재 워크스페이스 ${activeWorkspace?.name ?? ''}, 변경하려면 탭`}
+        accessibilityHint="워크스페이스 선택 시트가 열립니다"
+        className="min-h-[44px] flex-row items-center gap-2 px-2 py-2"
+      >
+        {({ pressed }) => (
+          <View
+            className={`flex-row items-center gap-2 rounded-md px-2 py-1 ${
+              pressed ? 'bg-surface-overlay dark:bg-surface-elevated' : ''
+            }`}
+          >
+            <Text
+              className="text-base font-sans-medium text-content-primary"
+              numberOfLines={1}
+              maxFontSizeMultiplier={1.5}
+            >
+              {activeWorkspace?.name ?? '워크스페이스 선택'}
+            </Text>
+            <ChevronDownIcon size={16} />
+          </View>
+        )}
+      </Pressable>
+
+      <Modal visible={open} transparent animationType="slide" onRequestClose={() => setOpen(false)}>
+        <View className="flex-1 justify-end">
+          <Pressable
+            className="flex-1 bg-black/40"
+            onPress={() => setOpen(false)}
+            accessibilityRole="button"
+            accessibilityLabel="시트 닫기"
+          />
+          <View
+            className="rounded-t-md bg-surface-card dark:bg-surface-elevated"
+            style={{ paddingBottom: insets.bottom + 12 }}
+          >
+            <View className="flex-row items-center justify-between px-6 pb-2 pt-4">
+              <Text className="text-sm font-sans-medium text-content-secondary">
+                워크스페이스 선택
+              </Text>
+              <Pressable
+                onPress={() => setOpen(false)}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel="닫기"
+                className="min-h-[44px] min-w-[44px] items-center justify-center"
+              >
+                <XMarkIcon size={20} />
+              </Pressable>
+            </View>
+            <ScrollView style={{ maxHeight: 360 }}>
+              {workspaces.map((w) => {
+                const isActive = w.id === activeWorkspace?.id;
+                return (
+                  <Pressable
+                    key={w.id}
+                    onPress={() => handleSelect(w.id)}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: isActive }}
+                    accessibilityLabel={`${w.name} ${isOwnerOf(w) ? '소유' : '공동관리'}${
+                      isActive ? ', 현재 활성' : ''
+                    }`}
+                    className="min-h-[44px] flex-row items-center justify-between px-6 py-3"
+                  >
+                    {({ pressed }) => (
+                      <View
+                        className={`flex-1 flex-row items-center justify-between gap-3 rounded-sm px-1 py-1 ${
+                          pressed ? 'bg-surface-overlay dark:bg-surface-card' : ''
+                        }`}
+                      >
+                        <View className="flex-1 flex-row items-center gap-2">
+                          <Text
+                            className="flex-shrink text-base text-content-primary"
+                            numberOfLines={1}
+                          >
+                            {w.name}
+                          </Text>
+                          <Badge variant={isOwnerOf(w) ? 'warning' : 'info'} size="sm">
+                            {isOwnerOf(w) ? '소유' : '공동관리'}
+                          </Badge>
+                        </View>
+                        {isActive ? <CheckIcon size={18} /> : null}
+                      </View>
+                    )}
+                  </Pressable>
+                );
+              })}
+            </ScrollView>
+          </View>
+        </View>
+      </Modal>
+    </>
+  );
+}
+
+export default WorkspaceSwitcher;

--- a/uniqn-mobile/src/components/workspace/WorkspaceSwitcher.tsx
+++ b/uniqn-mobile/src/components/workspace/WorkspaceSwitcher.tsx
@@ -29,14 +29,14 @@ interface WorkspaceSwitcherProps {
 }
 
 export function WorkspaceSwitcher({ onChange }: WorkspaceSwitcherProps) {
-  const { user } = useAuthStore();
+  const userId = useAuthStore((s) => s.user?.uid);
   const { activeWorkspace, workspaces, setActiveWorkspaceId } = useActiveWorkspace();
   const [open, setOpen] = useState(false);
   const insets = useSafeAreaInsets();
 
   const isOwnerOf = useCallback(
-    (w: Workspace) => Boolean(user?.uid) && w.ownerId === user!.uid,
-    [user?.uid]
+    (w: Workspace) => Boolean(userId) && w.ownerId === userId,
+    [userId]
   );
 
   const handleSelect = useCallback(

--- a/uniqn-mobile/src/components/workspace/__tests__/WorkspaceSwitcher.test.tsx
+++ b/uniqn-mobile/src/components/workspace/__tests__/WorkspaceSwitcher.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+import { WorkspaceSwitcher } from '../WorkspaceSwitcher';
+
+const mockSetActiveWorkspaceId = jest.fn();
+let mockHookReturn: {
+  activeWorkspace: any;
+  workspaces: any[];
+  isLoading: boolean;
+  setActiveWorkspaceId: (id: string) => void;
+};
+
+jest.mock('@/hooks/workspace/useActiveWorkspace', () => ({
+  useActiveWorkspace: () => mockHookReturn,
+}));
+
+jest.mock('@/stores/authStore', () => ({
+  useAuthStore: (selector?: any) => {
+    const state = { user: { uid: 'user-1' } };
+    return selector ? selector(state) : state;
+  },
+}));
+
+jest.mock('@/utils/haptics', () => ({
+  triggerHaptic: jest.fn(),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const W = (overrides: { id: string; name: string; ownerId: string }) => ({
+  id: overrides.id,
+  name: overrides.name,
+  ownerId: overrides.ownerId,
+  memberCount: 0,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+});
+
+describe('WorkspaceSwitcher', () => {
+  beforeEach(() => {
+    mockSetActiveWorkspaceId.mockClear();
+  });
+
+  it('워크스페이스가 0개면 아무것도 렌더하지 않는다', () => {
+    mockHookReturn = {
+      activeWorkspace: undefined,
+      workspaces: [],
+      isLoading: false,
+      setActiveWorkspaceId: mockSetActiveWorkspaceId,
+    };
+    const { toJSON } = render(<WorkspaceSwitcher />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('워크스페이스가 1개면 텍스트만 표시 (BottomSheet 미노출)', () => {
+    const ws = W({ id: 'ws-1', name: '내 워크스페이스', ownerId: 'user-1' });
+    mockHookReturn = {
+      activeWorkspace: ws,
+      workspaces: [ws],
+      isLoading: false,
+      setActiveWorkspaceId: mockSetActiveWorkspaceId,
+    };
+    const { getByText, queryByLabelText } = render(<WorkspaceSwitcher />);
+    expect(getByText('내 워크스페이스')).toBeTruthy();
+    expect(queryByLabelText(/변경하려면 탭/)).toBeNull();
+  });
+
+  it('워크스페이스가 2개+이면 transfer 버튼 노출', () => {
+    const owned = W({ id: 'ws-1', name: '내 룸', ownerId: 'user-1' });
+    const shared = W({ id: 'ws-2', name: '공동 룸', ownerId: 'other' });
+    mockHookReturn = {
+      activeWorkspace: owned,
+      workspaces: [owned, shared],
+      isLoading: false,
+      setActiveWorkspaceId: mockSetActiveWorkspaceId,
+    };
+    const { getByLabelText } = render(<WorkspaceSwitcher />);
+    expect(getByLabelText(/현재 워크스페이스 내 룸, 변경하려면 탭/)).toBeTruthy();
+  });
+
+  it('다른 워크스페이스 선택 시 setActiveWorkspaceId + onChange 콜백 호출', () => {
+    const owned = W({ id: 'ws-1', name: '내 룸', ownerId: 'user-1' });
+    const shared = W({ id: 'ws-2', name: '공동 룸', ownerId: 'other' });
+    mockHookReturn = {
+      activeWorkspace: owned,
+      workspaces: [owned, shared],
+      isLoading: false,
+      setActiveWorkspaceId: mockSetActiveWorkspaceId,
+    };
+    const onChange = jest.fn();
+    const { getByLabelText } = render(<WorkspaceSwitcher onChange={onChange} />);
+    fireEvent.press(getByLabelText(/현재 워크스페이스 내 룸, 변경하려면 탭/));
+    fireEvent.press(getByLabelText(/공동 룸 공동관리/));
+
+    expect(mockSetActiveWorkspaceId).toHaveBeenCalledWith('ws-2');
+    expect(onChange).toHaveBeenCalledWith('ws-2');
+  });
+});

--- a/uniqn-mobile/src/components/workspace/index.ts
+++ b/uniqn-mobile/src/components/workspace/index.ts
@@ -1,0 +1,8 @@
+/**
+ * UNIQN Mobile - Workspace Components Barrel
+ *
+ * @description Phase 1+ workspace 협업 UI 컴포넌트
+ */
+
+export { WorkspaceSwitcher } from './WorkspaceSwitcher';
+export { WorkspaceContextBar } from './WorkspaceContextBar';

--- a/uniqn-mobile/src/hooks/workspace/index.ts
+++ b/uniqn-mobile/src/hooks/workspace/index.ts
@@ -23,3 +23,5 @@ export {
   type UseReceivedInvitationsResult,
   type UseSentInvitationsResult,
 } from './useWorkspaces';
+
+export { useActiveWorkspace, type UseActiveWorkspaceResult } from './useActiveWorkspace';

--- a/uniqn-mobile/src/hooks/workspace/useActiveWorkspace.ts
+++ b/uniqn-mobile/src/hooks/workspace/useActiveWorkspace.ts
@@ -1,0 +1,58 @@
+/**
+ * UNIQN Mobile - useActiveWorkspace Hook
+ *
+ * @description 다중 워크스페이스 — store 의 activeWorkspaceId 를 listForUser 결과와
+ *              매칭하고 자동 자기-치유 (orphan id → 첫 번째로 fallback) 수행.
+ *              (Phase 1B — workspace collaboration)
+ * @version 1.0.0
+ */
+
+import { useEffect } from 'react';
+import { useWorkspaces } from './useWorkspaces';
+import {
+  useActiveWorkspaceStore,
+  selectActiveWorkspaceId,
+  selectSetActiveWorkspaceId,
+} from '@/stores/activeWorkspaceStore';
+import type { Workspace } from '@/types/workspace';
+
+export interface UseActiveWorkspaceResult {
+  activeWorkspace: Workspace | undefined;
+  /** 사용자가 속한 모든 워크스페이스 (소유 + 멤버) */
+  workspaces: Workspace[];
+  isLoading: boolean;
+  /** 사용자가 활성 워크스페이스 변경 */
+  setActiveWorkspaceId: (id: string | null) => void;
+}
+
+/**
+ * 활성 워크스페이스 selector hook.
+ *
+ * - store 에 activeWorkspaceId 가 없거나, 사용자가 더 이상 속하지 않는 워크스페이스를
+ *   가리키면 자동으로 listForUser 의 첫 번째로 fallback (회수당한 후 재로그인 시나리오 대응).
+ * - workspaces.length === 0 인 동안에는 activeWorkspace = undefined.
+ */
+export function useActiveWorkspace(): UseActiveWorkspaceResult {
+  const { workspaces, isLoading } = useWorkspaces();
+  const activeId = useActiveWorkspaceStore(selectActiveWorkspaceId);
+  const setActiveWorkspaceId = useActiveWorkspaceStore(selectSetActiveWorkspaceId);
+
+  useEffect(() => {
+    if (workspaces.length === 0) return;
+    const isOrphan = !activeId || !workspaces.some((w) => w.id === activeId);
+    if (isOrphan) {
+      setActiveWorkspaceId(workspaces[0]!.id);
+    }
+  }, [workspaces, activeId, setActiveWorkspaceId]);
+
+  const activeWorkspace =
+    workspaces.find((w) => w.id === activeId) ??
+    (workspaces.length > 0 ? workspaces[0] : undefined);
+
+  return {
+    activeWorkspace,
+    workspaces,
+    isLoading,
+    setActiveWorkspaceId,
+  };
+}

--- a/uniqn-mobile/src/stores/__tests__/activeWorkspaceStore.test.ts
+++ b/uniqn-mobile/src/stores/__tests__/activeWorkspaceStore.test.ts
@@ -1,0 +1,47 @@
+/**
+ * UNIQN Mobile - Active Workspace Store Tests
+ *
+ * @description 다중 워크스페이스 — 현재 활성 워크스페이스 ID 추적
+ */
+
+import { act } from '@testing-library/react-native';
+import { useActiveWorkspaceStore } from '../activeWorkspaceStore';
+
+function resetStore() {
+  act(() => {
+    useActiveWorkspaceStore.setState({ activeWorkspaceId: null });
+  });
+}
+
+describe('activeWorkspaceStore', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it('초기 상태는 null', () => {
+    expect(useActiveWorkspaceStore.getState().activeWorkspaceId).toBeNull();
+  });
+
+  it('setActiveWorkspaceId 로 활성 ID 설정', () => {
+    act(() => {
+      useActiveWorkspaceStore.getState().setActiveWorkspaceId('ws-1');
+    });
+    expect(useActiveWorkspaceStore.getState().activeWorkspaceId).toBe('ws-1');
+  });
+
+  it('setActiveWorkspaceId(null) 로 초기화', () => {
+    act(() => {
+      useActiveWorkspaceStore.getState().setActiveWorkspaceId('ws-1');
+      useActiveWorkspaceStore.getState().setActiveWorkspaceId(null);
+    });
+    expect(useActiveWorkspaceStore.getState().activeWorkspaceId).toBeNull();
+  });
+
+  it('clear 로 null 로 리셋', () => {
+    act(() => {
+      useActiveWorkspaceStore.getState().setActiveWorkspaceId('ws-1');
+      useActiveWorkspaceStore.getState().clear();
+    });
+    expect(useActiveWorkspaceStore.getState().activeWorkspaceId).toBeNull();
+  });
+});

--- a/uniqn-mobile/src/stores/activeWorkspaceStore.ts
+++ b/uniqn-mobile/src/stores/activeWorkspaceStore.ts
@@ -1,0 +1,60 @@
+/**
+ * UNIQN Mobile - Active Workspace Store
+ *
+ * @description 다중 워크스페이스 사용자가 현재 활성으로 보고 있는 워크스페이스 ID 를
+ *              추적. zustand persist + mmkvStorage 로 앱 재시작 후에도 유지.
+ *              (Phase 1B — workspace collaboration)
+ *
+ *              자동 자기-치유 (selectedId 가 listForUser 에 없으면 첫 번째로 fallback)
+ *              은 useActiveWorkspace selector hook 에서 처리.
+ * @version 1.0.0
+ */
+
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { mmkvStorage } from '@/lib/mmkvStorage';
+import { logger } from '@/utils/logger';
+
+interface ActiveWorkspaceState {
+  /** 사용자가 마지막으로 선택한 워크스페이스 ID. 미선택 또는 비로그인 시 null. */
+  activeWorkspaceId: string | null;
+  /** Hydration 완료 여부 */
+  _hasHydrated: boolean;
+}
+
+interface ActiveWorkspaceActions {
+  setActiveWorkspaceId: (id: string | null) => void;
+  clear: () => void;
+  setHasHydrated: (state: boolean) => void;
+}
+
+type ActiveWorkspaceStore = ActiveWorkspaceState & ActiveWorkspaceActions;
+
+export const useActiveWorkspaceStore = create<ActiveWorkspaceStore>()(
+  persist(
+    (set) => ({
+      activeWorkspaceId: null,
+      _hasHydrated: false,
+      setActiveWorkspaceId: (id) => set({ activeWorkspaceId: id }),
+      clear: () => set({ activeWorkspaceId: null }),
+      setHasHydrated: (state) => set({ _hasHydrated: state }),
+    }),
+    {
+      name: 'uniqn-active-workspace',
+      storage: createJSONStorage(() => mmkvStorage),
+      partialize: (state) => ({
+        activeWorkspaceId: state.activeWorkspaceId,
+      }),
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated(true);
+        logger.debug('활성 워크스페이스 스토어 복원 완료', {
+          activeWorkspaceId: state?.activeWorkspaceId ?? null,
+        });
+      },
+    }
+  )
+);
+
+export const selectActiveWorkspaceId = (state: ActiveWorkspaceStore) => state.activeWorkspaceId;
+export const selectSetActiveWorkspaceId = (state: ActiveWorkspaceStore) =>
+  state.setActiveWorkspaceId;


### PR DESCRIPTION
## Summary

다중 워크스페이스 사용자가 활성 워크스페이스를 자유롭게 전환할 수 있도록 하는 UI 인프라.

- **`activeWorkspaceStore`** — zustand persist + mmkvStorage 로 활성 워크스페이스 ID 추적 (앱 재시작 후 유지)
- **`useActiveWorkspace`** — `useWorkspaces` 와 store 결합. orphan ID (사용자가 회수당한 워크스페이스 가리킴) 자동 자기-치유
- **`WorkspaceSwitcher`** — 1개 사용자 텍스트만, 2개+ BottomSheet dropdown. 소유/공동관리 Badge + active CheckIcon
- **`WorkspaceContextBar`** — 헤더 직하 컨텍스트 바 헬퍼. 1개 사용자에게는 자동 숨김 (UI 노이즈 0)

### 적용 위치

- `app/(app)/(tabs)/employer.tsx` (employer 대시보드 탭)
- `app/(employer)/workspace/index.tsx` (워크스페이스 설정 — `workspaces[0]` → `useActiveWorkspace`)

### 디자인 컨벤션 준수

- 44px 터치 타깃 (impeccable §5)
- Pressed 피드백 다크/라이트 반대 방향 (impeccable §21)
- 골드 사용 0회 — active 표시는 CheckIcon 만 (impeccable §3)
- accessibilityState selected 포함, accessibilityLabel 풀 컨텍스트

### 의존성

- Phase 0 (PR #57) 머지 완료 — 무료 공고 INSERT workspace_id 주입 hotfix
- 후속: Phase 1A (회수 가드) 가 같은 release window 에 들어와 `useActiveWorkspace` 채택

## Test plan

- [x] `npm run quality` — 0 errors, 0 warnings (PressableCard 기존 1건 무관)
- [x] `npx jest src/components/workspace src/stores/__tests__/activeWorkspaceStore.test.ts` — 8/8 PASS
- [x] regression 8건 (`JobPostingRepository.workspace.regression.test.ts`) — 8/8 PASS (owner contract 무변경)
- [ ] staging 다중 워크스페이스 사용자: 전환 → 앱 재시작 → 활성 워크스페이스 유지
- [ ] staging 1개 워크스페이스 사용자: Switcher 텍스트만 표시 (UI 노이즈 0)

## 후속

- Phase 1A: 회수 Modal + 5초 자동 로그아웃 (별도 PR — release window 매칭)

🤖 Generated with [Claude Code](https://claude.com/claude-code)