### PR TITLE
fix(workspace): admin 비-소유 워크스페이스 누출 방지 — list_my_workspaces RPC

### DIFF
--- a/uniqn-mobile/src/repositories/supabase/WorkspaceRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/WorkspaceRepository.ts
@@ -79,15 +79,17 @@ export class SupabaseWorkspaceRepository implements IWorkspaceRepository {
   }
 
   /**
-   * "내가 멤버인 모든 워크스페이스" — owner OR editor.
-   * RLS workspaces_select_owner_or_member 가 자동으로 필터링하므로 select * 만 호출.
+   * "내가 멤버인 모든 워크스페이스" — owner OR explicit editor (workspace_members).
+   *
+   * `list_my_workspaces` RPC 경유 — RLS workspaces_select_owner_or_member 의 `OR is_admin()`
+   * 분기를 우회하여 admin role 사용자가 비-소유 워크스페이스를 "공동관리/편집자" 로
+   * 잘못 보지 않도록 한다. admin global access 는 다른 컨텍스트 (admin 화면) 에서 보존.
+   *
+   * @param _userId 호출 시그니처 호환용. RPC 가 auth.uid() 사용.
    */
   async findAllByMember(_userId: string): Promise<Workspace[]> {
     try {
-      const { data, error } = await supabase
-        .from(TABLE)
-        .select(COLUMNS)
-        .order('created_at', { ascending: true });
+      const { data, error } = await supabase.rpc('list_my_workspaces');
 
       if (error) {
         handleSupabaseError(error, { operation: '워크스페이스 목록 조회', table: TABLE });

--- a/uniqn-mobile/supabase/migrations/20260514040000_workspace_list_my_workspaces_rpc.sql
+++ b/uniqn-mobile/supabase/migrations/20260514040000_workspace_list_my_workspaces_rpc.sql
@@ -1,0 +1,53 @@
+-- list_my_workspaces RPC
+-- 문제: workspaces_select_owner_or_member RLS 의 `OR is_admin()` 으로 admin role 사용자는
+-- 모든 워크스페이스를 SELECT 할 수 있음. WorkspaceSwitcher / "내 워크스페이스" 화면이
+-- 이를 그대로 노출 → 비-소유 워크스페이스가 "편집자/공동관리" 로 잘못 표시.
+--
+-- 해결: 명시적 WHERE 로 owner OR 명시적 member 만 반환. RLS USING 은 그대로 유지하여
+-- admin global access 는 다른 컨텍스트 (admin 화면) 에서 보존.
+
+CREATE OR REPLACE FUNCTION public.list_my_workspaces()
+RETURNS TABLE (
+  id uuid,
+  name text,
+  owner_id uuid,
+  member_count int,
+  created_at timestamptz,
+  updated_at timestamptz
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY INVOKER
+SET search_path = 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_uid uuid;
+BEGIN
+  v_uid := auth.uid();
+  IF v_uid IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    w.id,
+    w.name,
+    w.owner_id,
+    w.member_count,
+    w.created_at,
+    w.updated_at
+  FROM public.workspaces w
+  WHERE
+    w.owner_id = v_uid
+    OR EXISTS (
+      SELECT 1 FROM public.workspace_members wm
+      WHERE wm.workspace_id = w.id AND wm.user_id = v_uid
+    )
+  ORDER BY w.created_at ASC;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.list_my_workspaces() TO authenticated;
+
+COMMENT ON FUNCTION public.list_my_workspaces() IS
+  '현재 사용자가 owner 또는 명시적 member 인 워크스페이스만 반환. admin global RLS 우회 (Switcher / 내 워크스페이스 UI 용). 2026-05-09.';


### PR DESCRIPTION
## Summary
- 🔴 **버그**: review-admin 로그인 후 WorkspaceSwitcher 에 본인 소유 외 review-employer 의 워크스페이스가 "공동관리/편집자" 로 잘못 노출
- migration: `list_my_workspaces()` SECURITY INVOKER RPC — owner OR explicit member 만 반환
- WorkspaceRepository.findAllByMember 가 RPC 경유로 변경

## Root cause

`workspaces_select_owner_or_member` USING:
\`\`\`sql
is_workspace_member(id, auth.uid()) OR is_admin()
\`\`\`

admin role 의 \`is_admin() = true\` → 모든 워크스페이스 SELECT 가능.

Repository.findAllByMember 가 \`.from('workspaces').select(...)\` 로 RLS 단독 의존 →
admin 사용자에게 모든 워크스페이스 리턴. UI 가 owner_id 매칭만으로 분기:
- \`owner_id === uid\` → "소유자"
- 그 외 → "편집자/공동관리"

→ admin 사용자가 다른 사람의 워크스페이스를 "공동관리" 로 보는 누출.

## Fix 설계

**`list_my_workspaces()` SECURITY INVOKER RPC**:
- \`auth.uid()\` null-check
- 명시적 WHERE: \`owner_id = uid OR EXISTS (workspace_members WHERE user_id = uid)\`
- admin global access 는 \`workspaces_select_owner_or_member\` USING 그대로 보존 → admin 화면 (별도 페이지) 영향 없음

## 검증

### `pg_temp.test_list_my_workspaces()` 시뮬레이션 (production DB)
| Caller | 결과 | 비고 |
|--------|------|------|
| admin | 1 workspace (본인 소유만) | 이전 2개 → 1개 (수정 효과) |
| employer | 1 workspace (본인 소유만) | 변화 없음 (정상 동작 유지) |
| staff | 0 workspaces | 변화 없음 |

### Quality Gate
- ✅ \`npx tsc --noEmit\` exit 0
- ✅ \`npx jest --testPathPattern=Workspace\` 87/87 PASS (12 suites)

## Test plan
- [x] migration 적용 (production DB)
- [x] 시뮬레이션 — admin / employer / staff 결과 검증
- [x] type-check / jest
- [ ] 머지 후 review-admin 재로그인 → Switcher 에 본인 소유 1개만 표시 확인

## Files
- migration: \`supabase/migrations/20260514040000_workspace_list_my_workspaces_rpc.sql\`
- repository: \`src/repositories/supabase/WorkspaceRepository.ts\` — findAllByMember RPC 호출

🤖 Generated with [Claude Code](https://claude.com/claude-code)