### PR TITLE
fix(workspace): mapWorkspaceRpcError 다중 원인 인식 메시지 — P2 hotfix

### DIFF
--- a/uniqn-mobile/src/errors/__tests__/workspace.test.ts
+++ b/uniqn-mobile/src/errors/__tests__/workspace.test.ts
@@ -73,12 +73,13 @@ describe('mapWorkspaceRpcError (PR #2)', () => {
     );
   });
 
-  it('RLS cap 도달 → CAP_REACHED', () => {
+  it('RLS INSERT 거절 → INSERT_DENIED (cap/role/owner_id 다중 원인 인식)', () => {
     const err = mapWorkspaceRpcError({
       message: 'new row violates row-level security policy',
     });
     expect(err).not.toBeNull();
-    expect(err!.code).toBe(WORKSPACE_ERROR_CODES.WORKSPACE_CAP_REACHED);
+    expect(err!.code).toBe(WORKSPACE_ERROR_CODES.WORKSPACE_INSERT_DENIED);
+    expect(err!.userMessage).toContain('권한이 부족하거나 최대 개수');
     expect(err!.userMessage).toContain('10개');
   });
 

--- a/uniqn-mobile/src/errors/workspace.ts
+++ b/uniqn-mobile/src/errors/workspace.ts
@@ -30,6 +30,8 @@ export const WORKSPACE_ERROR_CODES = {
   WORKSPACE_SELF_INVITE: 'E6088',
   WORKSPACE_CANNOT_REMOVE_OWNER: 'E6089',
   WORKSPACE_CAP_REACHED: 'E6090',
+  /** RLS INSERT 정책 위반 — cap/role/owner_id 중 어느 것이 fail 했는지 RPC 응답만으로 분간 불가 */
+  WORKSPACE_INSERT_DENIED: 'E6091',
 } as const;
 
 const WORKSPACE_ERROR_USER_MESSAGES: Record<string, string> = {
@@ -48,6 +50,8 @@ const WORKSPACE_ERROR_USER_MESSAGES: Record<string, string> = {
     '워크스페이스 소유자는 멤버에서 제외할 수 없습니다.',
   [WORKSPACE_ERROR_CODES.WORKSPACE_CAP_REACHED]:
     '워크스페이스는 사용자당 최대 10개까지 만들 수 있어요. 사용하지 않는 워크스페이스를 정리해주세요.',
+  [WORKSPACE_ERROR_CODES.WORKSPACE_INSERT_DENIED]:
+    '워크스페이스를 만들 수 없어요. 권한이 부족하거나 최대 개수(10개)에 도달했을 수 있어요. 잠시 후 다시 시도해주세요.',
 };
 
 function makeWorkspaceError(code: string): AppError {
@@ -118,11 +122,14 @@ export function mapWorkspaceRpcError(error: unknown): AppError | null {
   if (upper.includes('WORKSPACE_NOT_FOUND'))
     return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_NOT_FOUND);
 
-  // RLS 위반 패턴 — INSERT 정책 거절 (cap 도달 등)
+  // RLS 위반 패턴 — INSERT 정책 거절
+  // workspaces_insert_employer_with_cap CHECK = (owner_id 일치) AND (role) AND (cap < 10)
+  // 셋 중 어느 것이 fail 했는지 RPC 응답으로 분간 불가 — multi-cause 메시지로 통합
+  // (사전 cap 체크는 호출자가 workspace_count_for_owner RPC 로 확인 후 분기 가능)
   if (upper.includes('NEW ROW VIOLATES ROW-LEVEL SECURITY POLICY')) {
-    return new BusinessError(WORKSPACE_ERROR_CODES.WORKSPACE_CAP_REACHED, {
+    return new BusinessError(WORKSPACE_ERROR_CODES.WORKSPACE_INSERT_DENIED, {
       userMessage:
-        WORKSPACE_ERROR_USER_MESSAGES[WORKSPACE_ERROR_CODES.WORKSPACE_CAP_REACHED] ?? '권한 부족',
+        WORKSPACE_ERROR_USER_MESSAGES[WORKSPACE_ERROR_CODES.WORKSPACE_INSERT_DENIED] ?? '권한 부족',
     });
   }
 


### PR DESCRIPTION
## Summary
- ⚪ **P2 fix**: 기존은 모든 RLS INSERT 위반을 \"10개 cap\" 메시지로 매핑 → 사용자 오인유도
- 새 코드 \`WORKSPACE_INSERT_DENIED\` (E6091) + 다중 원인 메시지로 분리
- jest 11/11 PASS (기존 10 + 1 갱신)

## 발견 경위
2026-05-09 Phase 1 검증 중 review-employer (workspace 0개) 가 첫 워크스페이스 생성 시도:

```text
Console error: BusinessError: 워크스페이스는 사용자당 최대 10개까지 만들 수 있어요...
```

확인:
- workspace_count_for_owner(b2222...) = 0 ✅
- raw_app_meta_data.role = 'employer' ✅
- get_my_role() 는 SQL 컨텍스트로 호출 시 'employer' 정상

원인 미상 (client JWT 컨텍스트 문제 가능)이지만, **메시지 매핑 자체가 misleading**.

\`workspaces_insert_employer_with_cap\` CHECK:
\`\`\`
((owner_id = auth.uid()) AND (get_my_role() = ANY ('employer','admin')) AND (workspace_count_for_owner(owner_id) < 10))
\`\`\`

3 조건 중 어느 것이 fail 했어도 동일 RLS 에러. RPC 응답으로 분간 불가.

## 해결
**before:**
```
new row violates RLS → BusinessError(WORKSPACE_CAP_REACHED, '10개까지 만들 수 있어요')
```

**after:**
```
new row violates RLS → BusinessError(WORKSPACE_INSERT_DENIED,
  '권한이 부족하거나 최대 개수(10개)에 도달했을 수 있어요. 잠시 후 다시 시도해주세요.')
```

## 후속 작업 (별도 PR)
- 클라이언트가 \`workspace_count_for_owner\` 사전 호출 → cap 명확화
- RLS 정책 대신 SECURITY DEFINER trigger 로 명시적 RAISE EXCEPTION 'WORKSPACE_CAP_REACHED' 검토

## Test plan
- [x] jest 11/11 PASS
- [x] type-check 통과
- [ ] 머지 후 staging 환경에서 cap 도달 시 메시지 확인
- [ ] 신규 employer 워크스페이스 0개 시 생성 시도 root cause 추적 (별도 task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)