### PR TITLE
feat(workspace): Phase 2A + 3A — Service workspace화 + applications RLS

### DIFF
--- a/uniqn-mobile/app/(employer)/my-postings/[id]/_layout.tsx
+++ b/uniqn-mobile/app/(employer)/my-postings/[id]/_layout.tsx
@@ -15,8 +15,9 @@ import { QRCodeIcon } from '@/components/icons';
 import { useAuthStore } from '@/stores/authStore';
 import { useThemeStore } from '@/stores/themeStore';
 import { useToastStore } from '@/stores/toastStore';
+import { useWorkspaces } from '@/hooks/workspace';
 import { getLayoutColor, SECONDARY_PALETTE } from '@/constants/colors';
-import { isEmployerManageablePosting } from '@/utils/jobPostingVisibility';
+import { isEmployerManageablePosting, isManageableByUser } from '@/utils/jobPostingVisibility';
 import type { JobPosting } from '@/types';
 
 // ============================================================================
@@ -109,6 +110,8 @@ export default function JobPostingDetailLayout() {
   const isDark = useThemeStore((s) => s.isDarkMode);
   const { addToast } = useToastStore();
   const { job } = useJobDetail(id || '', { realtime: true });
+  const { workspaces } = useWorkspaces();
+  const userWorkspaceIds = useMemo(() => workspaces.map((w) => w.id), [workspaces]);
   const [showQRModal, setShowQRModal] = useState(false);
 
   const isFixed = job?.schedule.kind === 'fixed';
@@ -134,10 +137,11 @@ export default function JobPostingDetailLayout() {
       return;
     }
 
-    if (currentUserId && job.ownerId !== currentUserId) {
+    // Phase 2A — owner OR 워크스페이스 멤버 가능. RLS 가 진짜 게이트.
+    if (currentUserId && !isManageableByUser(job, currentUserId, userWorkspaceIds)) {
       addToast({
         type: 'warning',
-        message: '내가 작성한 공고만 관리할 수 있습니다.',
+        message: '이 공고에 대한 관리 권한이 없어요.',
       });
       router.replace('/(app)/(tabs)/employer');
       return;
@@ -152,7 +156,7 @@ export default function JobPostingDetailLayout() {
       message: '현재 관리 화면에서 지원하지 않는 공고입니다.',
     });
     router.replace('/(app)/(tabs)/employer');
-  }, [addToast, currentUserId, job, router]);
+  }, [addToast, currentUserId, job, router, userWorkspaceIds]);
 
   const contextValue = useMemo<JobDetailContextValue>(
     () => ({
@@ -165,7 +169,8 @@ export default function JobPostingDetailLayout() {
 
   if (
     job &&
-    ((currentUserId && job.ownerId !== currentUserId) || !isEmployerManageablePosting(job))
+    ((currentUserId && !isManageableByUser(job, currentUserId, userWorkspaceIds)) ||
+      !isEmployerManageablePosting(job))
   ) {
     return null;
   }

--- a/uniqn-mobile/src/repositories/interfaces/IJobPostingRepository.ts
+++ b/uniqn-mobile/src/repositories/interfaces/IJobPostingRepository.ts
@@ -130,6 +130,16 @@ export interface IJobPostingRepository {
   getByOwnerId(ownerId: string, status?: JobPostingStatus): Promise<JobPosting[]>;
 
   /**
+   * 호출자가 owner 이거나 활성 워크스페이스 멤버인 모든 공고를 RLS 통과로 조회.
+   *
+   * Phase 2A — 공고 공유 (editor 화면) 용도. RLS jp_select 가
+   * `owner_id = auth.uid() OR is_workspace_member(workspace_id, auth.uid())`
+   * 분기를 강제하므로 클라이언트는 status filter 만 추가하고 user_id WHERE 는
+   * 사용하지 않는다 (auth.uid() 단일 진실 — client uid 신뢰 불가).
+   */
+  getManagedJobPostings(status?: JobPostingStatus): Promise<JobPosting[]>;
+
+  /**
    * 공고 타입별 개수 조회
    * @param filters - 필터 조건 (status 등)
    * @returns 타입별 개수

--- a/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
@@ -295,6 +295,29 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
     }
   }
 
+  /**
+   * Phase 2A — 호출자가 owner 또는 워크스페이스 멤버인 모든 공고 조회.
+   *
+   * RLS jp_select 가 `owner_id = auth.uid() OR is_workspace_member(workspace_id, auth.uid())`
+   * 분기를 강제하므로 client 는 status filter 만 추가. user_id WHERE 는
+   * 의도적으로 사용 안 함 (client uid 와 auth.uid() 가 다를 위험 — 보안상 신뢰 불가).
+   */
+  async getManagedJobPostings(status?: JobPostingStatus): Promise<JobPosting[]> {
+    try {
+      logger.info('관리 가능 공고 조회', { status });
+      let query = supabase.from(TABLE).select(TABLE_COLUMNS);
+      if (status) query = query.eq('status', status);
+      query = query.order('created_at', { ascending: false });
+      const { data, error } = await query;
+      if (error) handleSupabaseError(error, { operation: '관리 가능 공고 조회', table: TABLE });
+      const items = rowsToJobPostings((data ?? []) as Record<string, unknown>[]);
+      logger.info('관리 가능 공고 조회 완료', { count: items.length });
+      return items;
+    } catch (error) {
+      rethrowOrHandle(error, '관리 가능 공고 조회', { status });
+    }
+  }
+
   async getTypeCounts(filters?: Pick<JobPostingFilters, 'status'>): Promise<PostingTypeCounts> {
     try {
       logger.info('공고 타입별 개수 조회', { filters });

--- a/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.workspace.editor.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.workspace.editor.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Phase 2A — JobPostingRepository.getManagedJobPostings editor contract test
+ *
+ * @description editor 가 활성 워크스페이스의 owner 공고를 RLS jp_select 통과로 조회.
+ *              client 는 status filter 만 추가, user_id WHERE 는 사용 안 함
+ *              (auth.uid() 가 RLS 단일 진실 — client uid 신뢰 불가).
+ *
+ * 본 테스트는 contract level (Supabase 호출 패턴) 만 검증.
+ */
+
+import { SupabaseJobPostingRepository } from '../JobPostingRepository';
+
+// ── Mock Supabase ────────────────────────────────────────────────────────────
+const mockFrom = jest.fn();
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    rpc: jest.fn(),
+    channel: jest.fn(),
+  },
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('@/utils/supabase', () => {
+  const actual = jest.requireActual('@/utils/supabase');
+  return {
+    ...actual,
+    handleSupabaseError: (error: { message?: string } | null) => {
+      if (error) throw new Error(`supabase: ${error.message ?? 'unknown'}`);
+    },
+  };
+});
+
+jest.mock('@sentry/react-native', () => ({
+  __esModule: true,
+  addBreadcrumb: jest.fn(),
+}));
+
+function makeChain(returnValue: { data: unknown; error: unknown }) {
+  const chain: Record<string, unknown> = {};
+  for (const m of [
+    'select',
+    'eq',
+    'in',
+    'is',
+    'order',
+    'limit',
+    'range',
+    'update',
+    'insert',
+    'delete',
+    'upsert',
+    'gte',
+    'lte',
+    'gt',
+    'lt',
+    'neq',
+    'contains',
+    'overlaps',
+    'or',
+    'and',
+    'not',
+    'filter',
+    'match',
+    'returns',
+  ]) {
+    chain[m] = jest.fn(() => chain);
+  }
+  for (const m of ['single', 'maybeSingle', 'csv']) {
+    chain[m] = jest.fn(() => Promise.resolve(returnValue));
+  }
+  (chain as { then?: unknown }).then = function then<TResult1 = unknown, TResult2 = never>(
+    onfulfilled?: ((value: unknown) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): PromiseLike<TResult1 | TResult2> {
+    return Promise.resolve(returnValue).then(onfulfilled, onrejected);
+  };
+  return chain as Record<string, jest.Mock> & PromiseLike<unknown>;
+}
+
+beforeEach(() => {
+  mockFrom.mockReset();
+});
+
+describe('JobPostingRepository.getManagedJobPostings — Phase 2A editor contract', () => {
+  const repo = new SupabaseJobPostingRepository();
+
+  it('Supabase from(job_postings) + status filter + order(created_at desc) 호출', async () => {
+    const chain = makeChain({ data: [], error: null });
+    mockFrom.mockReturnValueOnce(chain);
+
+    await repo.getManagedJobPostings('active');
+
+    expect(mockFrom).toHaveBeenCalledWith('job_postings');
+    expect(chain.eq).toHaveBeenCalledWith('status', 'active');
+    expect(chain.order).toHaveBeenCalledWith('created_at', { ascending: false });
+  });
+
+  it('status 미지정 시 status filter 추가 안 함 (RLS jp_select 가 status 필터 분기)', async () => {
+    const chain = makeChain({ data: [], error: null });
+    mockFrom.mockReturnValueOnce(chain);
+
+    await repo.getManagedJobPostings();
+
+    expect(chain.eq).not.toHaveBeenCalled();
+    expect(chain.order).toHaveBeenCalledWith('created_at', { ascending: false });
+  });
+
+  it('client 는 owner_id WHERE 를 추가하지 않음 (RLS auth.uid() 단일 진실)', async () => {
+    const chain = makeChain({ data: [], error: null });
+    mockFrom.mockReturnValueOnce(chain);
+
+    await repo.getManagedJobPostings('active');
+
+    const eqCalls = chain.eq.mock.calls.map((call) => call[0]);
+    expect(eqCalls).not.toContain('owner_id');
+    expect(eqCalls).not.toContain('user_id');
+  });
+
+  it('빈 결과 시에도 정상 종료 (RLS 가 0 row 반환 → 빈 배열)', async () => {
+    const chain = makeChain({ data: [], error: null });
+    mockFrom.mockReturnValueOnce(chain);
+
+    const result = await repo.getManagedJobPostings('active');
+    expect(result).toEqual([]);
+  });
+
+  it('error 응답 시 handleSupabaseError 트리거', async () => {
+    const chain = makeChain({ data: null, error: { message: 'permission denied' } });
+    mockFrom.mockReturnValueOnce(chain);
+
+    await expect(repo.getManagedJobPostings('active')).rejects.toThrow(/permission denied/);
+  });
+});

--- a/uniqn-mobile/src/services/jobs/__tests__/jobService.test.ts
+++ b/uniqn-mobile/src/services/jobs/__tests__/jobService.test.ts
@@ -37,6 +37,7 @@ jest.mock('@/repositories', () => ({
     getList: jest.fn(),
     getById: jest.fn(),
     getByOwnerId: jest.fn(),
+    getManagedJobPostings: jest.fn(),
     incrementViewCount: jest.fn(),
   },
 }));
@@ -448,16 +449,17 @@ describe('JobService', () => {
       const activeJobs = [createMockJobPosting({ id: 'active-1', status: 'active' })];
       const closedJobs = [createMockJobPosting({ id: 'closed-1', status: 'closed' })];
 
-      mockRepo.getByOwnerId
+      mockRepo.getManagedJobPostings
         .mockResolvedValueOnce(activeJobs as any)
         .mockResolvedValueOnce(closedJobs as any);
 
       const result = await getMyJobPostings('owner-1');
 
       expect(result).toHaveLength(2);
-      expect(mockRepo.getByOwnerId).toHaveBeenCalledTimes(2);
-      expect(mockRepo.getByOwnerId).toHaveBeenNthCalledWith(1, 'owner-1', 'active');
-      expect(mockRepo.getByOwnerId).toHaveBeenNthCalledWith(2, 'owner-1', 'closed');
+      expect(mockRepo.getManagedJobPostings).toHaveBeenCalledTimes(2);
+      // Phase 2A: ownerId 파라미터 제거 — RLS auth.uid() 가 단일 진실
+      expect(mockRepo.getManagedJobPostings).toHaveBeenNthCalledWith(1, 'active');
+      expect(mockRepo.getManagedJobPostings).toHaveBeenNthCalledWith(2, 'closed');
     });
 
     it('should merge active and closed postings results', async () => {
@@ -467,7 +469,7 @@ describe('JobService', () => {
       ];
       const closedJobs = [createMockJobPosting({ id: 'c1', status: 'closed' })];
 
-      mockRepo.getByOwnerId
+      mockRepo.getManagedJobPostings
         .mockResolvedValueOnce(activeJobs as any)
         .mockResolvedValueOnce(closedJobs as any);
 
@@ -493,7 +495,9 @@ describe('JobService', () => {
         }),
       ];
 
-      mockRepo.getByOwnerId.mockResolvedValueOnce(activeJobs as any).mockResolvedValueOnce([]);
+      mockRepo.getManagedJobPostings
+        .mockResolvedValueOnce(activeJobs as any)
+        .mockResolvedValueOnce([]);
 
       const result = await getMyJobPostings('owner-1');
 
@@ -503,34 +507,34 @@ describe('JobService', () => {
 
     it('should filter by specific status when provided', async () => {
       const activeJobs = [createMockJobPosting({ id: 'a1', status: 'active' })];
-      mockRepo.getByOwnerId.mockResolvedValue(activeJobs as any);
+      mockRepo.getManagedJobPostings.mockResolvedValue(activeJobs as any);
 
       await getMyJobPostings('owner-1', { status: 'active' as any });
 
-      expect(mockRepo.getByOwnerId).toHaveBeenCalledTimes(1);
-      expect(mockRepo.getByOwnerId).toHaveBeenCalledWith('owner-1', 'active');
+      expect(mockRepo.getManagedJobPostings).toHaveBeenCalledTimes(1);
+      expect(mockRepo.getManagedJobPostings).toHaveBeenCalledWith('active');
     });
 
     it('should use active status as default when includeAll is false', async () => {
-      mockRepo.getByOwnerId.mockResolvedValue([]);
+      mockRepo.getManagedJobPostings.mockResolvedValue([]);
 
       await getMyJobPostings('owner-1', { includeAll: false });
 
-      expect(mockRepo.getByOwnerId).toHaveBeenCalledTimes(1);
-      expect(mockRepo.getByOwnerId).toHaveBeenCalledWith('owner-1', 'active');
+      expect(mockRepo.getManagedJobPostings).toHaveBeenCalledTimes(1);
+      expect(mockRepo.getManagedJobPostings).toHaveBeenCalledWith('active');
     });
 
     it('should only fetch specific status when both status and includeAll are set', async () => {
-      mockRepo.getByOwnerId.mockResolvedValue([]);
+      mockRepo.getManagedJobPostings.mockResolvedValue([]);
 
       await getMyJobPostings('owner-1', { status: 'closed' as any, includeAll: true });
 
-      expect(mockRepo.getByOwnerId).toHaveBeenCalledTimes(1);
-      expect(mockRepo.getByOwnerId).toHaveBeenCalledWith('owner-1', 'closed');
+      expect(mockRepo.getManagedJobPostings).toHaveBeenCalledTimes(1);
+      expect(mockRepo.getManagedJobPostings).toHaveBeenCalledWith('closed');
     });
 
     it('should return empty array when no postings found', async () => {
-      mockRepo.getByOwnerId.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+      mockRepo.getManagedJobPostings.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
       const result = await getMyJobPostings('owner-1');
 
@@ -539,25 +543,25 @@ describe('JobService', () => {
 
     it('should propagate errors via handleServiceError', async () => {
       const error = new Error('My postings failed');
-      mockRepo.getByOwnerId.mockRejectedValue(error);
+      mockRepo.getManagedJobPostings.mockRejectedValue(error);
       mockHandleServiceError.mockReturnValue(error);
 
       await expect(getMyJobPostings('owner-1')).rejects.toThrow('My postings failed');
       expect(mockHandleServiceError).toHaveBeenCalledWith(error, {
-        operation: '내 공고 조회',
+        operation: '관리 가능 공고 조회',
         component: 'jobService',
         context: { ownerId: 'owner-1' },
       });
     });
 
     it('should handle no options parameter', async () => {
-      mockRepo.getByOwnerId.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+      mockRepo.getManagedJobPostings.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
       const result = await getMyJobPostings('owner-1');
 
       expect(result).toEqual([]);
       // Default includeAll = true, no status => fetches both active and closed
-      expect(mockRepo.getByOwnerId).toHaveBeenCalledTimes(2);
+      expect(mockRepo.getManagedJobPostings).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -688,24 +692,24 @@ describe('JobService', () => {
   // getMyJobPostings - additional edge cases
   // ==========================================================================
   describe('getMyJobPostings - additional edge cases', () => {
-    it('should pass ownerId in both queries when includeAll', async () => {
-      mockRepo.getByOwnerId.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    it('should not pass ownerId to repo (RLS auth.uid() — Phase 2A)', async () => {
+      mockRepo.getManagedJobPostings.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
       await getMyJobPostings('owner-123');
 
-      const calls = mockRepo.getByOwnerId.mock.calls;
-      expect(calls[0]).toEqual(['owner-123', 'active']);
-      expect(calls[1]).toEqual(['owner-123', 'closed']);
+      const calls = mockRepo.getManagedJobPostings.mock.calls;
+      expect(calls[0]).toEqual(['active']);
+      expect(calls[1]).toEqual(['closed']);
     });
 
     it('should request active and closed statuses when includeAll', async () => {
-      mockRepo.getByOwnerId.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+      mockRepo.getManagedJobPostings.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
       await getMyJobPostings('owner-1');
 
-      const calls = mockRepo.getByOwnerId.mock.calls;
-      expect(calls[0]).toEqual(['owner-1', 'active']);
-      expect(calls[1]).toEqual(['owner-1', 'closed']);
+      const calls = mockRepo.getManagedJobPostings.mock.calls;
+      expect(calls[0]).toEqual(['active']);
+      expect(calls[1]).toEqual(['closed']);
     });
   });
 });

--- a/uniqn-mobile/src/services/jobs/jobService.ts
+++ b/uniqn-mobile/src/services/jobs/jobService.ts
@@ -221,6 +221,10 @@ export async function getUrgentJobPostings(pageSize: number = 10): Promise<JobPo
 
 /**
  * 내 공고 목록 조회 (구인자용)
+ *
+ * Phase 2A — owner 본인 공고 + 소속 워크스페이스 공유 공고를 함께 반환.
+ * RLS jp_select 가 (owner_id = auth.uid() OR workspace_member) 분기를 강제하므로
+ * client 는 status filter 만 추가. ownerId 파라미터는 logging context 에만 사용.
  */
 export async function getMyJobPostings(
   ownerId: string,
@@ -228,21 +232,21 @@ export async function getMyJobPostings(
 ): Promise<JobPosting[]> {
   try {
     const { status, includeAll = true } = options || {};
-    logger.info('내 공고 목록 조회', { ownerId, status, includeAll });
+    logger.info('관리 가능 공고 목록 조회', { ownerId, status, includeAll });
 
     // includeAll이 true면 모든 상태의 공고 조회 (active, closed)
     if (includeAll && !status) {
       const results = await Promise.all([
-        jobPostingRepository.getByOwnerId(ownerId, STATUS.JOB_POSTING.ACTIVE),
-        jobPostingRepository.getByOwnerId(ownerId, STATUS.JOB_POSTING.CLOSED),
+        jobPostingRepository.getManagedJobPostings(STATUS.JOB_POSTING.ACTIVE),
+        jobPostingRepository.getManagedJobPostings(STATUS.JOB_POSTING.CLOSED),
       ]);
       return [...results[0], ...results[1]];
     }
 
-    return jobPostingRepository.getByOwnerId(ownerId, status || STATUS.JOB_POSTING.ACTIVE);
+    return jobPostingRepository.getManagedJobPostings(status || STATUS.JOB_POSTING.ACTIVE);
   } catch (error) {
     throw handleServiceError(error, {
-      operation: '내 공고 조회',
+      operation: '관리 가능 공고 조회',
       component: 'jobService',
       context: { ownerId }, // ownerId 자동 마스킹
     });

--- a/uniqn-mobile/src/services/work/settlement/settlementQuery.ts
+++ b/uniqn-mobile/src/services/work/settlement/settlementQuery.ts
@@ -301,8 +301,9 @@ export async function getMySettlementSummary(
   try {
     logger.info('전체 정산 요약 조회', { ownerId, dateRange });
 
-    // 1. 내 공고 조회 (Repository 사용)
-    const jobPostings = (await jobPostingRepository.getByOwnerId(ownerId)).filter(
+    // 1. 관리 가능 공고 조회 — owner 본인 + 워크스페이스 멤버 공고 (RLS 통과)
+    // Phase 2A: getByOwnerId → getManagedJobPostings 로 전환
+    const jobPostings = (await jobPostingRepository.getManagedJobPostings()).filter(
       isCanonicalDatedPosting
     );
 

--- a/uniqn-mobile/src/utils/jobPostingVisibility.ts
+++ b/uniqn-mobile/src/utils/jobPostingVisibility.ts
@@ -43,3 +43,24 @@ export function isEmployerManageablePosting(
 ): boolean {
   return isSupportedReleasePosting(posting);
 }
+
+/**
+ * Phase 2A — 사용자가 공고를 "관리 (편집 / 마감 / 지원자 확정)" 할 수 있는지.
+ *
+ * UI 분기 전용 (라우트 가드 등). 실제 권한 게이트는 RLS jp_select / jp_update 가
+ * 단일 진실 — 본 함수는 클라이언트 사이드 가드일 뿐이며 RLS 가 차단할 수도 있다.
+ *
+ * @param job - 대상 공고
+ * @param userId - 현재 사용자 uid
+ * @param userWorkspaceIds - 사용자가 owner 또는 멤버인 워크스페이스 ID 목록
+ *                           (useWorkspaces.workspaces.map(w => w.id))
+ */
+export function isManageableByUser(
+  job: Pick<JobPosting, 'ownerId' | 'workspaceId'>,
+  userId: string,
+  userWorkspaceIds: string[]
+): boolean {
+  if (job.ownerId === userId) return true;
+  if (job.workspaceId && userWorkspaceIds.includes(job.workspaceId)) return true;
+  return false;
+}

--- a/uniqn-mobile/supabase/migrations/20260508150417_workspace_m4_applications_rls.sql
+++ b/uniqn-mobile/supabase/migrations/20260508150417_workspace_m4_applications_rls.sql
@@ -1,0 +1,44 @@
+-- Phase 3A — applications RLS 워크스페이스 멤버 분기
+--
+-- editor 가 공유 공고의 지원자를 SELECT/UPDATE 할 수 있도록 정책에 is_workspace_member
+-- 분기 추가. 기존 owner_id / applicant_id / admin 분기는 보존.
+--
+-- DOWN script (rollback) — 별도 migration 으로 적용:
+-- DROP POLICY IF EXISTS app_select ON public.applications;
+-- CREATE POLICY app_select ON public.applications FOR SELECT TO public
+--   USING (
+--     applicant_id = (SELECT auth.uid())
+--     OR (job_posting_id IN (SELECT id FROM public.job_postings WHERE owner_id = (SELECT auth.uid())))
+--     OR ((SELECT get_my_role()) = 'admin')
+--   );
+-- DROP POLICY IF EXISTS app_update ON public.applications;
+-- CREATE POLICY app_update ON public.applications FOR UPDATE TO public
+--   USING (
+--     applicant_id = (SELECT auth.uid())
+--     OR (job_posting_id IN (SELECT id FROM public.job_postings WHERE owner_id = (SELECT auth.uid())))
+--     OR ((SELECT get_my_role()) = 'admin')
+--   );
+
+DROP POLICY IF EXISTS app_select ON public.applications;
+CREATE POLICY app_select ON public.applications FOR SELECT TO public
+  USING (
+    applicant_id = (SELECT auth.uid())
+    OR (job_posting_id IN (
+      SELECT id FROM public.job_postings
+      WHERE owner_id = (SELECT auth.uid())
+        OR public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+    ))
+    OR ((SELECT get_my_role()) = 'admin')
+  );
+
+DROP POLICY IF EXISTS app_update ON public.applications;
+CREATE POLICY app_update ON public.applications FOR UPDATE TO public
+  USING (
+    applicant_id = (SELECT auth.uid())
+    OR (job_posting_id IN (
+      SELECT id FROM public.job_postings
+      WHERE owner_id = (SELECT auth.uid())
+        OR public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+    ))
+    OR ((SELECT get_my_role()) = 'admin')
+  );


### PR DESCRIPTION
## Summary

editor 가 활성 워크스페이스의 owner 공고를 조회/관리하고 지원자를 확정할 수 있도록
Service 레이어 + 클라이언트 가드 + applications RLS 를 entangled 로 변경.

> ⚠️ **Entangled — 단독으로 머지하면 silent failure 발생.**
> Phase 2A 만 머지: editor 가 \`getManagedJobPostings\` 호출 → RLS 통과 공고는 보이나
>                    applications 가 RLS app_select 차단으로 빈 결과 → 지원자 화면 공백.
> Phase 3A 만 머지: applications RLS 는 풀려도 client 는 여전히 \`getByOwnerId\` 만 호출.
> 두 변경을 같은 release window 에 묶음.

### 변경 (Phase 2A.1 — Repository)

- \`JobPostingRepository.getManagedJobPostings(status?)\` 신설
  * RLS jp_select 가 \`owner_id = auth.uid() OR is_workspace_member(...)\` 강제
  * client 는 status filter 만 추가, user_id WHERE 사용 안 함 (auth.uid() 단일 진실)
- 5건 contract test (status filter / order / no owner_id where / empty / error)

### 변경 (Phase 2A.2 — Service + Route Guard)

- \`jobService.getMyJobPostings\` → \`getManagedJobPostings\` (ownerId 파라미터는 logging context 만)
- \`settlementQuery.getMySettlementSummary\` → 동일 전환
- \`my-postings/[id]/_layout.tsx\` 라우트 가드: \`ownerId !== currentUserId\` → \`isManageableByUser(job, userId, workspaceIds)\`
- \`isManageableByUser\` helper 추가 (UI 분기 전용 — RLS 가 진짜 게이트)

### 변경 (Phase 3A — RLS Migration)

\`20260508150417_workspace_m4_applications_rls.sql\`:
- \`app_select\` / \`app_update\` 정책에 \`is_workspace_member(workspace_id, auth.uid())\` 분기
- DOWN script 주석으로 보존
- MCP \`apply_migration\` 으로 적용 완료
- workspace_members 인덱스 pre-flight 통과 (PK + idx_workspace_members_user_id)

## Test plan

- [x] \`npm run quality\` — 0 errors (PressableCard 기존 1 warning 무관)
- [x] \`npx jest\` — 3940/3942 PASS (사전 존재 scheduleService 2건 무관, 내 변경 0 regression)
  * regression 8 + editor contract 5 + jobService 43/43 = 56 직접 영향 PASS
- [x] Supabase advisors mode=performance ERROR 0건 (WARN/INFO 사전 존재)
- [x] Supabase advisors mode=security ERROR 0건
- [ ] staging editor 계정으로 공유 공고 진입 → 지원자 확정 → status='confirmed' 확인
- [ ] staging owner 흐름 회귀 — 본인 공고만 보이고 다른 워크스페이스 공고 안 섞임

## 의존성 / 후속

- Phase 1A (PR #59) / 1B (PR #58) 와 독립 — 병행 가능
- 다음 PR: Phase 3B (work_logs RLS) + 3C (event_qr_codes RLS)
- 1주 안정 후 Phase 3E/F (templates / settlements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)