### PR TITLE
feat(workspace): editor 권한 회수 가드 + Modal — Phase 1A (rebased)

### DIFF
--- a/uniqn-mobile/app/(employer)/_layout.tsx
+++ b/uniqn-mobile/app/(employer)/_layout.tsx
@@ -1,16 +1,77 @@
 /**
  * UNIQN Mobile - Employer Layout
  * 구인자 전용 레이아웃 (employer 권한 필요)
+ *
+ * @description Phase 1A — 활성 워크스페이스에서 멤버십 회수 감지 시
+ *              WorkspaceRevocationModal 마운트 + 5초 자동 로그아웃.
  */
 
+import { useState } from 'react';
 import { Stack, Redirect } from 'expo-router';
 import { useAuthStore, useHasRole, selectProfile } from '@/stores/authStore';
 import { useThemeStore } from '@/stores/themeStore';
 import { Loading } from '@/components/ui';
+import { WorkspaceRevocationModal } from '@/components/workspace';
+import {
+  useActiveWorkspace,
+  useWorkspaceMembers,
+  useWorkspaceRevocationGuard,
+} from '@/hooks/workspace';
+import { useQuery } from '@tanstack/react-query';
+import { workspaceService } from '@/services/workspace';
+import { queryKeys, cachingPolicies } from '@/lib/queryClient';
 import { getLayoutColor } from '@/constants/colors';
 
