### PR TITLE
feat(workspace): work_logs RLS workspace 분기 — Phase 3B

### DIFF
--- a/uniqn-mobile/src/repositories/supabase/__tests__/WorkLogRepository.workspace.editor.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/WorkLogRepository.workspace.editor.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Phase 3B — WorkLogRepository editor contract test
+ *
+ * @description editor 가 공유 공고의 work_logs 를 RLS wl_select / wl_update 통과로
+ *              SELECT/UPDATE. client 는 job_posting_id 또는 work_log id 만 추가,
+ *              owner_id WHERE 는 사용 안 함 (auth.uid() 가 RLS 단일 진실).
+ *
+ * 본 테스트는 contract level (Supabase 호출 패턴) 만 검증.
+ */
+
+import { SupabaseWorkLogRepository } from '../WorkLogRepository';
+
+const mockFrom = jest.fn();
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    rpc: jest.fn(),
+    channel: jest.fn(),
+  },
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('@/utils/supabase', () => {
+  const actual = jest.requireActual('@/utils/supabase');
+  return {
+    ...actual,
+    handleSupabaseError: (error: { message?: string } | null) => {
+      if (error) throw new Error(`supabase: ${error.message ?? 'unknown'}`);
+    },
+  };
+});
+
+jest.mock('@sentry/react-native', () => ({
+  __esModule: true,
+  addBreadcrumb: jest.fn(),
+}));
+
+function makeChain(returnValue: { data: unknown; error: unknown }) {
+  const chain: Record<string, unknown> = {};
+  for (const m of [
+    'select',
+    'eq',
+    'in',
+    'is',
+    'order',
+    'limit',
+    'range',
+    'update',
+    'insert',
+    'delete',
+    'upsert',
+    'gte',
+    'lte',
+    'gt',
+    'lt',
+    'neq',
+    'contains',
+    'overlaps',
+    'or',
+    'and',
+    'not',
+    'filter',
+    'match',
+    'returns',
+  ]) {
+    chain[m] = jest.fn(() => chain);
+  }
+  for (const m of ['single', 'maybeSingle', 'csv']) {
+    chain[m] = jest.fn(() => Promise.resolve(returnValue));
+  }
+  (chain as { then?: unknown }).then = function then<TResult1 = unknown, TResult2 = never>(
+    onfulfilled?: ((value: unknown) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): PromiseLike<TResult1 | TResult2> {
+    return Promise.resolve(returnValue).then(onfulfilled, onrejected);
+  };
+  return chain as Record<string, jest.Mock> & PromiseLike<unknown>;
+}
+
+beforeEach(() => {
+  mockFrom.mockReset();
+});
+
+describe('WorkLogRepository — Phase 3B editor contract', () => {
+  const repo = new SupabaseWorkLogRepository();
+
+  describe('getByJobPostingId — SELECT 흐름', () => {
+    it('Supabase from(work_logs) + job_posting_id filter + order(date desc) 호출', async () => {
+      const chain = makeChain({ data: [], error: null });
+      mockFrom.mockReturnValueOnce(chain);
+
+      await repo.getByJobPostingId('job-posting-id');
+
+      expect(mockFrom).toHaveBeenCalledWith('work_logs');
+      expect(chain.eq).toHaveBeenCalledWith('job_posting_id', 'job-posting-id');
+      expect(chain.order).toHaveBeenCalledWith('date', { ascending: false });
+    });
+
+    it('client 는 owner_id / staff_id WHERE 를 추가하지 않음 (RLS auth.uid() 단일 진실)', async () => {
+      const chain = makeChain({ data: [], error: null });
+      mockFrom.mockReturnValueOnce(chain);
+
+      await repo.getByJobPostingId('job-posting-id');
+
+      const eqCalls = chain.eq.mock.calls.map((call) => call[0]);
+      expect(eqCalls).not.toContain('owner_id');
+      expect(eqCalls).not.toContain('staff_id');
+    });
+
+    it('빈 결과 시에도 정상 종료 (RLS 가 0 row 반환 → 빈 배열)', async () => {
+      const chain = makeChain({ data: [], error: null });
+      mockFrom.mockReturnValueOnce(chain);
+
+      const result = await repo.getByJobPostingId('job-posting-id');
+      expect(result).toEqual([]);
+    });
+
+    it('error 응답 시 handleSupabaseError 트리거', async () => {
+      const chain = makeChain({ data: null, error: { message: 'permission denied' } });
+      mockFrom.mockReturnValueOnce(chain);
+
+      await expect(repo.getByJobPostingId('job-posting-id')).rejects.toThrow(/permission denied/);
+    });
+  });
+
+  describe('updatePayrollStatus — UPDATE 흐름', () => {
+    it('Supabase from(work_logs) + update + id WHERE 만 호출 (workspace 분기는 RLS 가 처리)', async () => {
+      const chain = makeChain({ data: null, error: null });
+      mockFrom.mockReturnValueOnce(chain);
+
+      await repo.updatePayrollStatus('work-log-id', 'pending');
+
+      expect(mockFrom).toHaveBeenCalledWith('work_logs');
+      expect(chain.update).toHaveBeenCalled();
+      expect(chain.eq).toHaveBeenCalledWith('id', 'work-log-id');
+    });
+
+    it('client 는 owner_id / workspace_id WHERE 를 추가하지 않음', async () => {
+      const chain = makeChain({ data: null, error: null });
+      mockFrom.mockReturnValueOnce(chain);
+
+      await repo.updatePayrollStatus('work-log-id', 'pending');
+
+      const eqCalls = chain.eq.mock.calls.map((call) => call[0]);
+      expect(eqCalls).not.toContain('owner_id');
+      expect(eqCalls).not.toContain('workspace_id');
+    });
+
+    it('error 응답 시 handleSupabaseError 트리거 (RLS 거부 시 permission denied)', async () => {
+      const chain = makeChain({ data: null, error: { message: 'permission denied' } });
+      mockFrom.mockReturnValueOnce(chain);
+
+      await expect(repo.updatePayrollStatus('work-log-id', 'pending')).rejects.toThrow(
+        /permission denied/
+      );
+    });
+  });
+});

--- a/uniqn-mobile/supabase/migrations/20260509000000_workspace_m4_work_logs_rls.sql
+++ b/uniqn-mobile/supabase/migrations/20260509000000_workspace_m4_work_logs_rls.sql
@@ -1,0 +1,52 @@
+-- Phase 3B — work_logs RLS 워크스페이스 멤버 분기
+--
+-- editor 가 공유 공고의 work_logs 를 SELECT/UPDATE 할 수 있도록 정책에
+-- is_workspace_member 분기 추가. 기존 staff_id / owner_id / admin 분기는 보존.
+--
+-- INSERT/DELETE 정책은 work_logs 에 존재하지 않음 (SECURITY DEFINER trigger 및
+-- RPC 가 직접 데이터를 삽입). editor 권한이 영향을 미치지 않음.
+--
+-- payroll trigger 와의 상호작용:
+-- - work_logs UPDATE 시 trigger 가 발동되어 정산 상태를 동기화. owner 가
+--   소유한 공고에 한해 수정 권한이 있던 기존 동작을 유지하면서, editor 도
+--   동일 권한 범위에서 수정 가능 (정산 흐름 단일성 유지).
+--
+-- DOWN script (rollback) — 별도 migration 으로 적용:
+-- DROP POLICY IF EXISTS wl_select ON public.work_logs;
+-- CREATE POLICY wl_select ON public.work_logs FOR SELECT TO public
+--   USING (
+--     staff_id = (SELECT auth.uid())
+--     OR owner_id = (SELECT auth.uid())
+--     OR ((SELECT get_my_role()) = 'admin')
+--   );
+-- DROP POLICY IF EXISTS wl_update ON public.work_logs;
+-- CREATE POLICY wl_update ON public.work_logs FOR UPDATE TO public
+--   USING (
+--     staff_id = (SELECT auth.uid())
+--     OR owner_id = (SELECT auth.uid())
+--     OR ((SELECT get_my_role()) = 'admin')
+--   );
+
+DROP POLICY IF EXISTS wl_select ON public.work_logs;
+CREATE POLICY wl_select ON public.work_logs FOR SELECT TO public
+  USING (
+    staff_id = (SELECT auth.uid())
+    OR owner_id = (SELECT auth.uid())
+    OR (job_posting_id IN (
+      SELECT id FROM public.job_postings
+      WHERE public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+    ))
+    OR ((SELECT get_my_role()) = 'admin')
+  );
+
+DROP POLICY IF EXISTS wl_update ON public.work_logs;
+CREATE POLICY wl_update ON public.work_logs FOR UPDATE TO public
+  USING (
+    staff_id = (SELECT auth.uid())
+    OR owner_id = (SELECT auth.uid())
+    OR (job_posting_id IN (
+      SELECT id FROM public.job_postings
+      WHERE public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+    ))
+    OR ((SELECT get_my_role()) = 'admin')
+  );


### PR DESCRIPTION
## Summary
- editor 가 공유 공고의 work_logs 를 SELECT/UPDATE 할 수 있도록 wl_select / wl_update 정책에 is_workspace_member 분기 추가
- 기존 staff_id / owner_id / admin 분기 보존 (회귀 위험 0)
- migration: `20260509000000_workspace_m4_work_logs_rls.sql` (Phase 3A applications_rls 동일 패턴)
- regression test: `WorkLogRepository.workspace.editor.test.ts` (7 contract case)

## 검증
- [x] jest 7/7 PASS — getByJobPostingId / updatePayrollStatus contract 통과
- [x] Supabase advisors security 0 ERROR / performance 0 ERROR (baseline 변동 없음)
- [x] pg_policy 변경 확인 — wl_select / wl_update USING 에 `is_workspace_member(workspace_id, auth.uid())` 분기 추가
- [x] payroll trigger 흐름 영향 분석 — owner 권한 범위에서 editor 도 동일 수정 가능, 정산 흐름 단일성 유지

## DOWN script (rollback)
migration 파일 헤더에 명시. `wl_select` / `wl_update` 를 분기 없는 원본으로 되돌리는 SQL 포함.

## Staging note
plan 권장은 "3A 머지 후 1주 모니터링 → 3B" 였으나 단일 세션 진행 요청. 검증 게이트 (jest + advisors 0 ERROR) 모두 통과해서 안전 하한 충족.

## Test plan
- [ ] master 머지 후 staging 환경 editor 계정으로 work_logs 조회 회귀 확인
- [ ] payroll 정산 흐름 (owner) 회귀 확인 — work_logs UPDATE → 정산 trigger 정상 동작
- [ ] editor → work_log 수정 → 정산 status 동기화 동작 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)