### PR TITLE
fix(workspace): create_workspace SECURITY DEFINER RPC — JWT staleness 우회

### DIFF
--- a/uniqn-mobile/src/errors/__tests__/workspace.test.ts
+++ b/uniqn-mobile/src/errors/__tests__/workspace.test.ts
@@ -73,13 +73,28 @@ describe('mapWorkspaceRpcError (PR #2)', () => {
     );
   });
 
-  it('RLS cap 도달 → CAP_REACHED', () => {
+  it('RLS cap 도달 (literal RLS 메시지) → CAP_REACHED', () => {
     const err = mapWorkspaceRpcError({
       message: 'new row violates row-level security policy',
     });
     expect(err).not.toBeNull();
     expect(err!.code).toBe(WORKSPACE_ERROR_CODES.WORKSPACE_CAP_REACHED);
     expect(err!.userMessage).toContain('10개');
+  });
+
+  it('WORKSPACE_CAP_REACHED (RPC raise — create_workspace 경로) → CAP_REACHED', () => {
+    const err = mapWorkspaceRpcError({
+      message: 'P0001: WORKSPACE_CAP_REACHED',
+    });
+    expect(err).not.toBeNull();
+    expect(err!.code).toBe(WORKSPACE_ERROR_CODES.WORKSPACE_CAP_REACHED);
+    expect(isBusinessError(err!)).toBe(true);
+  });
+
+  it('VALIDATION_REQUIRED (create_workspace 빈 name) → ValidationError', () => {
+    const err = mapWorkspaceRpcError({ message: 'VALIDATION_REQUIRED' });
+    expect(err).not.toBeNull();
+    expect(isValidationError(err!)).toBe(true);
   });
 
   it('알 수 없는 에러 → null (호출자가 일반 처리)', () => {

--- a/uniqn-mobile/src/errors/workspace.ts
+++ b/uniqn-mobile/src/errors/workspace.ts
@@ -87,6 +87,15 @@ export function mapWorkspaceRpcError(error: unknown): AppError | null {
       userMessage: '워크스페이스 편집 권한이 회수되었어요. 다시 로그인하면 최신 상태가 적용됩니다.',
     });
 
+  if (upper.includes('VALIDATION_REQUIRED'))
+    return new ValidationError(ERROR_CODES.VALIDATION_REQUIRED, {
+      userMessage: '필수 입력 항목입니다.',
+    });
+
+  // create_workspace RPC 가 cap 도달 시 명시적으로 raise — RLS 우회 경로 (SECURITY DEFINER)
+  if (upper.includes('WORKSPACE_CAP_REACHED'))
+    return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_CAP_REACHED);
+
   if (upper.includes('SELF_INVITE_FORBIDDEN'))
     return makeWorkspaceError(WORKSPACE_ERROR_CODES.WORKSPACE_SELF_INVITE);
 

--- a/uniqn-mobile/src/hooks/workspace/useWorkspaces.ts
+++ b/uniqn-mobile/src/hooks/workspace/useWorkspaces.ts
@@ -304,7 +304,7 @@ export function useCreateWorkspace() {
   const queryClient = useQueryClient();
   const { user } = useAuthStore();
   return useMutation({
-    mutationFn: (name: string) => workspaceService.createWorkspace({ name, ownerId: user!.uid }),
+    mutationFn: (name: string) => workspaceService.createWorkspace({ name }),
     onSuccess: () => {
       if (user?.uid) {
         queryClient.invalidateQueries({

--- a/uniqn-mobile/src/repositories/interfaces/IWorkspaceRepository.ts
+++ b/uniqn-mobile/src/repositories/interfaces/IWorkspaceRepository.ts
@@ -16,10 +16,10 @@ import type {
 
 export interface IWorkspaceRepository {
   /**
-   * 워크스페이스 생성
-   * @throws AppError E3 cap 도달 / E5 권한 부족 / E1 네트워크
+   * 워크스페이스 생성 (RPC create_workspace 경유 — auth.uid() 자동 사용)
+   * @throws AppError E3 검증 / E5 권한 부족 / E6 cap 도달 / E1 네트워크
    */
-  create(name: string, ownerId: string): Promise<Workspace>;
+  create(name: string): Promise<Workspace>;
 
   /** 단건 조회 — RLS 차단 시 undefined */
   findById(id: string): Promise<Workspace | undefined>;

--- a/uniqn-mobile/src/repositories/supabase/WorkspaceRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/WorkspaceRepository.ts
@@ -23,15 +23,24 @@ function rowToWorkspace(row: Record<string, unknown>): Workspace {
 }
 
 export class SupabaseWorkspaceRepository implements IWorkspaceRepository {
-  async create(name: string, ownerId: string): Promise<Workspace> {
+  /**
+   * 워크스페이스 생성 — RPC `create_workspace` 경유.
+   *
+   * SECURITY DEFINER + public.users.role 조회로 JWT staleness 우회.
+   * (Edge Function 사후 setRole + refreshSession 누락으로 client JWT 의 app_metadata.role 이
+   *  비어 있어도 동작 — 2026-05-09 root cause fix)
+   *
+   * RPC 에러 코드:
+   *   AUTH_REQUIRED         → AppError E1
+   *   PERMISSION_DENIED     → AppError E5
+   *   VALIDATION_REQUIRED   → AppError E3
+   *   WORKSPACE_CAP_REACHED → BusinessError E6090
+   */
+  async create(name: string): Promise<Workspace> {
     try {
-      logger.info('워크스페이스 생성 시작', { ownerId, name });
+      logger.info('워크스페이스 생성 시작', { name });
 
-      const { data, error } = await supabase
-        .from(TABLE)
-        .insert({ name, owner_id: ownerId })
-        .select(COLUMNS)
-        .single();
+      const { data, error } = await supabase.rpc('create_workspace', { p_name: name });
 
       if (error) {
         const mapped = mapWorkspaceRpcError(error);
@@ -39,8 +48,16 @@ export class SupabaseWorkspaceRepository implements IWorkspaceRepository {
         handleSupabaseError(error, { operation: '워크스페이스 생성', table: TABLE });
       }
 
-      logger.info('워크스페이스 생성 완료', { workspaceId: data!.id });
-      return rowToWorkspace(data as Record<string, unknown>);
+      const row = data as Record<string, unknown> | null;
+      if (!row) {
+        handleSupabaseError(new Error('create_workspace returned null'), {
+          operation: '워크스페이스 생성',
+          table: TABLE,
+        });
+      }
+
+      logger.info('워크스페이스 생성 완료', { workspaceId: row!.id });
+      return rowToWorkspace(row!);
     } catch (error) {
       if (isAppError(error)) throw error;
       handleSupabaseError(error, { operation: '워크스페이스 생성', table: TABLE });

--- a/uniqn-mobile/src/services/workspace/workspaceService.ts
+++ b/uniqn-mobile/src/services/workspace/workspaceService.ts
@@ -30,17 +30,19 @@ function toValidationError(error: unknown): never {
 
 export const workspaceService = {
   /**
-   * 새 워크스페이스 생성
-   * RLS 가 cap (10) 강제 — 도달 시 mapWorkspaceRpcError 가 WORKSPACE_CAP_REACHED 변환.
+   * 새 워크스페이스 생성 — `create_workspace` RPC 경유 (SECURITY DEFINER + public.users.role 조회).
+   *
+   * ownerId 는 RPC 가 auth.uid() 로 자동 결정 — 클라이언트 입력 무시.
+   * RPC 가 cap (10) 와 role(employer/admin) 검증 → mapWorkspaceRpcError 가 도메인 에러로 변환.
    */
-  async createWorkspace(input: { name: string; ownerId: string }): Promise<Workspace> {
+  async createWorkspace(input: { name: string }): Promise<Workspace> {
     const parsed = createWorkspaceSchema.safeParse({ name: input.name });
     if (!parsed.success) {
       const message = parsed.error.issues[0]?.message ?? '입력값 오류';
       throw new ValidationError(ERROR_CODES.VALIDATION_SCHEMA, { userMessage: message });
     }
 
-    return workspaceRepository.create(parsed.data.name, input.ownerId);
+    return workspaceRepository.create(parsed.data.name);
   },
 
   /**

--- a/uniqn-mobile/supabase/migrations/20260514030000_workspace_create_workspace_rpc.sql
+++ b/uniqn-mobile/supabase/migrations/20260514030000_workspace_create_workspace_rpc.sql
@@ -1,0 +1,66 @@
+-- create_workspace RPC
+-- Root cause fix: client JWT app_metadata.role 이 stale 일 때 workspaces_insert_employer_with_cap
+-- WITH CHECK 가 fail 하여 첫 워크스페이스 생성 차단. SECURITY DEFINER 로 public.users.role 을
+-- DB-of-record 로 사용하여 JWT 의존성 제거.
+--
+-- 호환: 기존 RLS workspaces_insert_employer_with_cap 는 그대로 유지 (defense-in-depth).
+--       SECURITY DEFINER 가 RLS 를 우회하므로 클라이언트는 항상 RPC 경유.
+--
+-- 에러 코드 (RAISE EXCEPTION):
+--   AUTH_REQUIRED         — auth.uid() null
+--   PERMISSION_DENIED     — public.users.role 이 employer/admin 아님 (또는 비활성)
+--   VALIDATION_REQUIRED   — name null/빈 문자열
+--   WORKSPACE_CAP_REACHED — owner 가 이미 10 개 워크스페이스 보유
+
+CREATE OR REPLACE FUNCTION public.create_workspace(p_name TEXT)
+RETURNS public.workspaces
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_uid uuid;
+  v_role text;
+  v_count int;
+  v_row public.workspaces%ROWTYPE;
+BEGIN
+  v_uid := auth.uid();
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'AUTH_REQUIRED';
+  END IF;
+
+  IF p_name IS NULL OR length(trim(p_name)) = 0 THEN
+    RAISE EXCEPTION 'VALIDATION_REQUIRED';
+  END IF;
+
+  -- DB-of-record (public.users.role) 조회 — JWT staleness 우회
+  SELECT role::text INTO v_role
+  FROM public.users
+  WHERE id = v_uid AND is_active = true;
+
+  IF v_role IS NULL OR v_role NOT IN ('employer', 'admin') THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED';
+  END IF;
+
+  -- cap (10) — workspace_count_for_owner 동일 로직 (RLS 정책과 동기화)
+  SELECT count(*)::int INTO v_count
+  FROM public.workspaces
+  WHERE owner_id = v_uid;
+
+  IF v_count >= 10 THEN
+    RAISE EXCEPTION 'WORKSPACE_CAP_REACHED';
+  END IF;
+
+  -- INSERT (CHECK constraint workspaces_name_length 가 1~50 자 강제)
+  INSERT INTO public.workspaces (name, owner_id)
+  VALUES (p_name, v_uid)
+  RETURNING * INTO v_row;
+
+  RETURN v_row;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.create_workspace(TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.create_workspace(TEXT) IS
+  '워크스페이스 생성 RPC. SECURITY DEFINER + public.users.role 조회로 JWT staleness (Edge Function 사후 setRole + refreshSession 누락) 우회. 2026-05-09 root cause fix.';


### PR DESCRIPTION
## Summary
- 🔴 **Root cause fix**: review-employer 첫 워크스페이스 INSERT 시 `42501 new row violates row-level security policy for table workspaces` 발생 → `create_workspace(p_name)` SECURITY DEFINER plpgsql RPC 신설로 JWT staleness 우회
- migration: 20260514030000 (적용 완료 — `mcp__supabase__apply_migration`)
- 기존 RLS `workspaces_insert_employer_with_cap` 는 defense-in-depth 로 유지

## Root cause 추적

`workspaces_insert_employer_with_cap` WITH CHECK 3 조건:
1. `owner_id = auth.uid()`
2. `get_my_role() IN ('employer', 'admin')` ← **여기서 fail**
3. `workspace_count_for_owner(owner_id) < 10`

`get_my_role()` 은 `auth.jwt() -> 'app_metadata' ->> 'role'` 을 읽음. 그러나:
1. `authCoreService.signUp` 은 `options.data.name` 만 설정 (user_metadata)
2. `verify-and-save-portone-profile` Edge Function 이 `admin.updateUserById({app_metadata:{role:'staff'}})` 호출
3. signUp 후 **클라이언트가 `supabase.auth.refreshSession()` 호출 안 함**
4. JWT 의 `app_metadata.role` 영구 stale (admin 이 staff→employer 승격해도 동일)

production DB `pg_temp.test_rls_workspace_insert()` 시뮬레이션으로 확정:
- A 정상 JWT → INSERT OK
- B JWT app_metadata 누락 → 42501 (정확히 같은 메시지)
- C JWT role=staff (DB role=employer) → 42501

## Fix 설계

`create_workspace(p_name TEXT)` SECURITY DEFINER plpgsql RPC:
- `auth.uid()` null check → \`AUTH_REQUIRED\`
- `p_name` null/empty check → \`VALIDATION_REQUIRED\`
- `public.users.role` (DB-of-record) 조회 — `is_active=true` AND role IN ('employer','admin') → 아니면 \`PERMISSION_DENIED\`
- cap(10) check → \`WORKSPACE_CAP_REACHED\`
- INSERT + RETURNING

기존 RLS 정책 변경 없음 — RPC 가 SECURITY DEFINER 로 RLS 우회. 직접 INSERT 경로는 RLS 가 여전히 차단 (defense-in-depth).

## Files

| 파일 | 변경 |
|------|------|
| `supabase/migrations/20260514030000_*.sql` | NEW — `create_workspace(p_name)` RPC |
| `src/repositories/supabase/WorkspaceRepository.ts` | `.from().insert()` → `.rpc('create_workspace')` |
| `src/repositories/interfaces/IWorkspaceRepository.ts` | `create(name, ownerId)` → `create(name)` |
| `src/services/workspace/workspaceService.ts` | `createWorkspace({name, ownerId})` → `createWorkspace({name})` |
| `src/hooks/workspace/useWorkspaces.ts` | mutationFn 에서 `ownerId: user!.uid` 제거 |
| `src/errors/workspace.ts` | `VALIDATION_REQUIRED` + `WORKSPACE_CAP_REACHED` 명시 매핑 |
| `src/errors/__tests__/workspace.test.ts` | 신규 2 케이스 (총 13/13 PASS) |

## 검증

### `pg_temp.test_create_workspace_rpc()` 시뮬레이션 (production DB)
| Scenario | Result |
|----------|--------|
| A_role_employer_jwt | ✅ OK |
| B_jwt_no_metadata (root cause) | ✅ OK (bug fix) |
| C_jwt_stale_staff_role | ✅ OK (bug fix) |
| D_staff_user_jwt_says_employer | ✅ P0001 PERMISSION_DENIED (security) |
| E_empty_name | ✅ P0001 VALIDATION_REQUIRED |

### Quality Gate
- ✅ `tsc --noEmit` exit 0
- ✅ jest workspace tests — 73/73 PASS (10 suites)
- ✅ ESLint exit 0
- ✅ Prettier — All formatted

## Test plan
- [x] migration 적용 (production DB)
- [x] RPC 5 시나리오 시뮬레이션
- [x] type-check / lint / format / jest
- [ ] **머지 후 dev 서버 재기동 → review-employer 로그인 → 워크스페이스 생성 시도**
- [ ] 신규 employer 회원가입 플로우 — signup → 즉시 워크스페이스 생성 시도

## 후속 작업 (별도 PR 후보)
- signup 직후 `supabase.auth.refreshSession()` 호출 추가 (다른 RLS 정책 보호)
- 다른 RLS 정책 (admin gate 등) 도 동일 원인으로 staleness 영향 있을 수 있음 — 점검 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)