### PR TITLE
fix(workspace): 멤버 제거 버튼 hotfix — 다크모드 색상 + 터치 타깃 + web Alert 호환

### DIFF
--- a/uniqn-mobile/app/(employer)/workspace/index.tsx
+++ b/uniqn-mobile/app/(employer)/workspace/index.tsx
@@ -8,13 +8,14 @@
  */
 
 import { useCallback, useState } from 'react';
-import { View, Text, ScrollView, Pressable, ActivityIndicator, Alert } from 'react-native';
+import { View, Text, ScrollView, Pressable, ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { StackHeader } from '@/components/headers';
 import { Avatar, Badge, Button, EmptyState, ErrorState, Input } from '@/components/ui';
 import { useAuthStore } from '@/stores/authStore';
 import { useToastStore } from '@/stores/toastStore';
+import { useModalStore } from '@/stores/modalStore';
 import {
   useActiveWorkspace,
   useWorkspaceMembers,
@@ -32,6 +33,7 @@ import type { WorkspaceMemberWithUser } from '@/types/workspace';
 export default function WorkspaceSettingsScreen() {
   const { user } = useAuthStore();
   const { addToast } = useToastStore();
+  const { showConfirm } = useModalStore();
   // useActiveWorkspace 가 내부에서 useWorkspaces 를 호출 — TanStack Query 가 동일 키로
   // 중복 조회 dedup. error 만 별도로 노출되지 않으므로 useWorkspaces 한 번 더 호출.
   const { error } = useWorkspaces();
@@ -72,29 +74,23 @@ export default function WorkspaceSettingsScreen() {
 
   const handleRemoveMember = useCallback(
     (member: WorkspaceMemberWithUser) => {
-      Alert.alert(
+      // showConfirm — native + web 양쪽 호환 (Alert.alert 은 web 에서 무음)
+      showConfirm(
         '멤버 제거',
-        `${member.displayName ?? member.email ?? '멤버'}님을 워크스페이스에서 제거할까요? 권한이 즉시 회수됩니다.`,
-        [
-          { text: '취소', style: 'cancel' },
-          {
-            text: '제거',
-            style: 'destructive',
-            onPress: async () => {
-              try {
-                await removeMemberMutation.mutateAsync(member.userId);
-                addToast({ type: 'success', message: '멤버를 제거했어요' });
-              } catch (err) {
-                const message =
-                  isAppError(err) && err.userMessage ? err.userMessage : '제거에 실패했어요';
-                addToast({ type: 'error', message });
-              }
-            },
-          },
-        ]
+        `${member.displayName ?? member.email ?? '멤버'}님을 워크스페이스에서 제거할까요?\n권한이 즉시 회수됩니다.`,
+        async () => {
+          try {
+            await removeMemberMutation.mutateAsync(member.userId);
+            addToast({ type: 'success', message: '멤버를 제거했어요' });
+          } catch (err) {
+            const message =
+              isAppError(err) && err.userMessage ? err.userMessage : '제거에 실패했어요';
+            addToast({ type: 'error', message });
+          }
+        }
       );
     },
-    [removeMemberMutation, addToast]
+    [removeMemberMutation, addToast, showConfirm]
   );
 
   const handleCreateFirstWorkspace = useCallback(async () => {

--- a/uniqn-mobile/app/(employer)/workspace/index.tsx
+++ b/uniqn-mobile/app/(employer)/workspace/index.tsx
@@ -304,10 +304,20 @@ export default function WorkspaceSettingsScreen() {
                       onPress={() => handleRemoveMember(member)}
                       hitSlop={8}
                       accessibilityRole="button"
-                      accessibilityLabel="멤버 제거"
-                      className="ml-3"
+                      accessibilityLabel={`${member.displayName ?? '멤버'} 제거`}
+                      className="ml-2 min-h-[44px] min-w-[44px] items-center justify-center rounded-md"
                     >
-                      <Text className="text-sm text-danger-500">제거</Text>
+                      {({ pressed }) => (
+                        <View
+                          className={`rounded-md px-3 py-2 ${
+                            pressed ? 'bg-error-100 dark:bg-error-900/30' : ''
+                          }`}
+                        >
+                          <Text className="text-sm font-sans-medium text-error-600 dark:text-error-400">
+                            제거
+                          </Text>
+                        </View>
+                      )}
                     </Pressable>
                   )}
                 </View>


### PR DESCRIPTION
## Summary

워크스페이스 설정 화면 멤버 제거 버튼 3가지 이슈 동시 해결.

### 문제

| 증상 | 원인 |
|---|---|
| 다크모드 "제거" 텍스트 흐릿한 회색 | \`text-danger-500\` 이 tailwind 팔레트 미정의 → fallback 색상 |
| 버튼이 안 눌림 (터치 영역 작음) | hit target = 텍스트 박스 ≈12×30px, impeccable §5 (44px) 미달 |
| **버튼 눌러도 web 에서 무반응** | \`Alert.alert\` 가 react-native-web 에서 무음 (브라우저 대화상자 미호출) |

### 수정

**색상 & 터치**
- \`text-danger-500\` → \`text-error-600 dark:text-error-400\` (프로젝트 컨벤션)
- min-h-[44px] min-w-[44px] + items-center justify-center
- Pressed 피드백 \`bg-error-100 dark:bg-error-900/30\` (impeccable §21)
- accessibilityLabel 멤버 이름 컨텍스트 추가

**Web 호환**
- \`Alert.alert\` → \`useModalStore.showConfirm\`
- settings/index.tsx 의 로그아웃 / 캐시 삭제 동일 패턴
- native + web 양쪽 동작

## Test plan

- [x] \`npm run quality\` 0 errors
- [x] \`npx tsc --noEmit\` 0 errors
- [ ] **web 브라우저** — "제거" 버튼 탭 → ConfirmModal 표시 → 확인 → 멤버 제거 성공
- [ ] iOS/Android — 동일 동작 + 다크모드 빨간 텍스트 명확히 보임
- [ ] Pressed 피드백 — 누를 때 배경 빨간 톤