### PR TITLE
fix(workspace): workspace_members realtime publication 추가 — Phase 1A 회수 가드 P0 hotfix

### DIFF
--- a/uniqn-mobile/supabase/migrations/20260509020000_workspace_members_realtime_publication.sql
+++ b/uniqn-mobile/supabase/migrations/20260509020000_workspace_members_realtime_publication.sql
@@ -1,0 +1,17 @@
+-- Phase 1A hotfix — workspace_members 를 supabase_realtime publication 에 추가
+--
+-- PR #61 의 useWorkspaceRevocationGuard 가 1차 채널로 workspace_members DELETE
+-- 이벤트를 postgres_changes 로 구독하나, 본 publication 누락으로 영원히
+-- 트리거되지 않았음. 30초 검증 결과 RevocationModal 미표시 (2026-05-09 세션).
+--
+-- 본 hotfix:
+-- - workspace_members 를 publication 에 추가하여 Realtime DELETE 이벤트 활성화
+-- - editor 가 회수당했을 때 5초 내 RevocationModal + 자동 logout 정상 동작
+--
+-- 다른 workspace 테이블 (workspaces, workspace_invitations) 도 향후 Realtime
+-- 필요 시 별도 migration 으로 추가. 본 hotfix 는 회수 가드만 우선 복구.
+--
+-- DOWN script (rollback) — 별도 migration 으로 적용:
+-- ALTER PUBLICATION supabase_realtime DROP TABLE public.workspace_members;
+
+ALTER PUBLICATION supabase_realtime ADD TABLE public.workspace_members;


### PR DESCRIPTION
## Summary
- 🔴 **P0 fix**: `workspace_members` 테이블이 `supabase_realtime` publication 에 누락되어 PR #61 의 회수 가드 1차 채널이 작동하지 않음
- migration: `ALTER PUBLICATION supabase_realtime ADD TABLE public.workspace_members`
- 코드 변경 0, RLS 정책 변경 0

## 발견 경위
2026-05-09 Phase 1 검증 (Playwright MCP) 중 S3 시나리오 실행:
1. review-employer 가 admin owner workspace 의 editor 로 활성화
2. SQL DELETE workspace_members → 30초 대기
3. RevocationModal 미표시 → root cause 추적

```sql
SELECT schemaname, tablename FROM pg_publication_tables 
WHERE pubname = 'supabase_realtime' AND tablename LIKE 'workspace%';
-- 결과: 0건 (notifications, applications, work_logs, board_* 만 등록)
```

`useWorkspaceRevocationGuard` 의 `createRealtimeSubscription('workspace_members', ...)` 호출은
정상이지만, publication 누락으로 PostgreSQL → Realtime broker → client 의 이벤트 흐름 자체가 차단됨.

## 검증 (자동화 차단 사항)
- ✅ `pg_publication_tables` 에 `workspace_members` 추가 확인 (apply_migration 직후)
- ⚠️ Playwright 자동 검증은 dev server hot reload 이슈로 본 PR 에서는 미실행
  - hot reload 미적용 → 코드 변경 (디버그 로그) 이 새 bundle 에 반영 안 됨
  - migration 자체는 명백한 누락 보강 — 다른 6개 테이블은 동일 패턴으로 등록되어 있음
  - 머지 후 staging 환경에서 회수 시나리오 회귀 검증 권장

## 후속 작업 (별도 PR)
- 2차 채널 (`useWorkspaceMembers` fetch diff) 자동 폴링 (`refetchInterval: 30_000`) 추가
- staging 환경 두 컨텍스트 (owner / editor) 동시 운용 → 5초 내 RevocationModal + 자동 logout 측정

## Test plan
- [ ] 머지 후 staging 환경에서 editor 회수 시 5초 내 RevocationModal 등장 확인
- [ ] `useWorkspaceRevocationGuard` Realtime DELETE 이벤트 수신 콘솔 로그 확인
- [ ] owner 본인 회수 시 (자기 자신) modal 미표시 — isOwner 가드 회귀

## DOWN script
migration 헤더 주석:
```sql
ALTER PUBLICATION supabase_realtime DROP TABLE public.workspace_members;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)