-export default function EmployerLayout() {
+function EmployerStack() {
   const isDark = useThemeStore((s) => s.isDarkMode);
+  const userId = useAuthStore((s) => s.user?.uid);
+  const { activeWorkspace } = useActiveWorkspace();
+
+  // useWorkspaceMembers 의 isFetched/isError 직접 노출이 없어 동일 query 를 별도 조회
+  // — TanStack Query 가 같은 키로 dedup 하므로 추가 fetch 비용 없음
+  const membersQuery = useQuery({
+    queryKey: activeWorkspace?.id
+      ? queryKeys.workspaces.members(activeWorkspace.id)
+      : [...queryKeys.workspaces.all, 'members', 'none'],
+    queryFn: () => workspaceService.listMembers(activeWorkspace!.id),
+    enabled: !!activeWorkspace?.id,
+    staleTime: cachingPolicies.frequent,
+  });
+
+  const { members } = useWorkspaceMembers(activeWorkspace?.id, activeWorkspace?.ownerId);
+  const isOwner = !!userId && activeWorkspace?.ownerId === userId;
+
+  const [revoked, setRevoked] = useState(false);
+
+  useWorkspaceRevocationGuard({
+    activeWorkspaceId: activeWorkspace?.id,
+    currentUserId: userId,
+    members,
+    isOwner,
+    isFetched: membersQuery.isFetched,
+    isError: membersQuery.isError,
+    onRevoked: () => setRevoked(true),
+  });
+
+  return (
+    <>
+      <Stack
+        screenOptions={{
+          headerShown: false,
+          animation: 'slide_from_right',
+          statusBarStyle: 'auto',
+          statusBarBackgroundColor: 'transparent',
+          contentStyle: {
+            backgroundColor: getLayoutColor(isDark, 'content'),
+          },
+        }}
+      />
+      <WorkspaceRevocationModal visible={revoked} workspaceName={activeWorkspace?.name} />
+    </>
+  );
+}
+
+export default function EmployerLayout() {
   const { isLoading, isAuthenticated } = useAuthStore();
   const profile = useAuthStore(selectProfile);
   const hasEmployerRole = useHasRole('employer');
@@ -30,17 +91,5 @@ export default function EmployerLayout() {
     return <Redirect href="/(app)/(tabs)" />;
   }
 
-  return (
-    <Stack
-      screenOptions={{
-        headerShown: false,
-        animation: 'slide_from_right',
-        statusBarStyle: 'auto',
-        statusBarBackgroundColor: 'transparent',
-        contentStyle: {
-          backgroundColor: getLayoutColor(isDark, 'content'),
-        },
-      }}
-    />
-  );
+  return <EmployerStack />;
 }

--- a/uniqn-mobile/src/components/workspace/WorkspaceRevocationModal.tsx
+++ b/uniqn-mobile/src/components/workspace/WorkspaceRevocationModal.tsx
@@ -1,0 +1,90 @@
+/**
+ * UNIQN Mobile - WorkspaceRevocationModal
+ *
+ * @description editor 가 워크스페이스에서 회수당했을 때 표시되는 보안 알림 Modal.
+ *              5초 카운트다운 후 자동 signOut + 로그인 화면 이동. 사용자에게 명시적
+ *              "보안상 자동 로그아웃" 메시지를 보여주어 무음 권한 박탈을 방지.
+ *
+ *              AppError 카테고리: E5 (보안 / authorization). impeccable v1 §1
+ *              다크모드 lineHeight 가산 적용.
+ *              (Phase 1A — workspace collaboration)
+ * @version 1.0.0
+ */
+
+import { useEffect, useState } from 'react';
+import { Modal, Text, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { signOut } from '@/services/auth';
+import { logger } from '@/utils/logger';
+
+interface WorkspaceRevocationModalProps {
+  visible: boolean;
+  workspaceName?: string;
+  /** 카운트다운 초 (테스트 용도. 기본 5) */
+  countdownSeconds?: number;
+}
+
+const DEFAULT_COUNTDOWN = 5;
+
+export function WorkspaceRevocationModal({
+  visible,
+  workspaceName,
+  countdownSeconds = DEFAULT_COUNTDOWN,
+}: WorkspaceRevocationModalProps) {
+  const router = useRouter();
+  const [countdown, setCountdown] = useState(countdownSeconds);
+
+  // visible=false 시 카운트다운 리셋
+  useEffect(() => {
+    if (!visible) {
+      setCountdown(countdownSeconds);
+      return;
+    }
+
+    const tick = setInterval(() => {
+      setCountdown((c) => Math.max(0, c - 1));
+    }, 1000);
+
+    const timer = setTimeout(async () => {
+      try {
+        logger.info('워크스페이스 회수로 자동 로그아웃', { workspaceName });
+        await signOut();
+        router.replace('/(auth)/login');
+      } catch (error) {
+        logger.error('회수 로그아웃 실패 — fallback 으로 로그인 화면 이동', error as Error);
+        // E5: 실패해도 로그인 화면으로 강제 이동 — 회수된 세션 유지 위험
+        router.replace('/(auth)/login');
+      }
+    }, countdownSeconds * 1000);
+
+    return () => {
+      clearInterval(tick);
+      clearTimeout(timer);
+    };
+  }, [visible, workspaceName, countdownSeconds, router]);
+
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <View
+        testID="workspace-revocation-alert"
+        accessibilityRole="alert"
+        accessibilityLiveRegion="polite"
+        className="flex-1 items-center justify-center bg-black/60 px-6"
+      >
+        <View className="w-full max-w-sm rounded-md bg-surface-card p-6 dark:bg-surface-elevated">
+          <Text className="mb-3 text-xl font-display text-content-primary">
+            워크스페이스 접근이 회수됐어요
+          </Text>
+          <Text className="mb-2 text-base leading-6 text-content-secondary dark:leading-[1.625rem]">
+            {workspaceName ? `‘${workspaceName}’ ` : ''}워크스페이스 소유자가 권한을 회수했습니다.
+          </Text>
+          <Text className="text-base leading-6 text-content-secondary dark:leading-[1.625rem]">
+            보안을 위해 {countdown}초 후 자동으로 로그아웃됩니다.
+          </Text>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+export default WorkspaceRevocationModal;

--- a/uniqn-mobile/src/components/workspace/__tests__/WorkspaceRevocationModal.test.tsx
+++ b/uniqn-mobile/src/components/workspace/__tests__/WorkspaceRevocationModal.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+
+import { WorkspaceRevocationModal } from '../WorkspaceRevocationModal';
+
+const mockSignOut = jest.fn().mockResolvedValue(undefined);
+const mockReplace = jest.fn();
+
+jest.mock('@/services/auth', () => ({
+  signOut: () => mockSignOut(),
+}));
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+describe('WorkspaceRevocationModal', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockSignOut.mockClear();
+    mockReplace.mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('visible=false 면 signOut 호출 안 함', () => {
+    render(<WorkspaceRevocationModal visible={false} workspaceName="포커룸 A" />);
+    act(() => {
+      jest.advanceTimersByTime(10_000);
+    });
+    expect(mockSignOut).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('visible=true 후 카운트다운 0 도달 시 signOut + login 이동', async () => {
+    render(<WorkspaceRevocationModal visible workspaceName="포커룸 A" countdownSeconds={3} />);
+    act(() => {
+      jest.advanceTimersByTime(3_000);
+    });
+    // signOut 은 promise 라 resolution 대기
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledWith('/(auth)/login');
+  });
+
+  it('카운트다운이 다 되기 전 visible=false 가 되면 timer 취소 (signOut 호출 안 함)', () => {
+    const { rerender } = render(<WorkspaceRevocationModal visible countdownSeconds={5} />);
+    act(() => {
+      jest.advanceTimersByTime(2_000);
+    });
+    rerender(<WorkspaceRevocationModal visible={false} countdownSeconds={5} />);
+    act(() => {
+      jest.advanceTimersByTime(10_000);
+    });
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+
+  it('signOut 실패해도 fallback 으로 login 화면 강제 이동 (E5 보안)', async () => {
+    mockSignOut.mockRejectedValueOnce(new Error('network down'));
+    render(<WorkspaceRevocationModal visible workspaceName="포커룸 A" countdownSeconds={1} />);
+    act(() => {
+      jest.advanceTimersByTime(1_000);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledWith('/(auth)/login');
+  });
+
+  it('accessibilityRole="alert" + liveRegion="polite" 설정', () => {
+    const { getByTestId } = render(<WorkspaceRevocationModal visible countdownSeconds={5} />);
+    const alert = getByTestId('workspace-revocation-alert');
+    expect(alert.props.accessibilityRole).toBe('alert');
+    expect(alert.props.accessibilityLiveRegion).toBe('polite');
+  });
+});

--- a/uniqn-mobile/src/components/workspace/index.ts
+++ b/uniqn-mobile/src/components/workspace/index.ts
@@ -6,3 +6,4 @@
 
 export { WorkspaceSwitcher } from './WorkspaceSwitcher';
 export { WorkspaceContextBar } from './WorkspaceContextBar';
+export { WorkspaceRevocationModal } from './WorkspaceRevocationModal';

--- a/uniqn-mobile/src/hooks/workspace/__tests__/useWorkspaceRevocationGuard.test.tsx
+++ b/uniqn-mobile/src/hooks/workspace/__tests__/useWorkspaceRevocationGuard.test.tsx
@@ -6,7 +6,6 @@
  *              모두 검증.
  */
 
-import React from 'react';
 import { renderHook } from '@testing-library/react-native';
 
 import { useWorkspaceRevocationGuard } from '../useWorkspaceRevocationGuard';

--- a/uniqn-mobile/src/hooks/workspace/__tests__/useWorkspaceRevocationGuard.test.tsx
+++ b/uniqn-mobile/src/hooks/workspace/__tests__/useWorkspaceRevocationGuard.test.tsx
@@ -1,0 +1,316 @@
+/**
+ * UNIQN Mobile - useWorkspaceRevocationGuard Tests
+ *
+ * @description Phase 1A — editor 가 회수당했을 때 onRevoked 콜백 호출.
+ *              false-positive 방지 가드 (isFetched / isError / workspaceId 변경 시 ref 리셋)
+ *              모두 검증.
+ */
+
+import React from 'react';
+import { renderHook } from '@testing-library/react-native';
+
+import { useWorkspaceRevocationGuard } from '../useWorkspaceRevocationGuard';
+
+const mockCreateRealtimeSubscription = jest.fn();
+
+jest.mock('@/utils/supabase', () => ({
+  createRealtimeSubscription: (...args: unknown[]) => mockCreateRealtimeSubscription(...args),
+}));
+
+interface Member {
+  userId: string;
+}
+
+const m = (userId: string): Member => ({ userId });
+
+describe('useWorkspaceRevocationGuard', () => {
+  beforeEach(() => {
+    mockCreateRealtimeSubscription.mockReset();
+    mockCreateRealtimeSubscription.mockReturnValue(() => {
+      /* unsubscribe noop */
+    });
+  });
+
+  describe('fetch fallback diff', () => {
+    it('현재 활성 워크스페이스에서 회수되면 onRevoked 콜백 호출', () => {
+      const onRevoked = jest.fn();
+      const { rerender } = renderHook(
+        ({ members }: { members: Member[] }) =>
+          useWorkspaceRevocationGuard({
+            activeWorkspaceId: 'ws-1',
+            currentUserId: 'editor-1',
+            members,
+            isOwner: false,
+            isFetched: true,
+            isError: false,
+            onRevoked,
+          }),
+        {
+          initialProps: { members: [m('editor-1')] },
+        }
+      );
+
+      rerender({ members: [] });
+
+      expect(onRevoked).toHaveBeenCalledTimes(1);
+    });
+
+    it('처음부터 멤버가 아니면 onRevoked 호출 안 함', () => {
+      const onRevoked = jest.fn();
+      renderHook(() =>
+        useWorkspaceRevocationGuard({
+          activeWorkspaceId: 'ws-1',
+          currentUserId: 'editor-1',
+          members: [m('other')],
+          isOwner: false,
+          isFetched: true,
+          isError: false,
+          onRevoked,
+        })
+      );
+      expect(onRevoked).not.toHaveBeenCalled();
+    });
+
+    it('owner 본인은 onRevoked 호출 안 함', () => {
+      const onRevoked = jest.fn();
+      const { rerender } = renderHook(
+        ({ members }: { members: Member[] }) =>
+          useWorkspaceRevocationGuard({
+            activeWorkspaceId: 'ws-1',
+            currentUserId: 'owner-1',
+            members,
+            isOwner: true,
+            isFetched: true,
+            isError: false,
+            onRevoked,
+          }),
+        { initialProps: { members: [m('owner-1')] } }
+      );
+
+      rerender({ members: [] });
+
+      expect(onRevoked).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('false-positive 가드 (E5)', () => {
+    it('isError=true 면 비교 건너뛰기 (네트워크 단절 false-positive 방지)', () => {
+      const onRevoked = jest.fn();
+      const { rerender } = renderHook(
+        ({ members, isError }: { members: Member[]; isError: boolean }) =>
+          useWorkspaceRevocationGuard({
+            activeWorkspaceId: 'ws-1',
+            currentUserId: 'editor-1',
+            members,
+            isOwner: false,
+            isFetched: true,
+            isError,
+            onRevoked,
+          }),
+        {
+          initialProps: { members: [m('editor-1')], isError: false },
+        }
+      );
+
+      // 네트워크 에러 발생 → members 가 빈 배열이지만 isError=true
+      rerender({ members: [], isError: true });
+
+      expect(onRevoked).not.toHaveBeenCalled();
+    });
+
+    it('isFetched=false 면 비교 건너뛰기 (첫 로딩 false-positive 방지)', () => {
+      const onRevoked = jest.fn();
+      const { rerender } = renderHook(
+        ({ members, isFetched }: { members: Member[]; isFetched: boolean }) =>
+          useWorkspaceRevocationGuard({
+            activeWorkspaceId: 'ws-1',
+            currentUserId: 'editor-1',
+            members,
+            isOwner: false,
+            isFetched,
+            isError: false,
+            onRevoked,
+          }),
+        {
+          initialProps: { members: [], isFetched: false },
+        }
+      );
+
+      // 로딩 중 빈 배열이 도착하더라도 비교 안 함
+      rerender({ members: [], isFetched: false });
+
+      expect(onRevoked).not.toHaveBeenCalled();
+    });
+
+    it('workspaceId 가 바뀌면 ref 리셋 — 새 워크스페이스에서 빈 멤버 시 false-positive 방지', () => {
+      const onRevoked = jest.fn();
+      const { rerender } = renderHook(
+        ({ workspaceId, members }: { workspaceId: string; members: Member[] }) =>
+          useWorkspaceRevocationGuard({
+            activeWorkspaceId: workspaceId,
+            currentUserId: 'editor-1',
+            members,
+            isOwner: false,
+            isFetched: true,
+            isError: false,
+            onRevoked,
+          }),
+        {
+          initialProps: { workspaceId: 'ws-1', members: [m('editor-1')] },
+        }
+      );
+
+      // 워크스페이스 전환 — wasMemberRef 리셋되어야 함
+      rerender({ workspaceId: 'ws-2', members: [] });
+
+      // 새 워크스페이스 ws-2 에서는 처음부터 멤버 아님 → false-positive 발생하면 안 됨
+      expect(onRevoked).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('realtime DELETE 구독', () => {
+    it('owner 가 아니면 realtime 구독 시작', () => {
+      const onRevoked = jest.fn();
+      renderHook(() =>
+        useWorkspaceRevocationGuard({
+          activeWorkspaceId: 'ws-1',
+          currentUserId: 'editor-1',
+          members: [m('editor-1')],
+          isOwner: false,
+          isFetched: true,
+          isError: false,
+          onRevoked,
+        })
+      );
+
+      expect(mockCreateRealtimeSubscription).toHaveBeenCalledWith(
+        'workspace_members',
+        'workspace_id=eq.ws-1',
+        expect.any(Function)
+      );
+    });
+
+    it('owner 면 realtime 구독 시작 안 함', () => {
+      const onRevoked = jest.fn();
+      renderHook(() =>
+        useWorkspaceRevocationGuard({
+          activeWorkspaceId: 'ws-1',
+          currentUserId: 'owner-1',
+          members: [m('owner-1')],
+          isOwner: true,
+          isFetched: true,
+          isError: false,
+          onRevoked,
+        })
+      );
+
+      expect(mockCreateRealtimeSubscription).not.toHaveBeenCalled();
+    });
+
+    it('realtime DELETE 페이로드의 user_id 가 currentUserId 와 같으면 onRevoked 호출', () => {
+      const onRevoked = jest.fn();
+      let capturedCallback:
+        | ((payload: { eventType: string; old?: { user_id?: string } }) => void)
+        | undefined;
+      mockCreateRealtimeSubscription.mockImplementation(
+        (_table: string, _filter: string, cb: typeof capturedCallback) => {
+          capturedCallback = cb;
+          return () => {};
+        }
+      );
+
+      renderHook(() =>
+        useWorkspaceRevocationGuard({
+          activeWorkspaceId: 'ws-1',
+          currentUserId: 'editor-1',
+          members: [m('editor-1')],
+          isOwner: false,
+          isFetched: true,
+          isError: false,
+          onRevoked,
+        })
+      );
+
+      capturedCallback?.({ eventType: 'DELETE', old: { user_id: 'editor-1' } });
+      expect(onRevoked).toHaveBeenCalledTimes(1);
+    });
+
+    it('realtime DELETE 페이로드의 user_id 가 다른 사용자면 onRevoked 호출 안 함', () => {
+      const onRevoked = jest.fn();
+      let capturedCallback:
+        | ((payload: { eventType: string; old?: { user_id?: string } }) => void)
+        | undefined;
+      mockCreateRealtimeSubscription.mockImplementation(
+        (_table: string, _filter: string, cb: typeof capturedCallback) => {
+          capturedCallback = cb;
+          return () => {};
+        }
+      );
+
+      renderHook(() =>
+        useWorkspaceRevocationGuard({
+          activeWorkspaceId: 'ws-1',
+          currentUserId: 'editor-1',
+          members: [m('editor-1')],
+          isOwner: false,
+          isFetched: true,
+          isError: false,
+          onRevoked,
+        })
+      );
+
+      capturedCallback?.({ eventType: 'DELETE', old: { user_id: 'other-editor' } });
+      expect(onRevoked).not.toHaveBeenCalled();
+    });
+
+    it('realtime UPDATE 이벤트는 무시 (DELETE 만 트리거)', () => {
+      const onRevoked = jest.fn();
+      let capturedCallback:
+        | ((payload: { eventType: string; old?: { user_id?: string } }) => void)
+        | undefined;
+      mockCreateRealtimeSubscription.mockImplementation(
+        (_table: string, _filter: string, cb: typeof capturedCallback) => {
+          capturedCallback = cb;
+          return () => {};
+        }
+      );
+
+      renderHook(() =>
+        useWorkspaceRevocationGuard({
+          activeWorkspaceId: 'ws-1',
+          currentUserId: 'editor-1',
+          members: [m('editor-1')],
+          isOwner: false,
+          isFetched: true,
+          isError: false,
+          onRevoked,
+        })
+      );
+
+      capturedCallback?.({ eventType: 'UPDATE', old: { user_id: 'editor-1' } });
+      expect(onRevoked).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanup', () => {
+    it('unmount 시 unsubscribe 호출', () => {
+      const unsubscribe = jest.fn();
+      mockCreateRealtimeSubscription.mockReturnValue(unsubscribe);
+      const { unmount } = renderHook(() =>
+        useWorkspaceRevocationGuard({
+          activeWorkspaceId: 'ws-1',
+          currentUserId: 'editor-1',
+          members: [m('editor-1')],
+          isOwner: false,
+          isFetched: true,
+          isError: false,
+          onRevoked: jest.fn(),
+        })
+      );
+
+      unmount();
+
+      expect(unsubscribe).toHaveBeenCalled();
+    });
+  });
+});

--- a/uniqn-mobile/src/hooks/workspace/__tests__/useWorkspaceRevocationGuard.test.tsx
+++ b/uniqn-mobile/src/hooks/workspace/__tests__/useWorkspaceRevocationGuard.test.tsx
@@ -214,7 +214,9 @@ describe('useWorkspaceRevocationGuard', () => {
       mockCreateRealtimeSubscription.mockImplementation(
         (_table: string, _filter: string, cb: typeof capturedCallback) => {
           capturedCallback = cb;
-          return () => {};
+          return () => {
+            /* unsubscribe noop */
+          };
         }
       );
 
@@ -242,7 +244,9 @@ describe('useWorkspaceRevocationGuard', () => {
       mockCreateRealtimeSubscription.mockImplementation(
         (_table: string, _filter: string, cb: typeof capturedCallback) => {
           capturedCallback = cb;
-          return () => {};
+          return () => {
+            /* unsubscribe noop */
+          };
         }
       );
 
@@ -270,7 +274,9 @@ describe('useWorkspaceRevocationGuard', () => {
       mockCreateRealtimeSubscription.mockImplementation(
         (_table: string, _filter: string, cb: typeof capturedCallback) => {
           capturedCallback = cb;
-          return () => {};
+          return () => {
+            /* unsubscribe noop */
+          };
         }
       );
 

--- a/uniqn-mobile/src/hooks/workspace/index.ts
+++ b/uniqn-mobile/src/hooks/workspace/index.ts
@@ -25,3 +25,8 @@ export {
 } from './useWorkspaces';
 
 export { useActiveWorkspace, type UseActiveWorkspaceResult } from './useActiveWorkspace';
+
+export {
+  useWorkspaceRevocationGuard,
+  type UseWorkspaceRevocationGuardArgs,
+} from './useWorkspaceRevocationGuard';

--- a/uniqn-mobile/src/hooks/workspace/useWorkspaceRevocationGuard.ts
+++ b/uniqn-mobile/src/hooks/workspace/useWorkspaceRevocationGuard.ts
@@ -1,0 +1,100 @@
+/**
+ * UNIQN Mobile - useWorkspaceRevocationGuard
+ *
+ * @description editor 가 활성 워크스페이스에서 회수당했을 때 onRevoked 콜백을 호출.
+ *              두 채널을 결합해 실시간성과 회복력을 모두 확보:
+ *
+ *              1. **Realtime DELETE 우선** — Supabase postgres_changes 가
+ *                 `workspace_members` row 의 DELETE 를 즉시 감지. user_id 가
+ *                 currentUserId 와 일치할 때만 트리거.
+ *
+ *              2. **Fetch diff fallback** — Realtime 은 at-most-once 라 missed 가능.
+ *                 useWorkspaceMembers query 의 fetched 결과를 wasMember diff 로 비교.
+ *                 단 다음 가드를 모두 통과해야 비교:
+ *                 - `isFetched=true && !isError` (네트워크 단절 false-positive 방지 — E5 보안)
+ *                 - 같은 workspaceId 안에서만 (workspaceId 변경 시 wasMemberRef 리셋)
+ *
+ *              3. **owner 면 비활성** — 자기 자신을 회수할 수 없음.
+ *
+ *              (Phase 1A — workspace collaboration)
+ * @version 1.0.0
+ */
+
+import { useEffect, useRef } from 'react';
+import { createRealtimeSubscription } from '@/utils/supabase';
+
+interface MemberLike {
+  userId: string;
+}
+
+export interface UseWorkspaceRevocationGuardArgs<M extends MemberLike = MemberLike> {
+  activeWorkspaceId: string | undefined;
+  currentUserId: string | undefined;
+  /** useWorkspaceMembers 의 결과 (또는 동일 shape) */
+  members: M[];
+  /** 활성 워크스페이스의 owner 인지. true 면 회수 불가 → 모든 감지 비활성. */
+  isOwner: boolean;
+  /** TanStack Query isFetched — 첫 로딩 / 백그라운드 fetch 중 false. false 면 비교 skip. */
+  isFetched: boolean;
+  /** TanStack Query isError — 네트워크 단절 등 fetch 실패. true 면 비교 skip. */
+  isError: boolean;
+  /** 회수 감지 시 호출. layout 등 상위 컴포넌트가 Modal 표시 + signOut 트리거. */
+  onRevoked: () => void;
+}
+
+export function useWorkspaceRevocationGuard<M extends MemberLike>(
+  args: UseWorkspaceRevocationGuardArgs<M>
+): void {
+  const { activeWorkspaceId, currentUserId, members, isOwner, isFetched, isError, onRevoked } =
+    args;
+  const wasMemberRef = useRef<boolean>(false);
+  // onRevoked 변경으로 effect 재실행되지 않도록 ref 로 lock
+  const onRevokedRef = useRef(onRevoked);
+  onRevokedRef.current = onRevoked;
+
+  // 1) Realtime DELETE 구독 — owner 가 아닐 때만
+  useEffect(() => {
+    if (!activeWorkspaceId || !currentUserId || isOwner) return undefined;
+
+    const unsubscribe = createRealtimeSubscription(
+      'workspace_members',
+      `workspace_id=eq.${activeWorkspaceId}`,
+      (payload) => {
+        if (payload.eventType !== 'DELETE') return;
+        const oldRow = payload.old as { user_id?: string } | undefined;
+        if (oldRow?.user_id === currentUserId) {
+          onRevokedRef.current();
+        }
+      }
+    );
+
+    return unsubscribe;
+  }, [activeWorkspaceId, currentUserId, isOwner]);
+
+  // 2) Fetch diff fallback — 가드 통과 시에만 비교
+  useEffect(() => {
+    // owner / 비로그인 / 활성 워크스페이스 없음 → 비활성 + ref 리셋
+    if (!activeWorkspaceId || !currentUserId || isOwner) {
+      wasMemberRef.current = false;
+      return;
+    }
+
+    // false-positive 방지 가드 (E5 보안)
+    if (!isFetched || isError) return;
+
+    const isCurrentlyMember = members.some((m) => m.userId === currentUserId);
+
+    if (wasMemberRef.current && !isCurrentlyMember) {
+      onRevokedRef.current();
+    }
+
+    wasMemberRef.current = isCurrentlyMember;
+  }, [activeWorkspaceId, currentUserId, members, isOwner, isFetched, isError]);
+
+  // 3) workspaceId 전환 시 ref 강제 리셋 (Switcher 사용자 대응)
+  useEffect(() => {
+    return () => {
+      wasMemberRef.current = false;
+    };
+  }, [activeWorkspaceId]);
+}

--- a/uniqn-mobile/src/hooks/workspace/useWorkspaces.ts
+++ b/uniqn-mobile/src/hooks/workspace/useWorkspaces.ts
@@ -6,11 +6,12 @@
  * @version 1.0.0
  */
 
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { queryKeys, cachingPolicies } from '@/lib/queryClient';
 import { useAuthStore } from '@/stores/authStore';
 import { workspaceService, workspaceInvitationService } from '@/services/workspace';
+import { createRealtimeSubscription } from '@/utils/supabase';
 import type {
   Workspace,
   WorkspaceMemberWithUser,
@@ -80,6 +81,7 @@ export function useWorkspaceMembers(
   ownerId: string | undefined
 ): UseWorkspaceMembersResult {
   const { user } = useAuthStore();
+  const queryClient = useQueryClient();
 
   const query = useQuery({
     queryKey: workspaceId
@@ -89,6 +91,24 @@ export function useWorkspaceMembers(
     enabled: !!workspaceId,
     staleTime: cachingPolicies.frequent,
   });
+
+  // Realtime 구독 — workspace_members row 변경 시 query invalidate.
+  // Phase 1A 의 RevocationGuard 가 같은 채널을 활용 (createRealtimeSubscription 가
+  // ref-counting + fan-out 으로 단일 채널만 유지).
+  useEffect(() => {
+    if (!workspaceId) return undefined;
+    return createRealtimeSubscription('workspace_members', `workspace_id=eq.${workspaceId}`, () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.workspaces.members(workspaceId),
+      });
+      // listForUser 도 영향 — 새 멤버가 본인 워크스페이스 목록을 갱신해야 할 수 있음
+      if (user?.uid) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.workspaces.listForUser(user.uid),
+        });
+      }
+    });
+  }, [workspaceId, queryClient, user?.uid]);
 
   return {
     members: query.data ?? [],


### PR DESCRIPTION
## Summary

Phase 1A — editor 가 활성 워크스페이스에서 회수당했을 때 즉시/명시적으로 차단하고 안전하게 로그아웃.

> **재오픈 PR** — 원래 PR #59 가 base 브랜치 (\`feat/workspace-switcher\`) 삭제로 자동 close 됨. master 위로 4 commits cherry-pick 후 재푸시.

### 변경

- \`useWorkspaceRevocationGuard\` hook — Realtime DELETE 우선 + Fetch diff fallback
  - 가드 3종 (E5 보안): isFetched=false / isError=true / workspaceId 변경 시 ref 리셋
  - owner 본인은 모든 감지 비활성
- \`WorkspaceRevocationModal\` — 5초 카운트다운 자동 로그아웃, accessibilityLiveRegion=polite
- \`useWorkspaceMembers\` realtime 구독 — workspace_members 변경 시 query invalidate
- \`(employer)/_layout.tsx\` — EmployerStack inner 컴포넌트가 RevocationGuard + Modal 마운트

### 의존성

- Phase 1B (PR #58, MERGED) — useActiveWorkspace 활용
- Phase 0 (PR #57, MERGED) — workspace_id 자동 주입

## Test plan

- [x] \`npm run quality\` 0 errors
- [x] \`npx jest src/hooks/workspace src/components/workspace\` 21/21 PASS
- [x] regression 8건 PASS
- [ ] staging 두 계정 (owner + editor) 검증 — owner 가 editor 제거 → 5초 내 Modal + 자동 로그아웃
- [ ] staging 비행기 모드 false-positive 검증
- [ ] dark mode + VoiceOver/TalkBack 읽기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)