### PR TITLE
fix(workspace): active workspace 별 공고 분리 + cancellation 멤버 호환 — Phase 2A.후속

### DIFF
--- a/docs/superpowers/plans/2026-05-09-workspace-posting-filter.md
+++ b/docs/superpowers/plans/2026-05-09-workspace-posting-filter.md
@@ -1,0 +1,830 @@
+# Workspace Posting Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Active workspace 단위로 employer 의 공고 관리 흐름을 분리하고, cancellation/리뷰 헬퍼가 워크스페이스 멤버를 차단하지 않도록 한다.
+
+**Architecture:** (a) `JobPostingRepository.getManagedJobPostings` 가 `workspace_id` 필터를 받고, `useMyJobPostings` 가 `useActiveWorkspace` 의 id 를 query key + queryFn 인자로 주입한다 — Switcher 변경 시 React Query 가 자동 re-fetch. (b) `loadAndVerifyJobPostingOwner` 가 owner 외에 `is_workspace_member` / `is_admin` RPC 분기를 추가해 6+ employer 흐름(취소 검토, 거절, 읽음, 확정, 확정취소, 지원자 목록)이 워크스페이스 멤버 + admin 까지 호환된다.
+
+**Tech Stack:** TypeScript 5.x · React 19.2 · Expo 55 · TanStack Query 5 · Supabase JS · Zustand · NativeWind 4.2 · Jest
+
+---
+
+## Context — 검증된 Root Causes (2026-05-09 dogfooding)
+
+1. **`JobPostingRepository.getManagedJobPostings` 가 workspace_id 필터 미적용** (line 305-319). 주석은 "RLS 가 좁힌다"고 적혀 있으나 jp_select RLS 의 첫 분기 `status IN ('approved','active','closed')` 가 **모든 인증 사용자에게 active 공고 SELECT 허용**(staff 검색용). 결과: employer A 의 my-postings 에 employer B 의 active 공고 통합 노출.
+
+2. **`useMyJobPostings` query key 에 `activeWorkspaceId` 미포함** (`useJobManagement.ts:45-63`). Switcher 가 `setActiveWorkspaceId` 호출해도 query key 가 안 바뀌어 re-fetch 트리거 안 됨.
+
+3. **`loadAndVerifyJobPostingOwner` 가 owner-only 체크** (`ApplicationRepositoryHelpers.ts:156-168`). Phase 2A 에서 applications/job_postings RLS 는 owner OR workspace_member OR admin 으로 풀렸지만 클라이언트 헬퍼는 그대로 차단 → 부분 마이그레이션 상태. 6+ 흐름 영향: `getCancellationRequests`, `rejectWithTransaction`, `markAsRead`, `findByJobPostingWithStats`, `confirmWithHistoryTransaction`, `cancelConfirmationTransaction`.
+
+**Out of scope (별도 plan):**
+- Phase 3 (RLS jp_select 분리 — Task 5 follow-up section) — eng-review 필요.
+- Phase 4 (applications/work_logs/event_qr_codes/settlement/schedule 같은 패턴 audit — Task 6 follow-up section).
+- `JobPostingRepository.loadAndVerifyOwner` (write-side: update/close/reopen/delete/settlement) — 따로 검토. 본 plan 은 read + cancellation 흐름만.
+
+---
+
+## File Structure
+
+**Modify:**
+- `uniqn-mobile/src/repositories/interfaces/IJobPostingRepository.ts` — interface 시그니처에 `workspaceId?` 추가 (line 140 근처).
+- `uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts` — `getManagedJobPostings` 에 `workspaceId?` 파라미터 + `eq('workspace_id', ...)` 적용 (line 305-319).
+- `uniqn-mobile/src/services/jobs/jobService.ts` — `getMyJobPostings` options 에 `workspaceId?` 추가, repo 호출 두 군데 모두 pass-through (line 229-254).
+- `uniqn-mobile/src/hooks/useJobManagement.ts` — `getMyJobPostingsQueryKey` 시그니처 확장 + `useMyJobPostings` 가 `useActiveWorkspace` 사용 (line 45-63).
+- `uniqn-mobile/src/repositories/supabase/ApplicationRepositoryHelpers.ts` — `loadAndVerifyJobPostingOwner` 가 `is_workspace_member` + `is_admin` RPC 분기 추가 (line 156-168).
+
+**Modify (tests):**
+- `uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.workspace.editor.test.ts` — workspaceId 필터 회귀 테스트 추가.
+- `uniqn-mobile/src/services/jobs/__tests__/jobService.test.ts` — workspaceId pass-through 테스트 추가.
+- `uniqn-mobile/src/__tests__/hooks/useJobManagement.test.ts` — activeWorkspace 의존성 테스트 추가.
+
+**Create (tests):**
+- `uniqn-mobile/src/repositories/supabase/__tests__/ApplicationRepositoryHelpers.workspace.test.ts` — `loadAndVerifyJobPostingOwner` 4 역할(owner/member/admin/외부인) 테스트.
+
+---
+
+## Phase 1 — Workspace-Aware Managed Listing (P0)
+
+### Task 1A: Repository getManagedJobPostings 에 workspaceId 옵션 추가
+
+**Files:**
+- Modify: `uniqn-mobile/src/repositories/interfaces/IJobPostingRepository.ts:140`
+- Modify: `uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts:305-319`
+- Modify (test): `uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.workspace.editor.test.ts`
+
+- [ ] **Step 1: Failing 테스트 추가 — workspaceId 인자 시 .eq('workspace_id', ...) 호출 검증**
+
+`uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.workspace.editor.test.ts` 의 `describe('JobPostingRepository.getManagedJobPostings — Phase 2A editor contract', ...)` 블록 끝에 `it` 추가:
+
+```ts
+it('Phase 2A.후속 — workspaceId 가 주어지면 .eq("workspace_id", id) 를 호출한다', async () => {
+  await repo.getManagedJobPostings('active', 'ws-abc-123');
+
+  expect(eqSpy).toHaveBeenCalledWith('status', 'active');
+  expect(eqSpy).toHaveBeenCalledWith('workspace_id', 'ws-abc-123');
+});
+
+it('Phase 2A.후속 — workspaceId 가 undefined 이면 workspace_id 필터를 추가하지 않는다', async () => {
+  await repo.getManagedJobPostings('active');
+
+  const workspaceCall = eqSpy.mock.calls.find((c) => c[0] === 'workspace_id');
+  expect(workspaceCall).toBeUndefined();
+});
+```
+
+> 참고: `eqSpy` 는 기존 테스트의 supabase chain mock 패턴. 같은 파일의 기존 `it` 들이 어떻게 spy 를 설정하는지 보고 동일 패턴 재사용. 새 mock 만들지 말 것.
+
+- [ ] **Step 2: 테스트 실행 → FAIL 확인**
+
+```bash
+cd uniqn-mobile && npx jest src/repositories/supabase/__tests__/JobPostingRepository.workspace.editor.test.ts -t "Phase 2A.후속" --no-coverage
+```
+
+기대: 새로 추가한 2개 케이스 모두 FAIL — `workspaceId` 시그니처가 아직 없음.
+
+- [ ] **Step 3: Interface 시그니처 확장**
+
+`uniqn-mobile/src/repositories/interfaces/IJobPostingRepository.ts:140`:
+
+```ts
+// Before
+getManagedJobPostings(status?: JobPostingStatus): Promise<JobPosting[]>;
+
+// After
+getManagedJobPostings(status?: JobPostingStatus, workspaceId?: string): Promise<JobPosting[]>;
+```
+
+- [ ] **Step 4: Repository 구현 확장**
+
+`uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts:305-319` 전체 교체:
+
+```ts
+/**
+ * Phase 2A — 호출자가 owner 또는 워크스페이스 멤버인 모든 공고 조회.
+ *
+ * RLS jp_select 가 `owner_id = auth.uid() OR is_workspace_member(workspace_id, auth.uid())`
+ * 분기를 제공하지만, jp_select 의 첫 분기 `status IN ('approved','active','closed')`
+ * 가 모든 인증 사용자에게 공개 공고 SELECT 권한을 주므로 employer my-postings 흐름은
+ * 클라이언트에서 workspace_id 로 명시적으로 좁혀야 한다 (Phase 2A.후속 — 2026-05-09).
+ */
+async getManagedJobPostings(
+  status?: JobPostingStatus,
+  workspaceId?: string,
+): Promise<JobPosting[]> {
+  try {
+    logger.info('관리 가능 공고 조회', { status, workspaceId });
+    let query = supabase.from(TABLE).select(TABLE_COLUMNS);
+    if (status) query = query.eq('status', status);
+    if (workspaceId) query = query.eq('workspace_id', workspaceId);
+    query = query.order('created_at', { ascending: false });
+    const { data, error } = await query;
+    if (error) handleSupabaseError(error, { operation: '관리 가능 공고 조회', table: TABLE });
+    const items = rowsToJobPostings((data ?? []) as Record<string, unknown>[]);
+    logger.info('관리 가능 공고 조회 완료', { count: items.length });
+    return items;
+  } catch (error) {
+    rethrowOrHandle(error, '관리 가능 공고 조회', { status, workspaceId });
+  }
+}
+```
+
+- [ ] **Step 5: 테스트 실행 → PASS 확인**
+
+```bash
+cd uniqn-mobile && npx jest src/repositories/supabase/__tests__/JobPostingRepository.workspace.editor.test.ts --no-coverage
+```
+
+기대: 신규 2개 + 기존 케이스 모두 PASS.
+
+- [ ] **Step 6: 타입 체크 — 의존자 누락 확인**
+
+```bash
+cd uniqn-mobile && npx tsc --noEmit
+```
+
+기대: 0 errors. (`getManagedJobPostings` 호출자가 시그니처 변화로 깨지지 않음 — `workspaceId` optional.)
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add uniqn-mobile/src/repositories/interfaces/IJobPostingRepository.ts \
+        uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts \
+        uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.workspace.editor.test.ts
+git commit -m "feat(workspace): JobPostingRepository.getManagedJobPostings workspaceId 필터 — Phase 2A.후속"
+```
+
+---
+
+### Task 1B: jobService.getMyJobPostings 가 workspaceId pass-through
+
+**Files:**
+- Modify: `uniqn-mobile/src/services/jobs/jobService.ts:229-254`
+- Modify (test): `uniqn-mobile/src/services/jobs/__tests__/jobService.test.ts`
+
+- [ ] **Step 1: Failing 테스트 추가 — options.workspaceId 가 repo 두 호출 모두에 전달되는지**
+
+`uniqn-mobile/src/services/jobs/__tests__/jobService.test.ts` 의 `getMyJobPostings` describe 블록 끝에:
+
+```ts
+it('Phase 2A.후속 — workspaceId 옵션을 active/closed 두 호출 모두에 전달한다', async () => {
+  mockRepo.getManagedJobPostings.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+  await getMyJobPostings('user-1', { workspaceId: 'ws-abc-123' });
+
+  expect(mockRepo.getManagedJobPostings).toHaveBeenCalledTimes(2);
+  expect(mockRepo.getManagedJobPostings).toHaveBeenNthCalledWith(1, 'active', 'ws-abc-123');
+  expect(mockRepo.getManagedJobPostings).toHaveBeenNthCalledWith(2, 'closed', 'ws-abc-123');
+});
+
+it('Phase 2A.후속 — workspaceId 미지정 시 두 번째 인자는 undefined 로 전달된다', async () => {
+  mockRepo.getManagedJobPostings.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+  await getMyJobPostings('user-1');
+
+  expect(mockRepo.getManagedJobPostings).toHaveBeenNthCalledWith(1, 'active', undefined);
+  expect(mockRepo.getManagedJobPostings).toHaveBeenNthCalledWith(2, 'closed', undefined);
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → FAIL 확인**
+
+```bash
+cd uniqn-mobile && npx jest src/services/jobs/__tests__/jobService.test.ts -t "Phase 2A.후속" --no-coverage
+```
+
+기대: 두 케이스 모두 FAIL.
+
+- [ ] **Step 3: Service 시그니처 확장**
+
+`uniqn-mobile/src/services/jobs/jobService.ts:229-254` 전체 교체:
+
+```ts
+/**
+ * 내 공고 목록 조회 (구인자용)
+ *
+ * Phase 2A.후속 (2026-05-09) — active workspace 단위로 좁힌다. workspaceId 미지정
+ * 시 RLS 가 허용하는 범위 전체(소유 + 멤버 워크스페이스 합산)가 반환되며 이는
+ * Switcher 도입 전 레거시 호출자 호환을 위해서만 유지한다.
+ */
+export async function getMyJobPostings(
+  ownerId: string,
+  options?: { status?: JobPosting['status']; includeAll?: boolean; workspaceId?: string }
+): Promise<JobPosting[]> {
+  try {
+    const { status, includeAll = true, workspaceId } = options || {};
+    logger.info('관리 가능 공고 목록 조회', { ownerId, status, includeAll, workspaceId });
+
+    if (includeAll && !status) {
+      const results = await Promise.all([
+        jobPostingRepository.getManagedJobPostings(STATUS.JOB_POSTING.ACTIVE, workspaceId),
+        jobPostingRepository.getManagedJobPostings(STATUS.JOB_POSTING.CLOSED, workspaceId),
+      ]);
+      return [...results[0], ...results[1]];
+    }
+
+    return jobPostingRepository.getManagedJobPostings(
+      status || STATUS.JOB_POSTING.ACTIVE,
+      workspaceId,
+    );
+  } catch (error) {
+    throw handleServiceError(error, {
+      operation: '관리 가능 공고 조회',
+      component: 'jobService',
+      context: { ownerId, workspaceId },
+    });
+  }
+}
+```
+
+- [ ] **Step 4: 테스트 실행 → PASS 확인**
+
+```bash
+cd uniqn-mobile && npx jest src/services/jobs/__tests__/jobService.test.ts --no-coverage
+```
+
+기대: 신규 2개 + 기존 케이스 모두 PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add uniqn-mobile/src/services/jobs/jobService.ts \
+        uniqn-mobile/src/services/jobs/__tests__/jobService.test.ts
+git commit -m "feat(workspace): jobService.getMyJobPostings workspaceId pass-through — Phase 2A.후속"
+```
+
+---
+
+### Task 1C: useMyJobPostings hook 이 activeWorkspace 의존
+
+**Files:**
+- Modify: `uniqn-mobile/src/hooks/useJobManagement.ts:45-63`
+- Modify (test): `uniqn-mobile/src/__tests__/hooks/useJobManagement.test.ts`
+
+- [ ] **Step 1: Failing 테스트 추가 — activeWorkspace 변경 시 query key 변동**
+
+`uniqn-mobile/src/__tests__/hooks/useJobManagement.test.ts` 상단에 `useActiveWorkspace` mock 추가:
+
+```ts
+jest.mock('@/hooks/workspace/useActiveWorkspace', () => ({
+  useActiveWorkspace: jest.fn(),
+}));
+import { useActiveWorkspace } from '@/hooks/workspace/useActiveWorkspace';
+const mockUseActiveWorkspace = useActiveWorkspace as jest.MockedFunction<typeof useActiveWorkspace>;
+```
+
+`describe('useMyJobPostings', ...)` 블록에 케이스 3개:
+
+```ts
+it('Phase 2A.후속 — activeWorkspace 가 없으면 query 가 disabled 다', () => {
+  mockUseActiveWorkspace.mockReturnValue({
+    activeWorkspace: undefined,
+    workspaces: [],
+    isLoading: false,
+    setActiveWorkspaceId: jest.fn(),
+  });
+  const { result } = renderHook(() => useMyJobPostings(), { wrapper });
+
+  expect(result.current.fetchStatus).toBe('idle'); // enabled=false 일 때 fetchStatus=idle
+});
+
+it('Phase 2A.후속 — activeWorkspace.id 가 query key 에 포함된다', () => {
+  mockUseActiveWorkspace.mockReturnValue({
+    activeWorkspace: { id: 'ws-abc', name: 'Test', ownerId: 'u1', memberCount: 1 } as any,
+    workspaces: [],
+    isLoading: false,
+    setActiveWorkspaceId: jest.fn(),
+  });
+  const { result } = renderHook(() => useMyJobPostings(), { wrapper });
+
+  // queryClient 의 query 목록에서 key 확인
+  const queries = queryClient.getQueryCache().findAll();
+  const myPostingsQuery = queries.find((q) =>
+    Array.isArray(q.queryKey) && q.queryKey.includes('myPostings')
+  );
+  expect(myPostingsQuery?.queryKey).toEqual(
+    expect.arrayContaining(['ws-abc'])
+  );
+});
+
+it('Phase 2A.후속 — getMyJobPostings 호출 시 workspaceId 옵션이 전달된다', async () => {
+  const getMyJobPostingsSpy = jest.spyOn(servicesModule, 'getMyJobPostings').mockResolvedValue([]);
+  mockUseActiveWorkspace.mockReturnValue({
+    activeWorkspace: { id: 'ws-abc', name: 'Test', ownerId: 'u1', memberCount: 1 } as any,
+    workspaces: [],
+    isLoading: false,
+    setActiveWorkspaceId: jest.fn(),
+  });
+  renderHook(() => useMyJobPostings(), { wrapper });
+
+  await waitFor(() => {
+    expect(getMyJobPostingsSpy).toHaveBeenCalledWith('user-1-uid', { workspaceId: 'ws-abc' });
+  });
+});
+```
+
+> 참고: `wrapper`, `queryClient`, `servicesModule` 은 같은 파일의 기존 setup 에서 가져옴. 새 import 만들 때 기존 패턴 재사용.
+
+- [ ] **Step 2: 테스트 실행 → FAIL 확인**
+
+```bash
+cd uniqn-mobile && npx jest src/__tests__/hooks/useJobManagement.test.ts -t "Phase 2A.후속" --no-coverage
+```
+
+기대: 3 케이스 모두 FAIL.
+
+- [ ] **Step 3: Hook 구현 변경**
+
+`uniqn-mobile/src/hooks/useJobManagement.ts` 상단 import 추가:
+
+```ts
+import { useActiveWorkspace } from '@/hooks/workspace/useActiveWorkspace';
+```
+
+`uniqn-mobile/src/hooks/useJobManagement.ts:45-63` 전체 교체:
+
+```ts
+function getMyJobPostingsQueryKey(userId?: string, workspaceId?: string) {
+  return [
+    ...queryKeys.jobManagement.myPostings(),
+    userId ?? 'anonymous',
+    workspaceId ?? 'no-workspace',
+  ] as const;
+}
+
+function getMyJobPostingStatsQueryKey(userId?: string) {
+  return [...queryKeys.jobManagement.stats(), userId ?? 'anonymous'] as const;
+}
+
+export function useMyJobPostings() {
+  const { user } = useAuthStore();
+  const { activeWorkspace } = useActiveWorkspace();
+  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid, activeWorkspace?.id);
+
+  return useQuery({
+    queryKey: myPostingsQueryKey,
+    queryFn: () => getMyJobPostings(user!.uid, { workspaceId: activeWorkspace!.id }),
+    enabled: !!user && !!activeWorkspace?.id,
+    staleTime: cachingPolicies.frequent,
+  });
+}
+```
+
+- [ ] **Step 4: 테스트 실행 → PASS 확인**
+
+```bash
+cd uniqn-mobile && npx jest src/__tests__/hooks/useJobManagement.test.ts --no-coverage
+```
+
+기대: 신규 3개 + 기존 케이스 모두 PASS.
+
+- [ ] **Step 5: Widget 사이드 회귀 테스트 — 기존 mocking 보강 필요 여부 확인**
+
+```bash
+cd uniqn-mobile && npx jest src/components/home/widgets/__tests__ --no-coverage
+```
+
+기대: PASS. 만약 `useMyJobPostings` 의 `useActiveWorkspace` mock 미설정으로 깨지면, 각 widget 테스트 (`CancellationWidget.test.tsx`, `WeeklyStaffWidget.test.tsx`, `PostingOverviewWidget.test.tsx`) 의 `beforeEach` 에 다음 mock 추가:
+
+```ts
+jest.mock('@/hooks/workspace/useActiveWorkspace', () => ({
+  useActiveWorkspace: () => ({
+    activeWorkspace: { id: 'ws-test', name: 'Test', ownerId: 'u1', memberCount: 1 },
+    workspaces: [],
+    isLoading: false,
+    setActiveWorkspaceId: jest.fn(),
+  }),
+}));
+```
+
+각 깨진 widget 파일에 동일하게 추가하고 다시 jest 실행 → PASS 까지 반복.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add uniqn-mobile/src/hooks/useJobManagement.ts \
+        uniqn-mobile/src/__tests__/hooks/useJobManagement.test.ts \
+        uniqn-mobile/src/components/home/widgets/__tests__/CancellationWidget.test.tsx \
+        uniqn-mobile/src/components/home/widgets/__tests__/WeeklyStaffWidget.test.tsx \
+        uniqn-mobile/src/components/home/widgets/__tests__/PostingOverviewWidget.test.tsx
+git commit -m "feat(workspace): useMyJobPostings 가 activeWorkspace 의존 — Phase 2A.후속"
+```
+
+(깨지지 않은 widget 테스트 파일은 add 대상 제외.)
+
+---
+
+### Task 1D: dogfooding 검증 (Phase 1 마무리)
+
+**Files:** (변경 없음 — 검증만)
+
+- [ ] **Step 1: dev 서버 시작**
+
+```bash
+cd uniqn-mobile && npm run web
+```
+
+별도 터미널 유지. localhost dev 는 production Supabase 가리키므로 review-employer 의 기존 워크스페이스 + 공고 "234" 그대로 사용 가능.
+
+- [ ] **Step 2: review-employer 두 번째 워크스페이스 생성 (테스트 데이터 분리용)**
+
+브라우저에서 review-employer 로그인 → `/employer/workspace` → "워크스페이스 만들기" → 이름 "검증용 빈 워크스페이스".
+
+- [ ] **Step 3: 첫 번째 워크스페이스(공고 "234" 보유)로 전환 → 내공고 탭**
+
+기대: 공고 "234" 1건 표시.
+
+- [ ] **Step 4: Switcher 로 두 번째 워크스페이스("검증용 빈 워크스페이스") 전환 → 내공고 탭**
+
+기대: 공고 0건. 빈 상태 메시지.
+
+- [ ] **Step 5: review-admin 으로 로그인 → 내공고 탭**
+
+기대: review-admin 본인이 만든 공고만 표시 (review-employer 의 "234" 비노출).
+
+- [ ] **Step 6: 검증 결과 commit message 에 evidence 첨부 — Phase 1 종합 PR 본문에 4 케이스 결과 표 작성 (실제 커밋은 Phase 2 후 한꺼번에)**
+
+검증 표 형식:
+
+| 시나리오 | Before | After |
+|----------|--------|-------|
+| review-employer / WS1(공고 보유) | 공고 1 | 공고 1 ✅ |
+| review-employer / WS2(빈) | 공고 1 (잘못) | 공고 0 ✅ |
+| review-admin / 본인 WS | review-employer 공고 노출 (잘못) | 본인 공고만 ✅ |
+
+---
+
+## Phase 2 — Cancellation 워크스페이스 멤버 호환 (P0)
+
+### Task 2A: loadAndVerifyJobPostingOwner 가 workspace member + admin 분기 추가
+
+**Files:**
+- Modify: `uniqn-mobile/src/repositories/supabase/ApplicationRepositoryHelpers.ts:156-168`
+- Create: `uniqn-mobile/src/repositories/supabase/__tests__/ApplicationRepositoryHelpers.workspace.test.ts`
+
+- [ ] **Step 1: 신규 테스트 파일 — 4 역할 시나리오**
+
+`uniqn-mobile/src/repositories/supabase/__tests__/ApplicationRepositoryHelpers.workspace.test.ts`:
+
+```ts
+/**
+ * Phase 2A.후속 — loadAndVerifyJobPostingOwner workspace member + admin 호환
+ */
+import { loadAndVerifyJobPostingOwner } from '../ApplicationRepositoryHelpers';
+import { supabase } from '@/lib/supabase';
+import { PermissionError } from '@/errors';
+import type { JobPosting } from '@/types';
+
+jest.mock('@/lib/supabase');
+
+const mockSupabase = supabase as jest.Mocked<typeof supabase>;
+
+const fakePosting: JobPosting = {
+  id: 'jp-1',
+  ownerId: 'owner-uid',
+  workspaceId: 'ws-1',
+  title: '234',
+  status: 'active',
+} as JobPosting;
+
+describe('loadAndVerifyJobPostingOwner — workspace member + admin', () => {
+  let fromSpy: jest.Mock;
+  let rpcSpy: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    fromSpy = jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: {
+              id: 'jp-1',
+              owner_id: 'owner-uid',
+              workspace_id: 'ws-1',
+              title: '234',
+              status: 'active',
+              schedule: { kind: 'fixed', dates: ['2026-05-09'] },
+              schema_version: 3,
+              role_catalog: [],
+              compensation: { type: 'daily', amount: 100000 },
+              total_positions: 1,
+              filled_positions: 0,
+              stats: {},
+              tags: [],
+              role_keys: [],
+              created_at: '2026-05-09T00:00:00Z',
+              updated_at: '2026-05-09T00:00:00Z',
+              work_date: '2026-05-09',
+            },
+            error: null,
+          }),
+        }),
+      }),
+    });
+    rpcSpy = jest.fn();
+    (mockSupabase.from as any) = fromSpy;
+    (mockSupabase.rpc as any) = rpcSpy;
+  });
+
+  it('owner 본인 호출 시 통과 (RPC 호출 없음)', async () => {
+    const result = await loadAndVerifyJobPostingOwner('jp-1', 'owner-uid', '취소 요청 목록 조회');
+
+    expect(result.id).toBe('jp-1');
+    expect(rpcSpy).not.toHaveBeenCalled();
+  });
+
+  it('워크스페이스 멤버 호출 시 통과 (is_workspace_member=true)', async () => {
+    rpcSpy.mockImplementation((fn: string) => {
+      if (fn === 'is_workspace_member') return Promise.resolve({ data: true, error: null });
+      return Promise.resolve({ data: false, error: null });
+    });
+
+    const result = await loadAndVerifyJobPostingOwner('jp-1', 'member-uid', '취소 요청 목록 조회');
+
+    expect(result.id).toBe('jp-1');
+    expect(rpcSpy).toHaveBeenCalledWith('is_workspace_member', {
+      _workspace_id: 'ws-1',
+      _user_id: 'member-uid',
+    });
+  });
+
+  it('admin 호출 시 통과 (is_workspace_member=false 인데 is_admin=true)', async () => {
+    rpcSpy.mockImplementation((fn: string) => {
+      if (fn === 'is_workspace_member') return Promise.resolve({ data: false, error: null });
+      if (fn === 'is_admin') return Promise.resolve({ data: true, error: null });
+      return Promise.resolve({ data: false, error: null });
+    });
+
+    const result = await loadAndVerifyJobPostingOwner('jp-1', 'admin-uid', '취소 요청 목록 조회');
+
+    expect(result.id).toBe('jp-1');
+  });
+
+  it('외부인 호출 시 PermissionError', async () => {
+    rpcSpy.mockResolvedValue({ data: false, error: null });
+
+    await expect(
+      loadAndVerifyJobPostingOwner('jp-1', 'stranger-uid', '취소 요청 목록 조회')
+    ).rejects.toThrow(PermissionError);
+  });
+
+  it('is_workspace_member RPC 에러 시 handleSupabaseError', async () => {
+    rpcSpy.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'rpc error', code: 'PGRST000' },
+    });
+
+    await expect(
+      loadAndVerifyJobPostingOwner('jp-1', 'member-uid', '취소 요청 목록 조회')
+    ).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → FAIL 확인**
+
+```bash
+cd uniqn-mobile && npx jest src/repositories/supabase/__tests__/ApplicationRepositoryHelpers.workspace.test.ts --no-coverage
+```
+
+기대: 5 케이스 중 외부인 케이스만 PASS (현재 owner-only 코드가 PermissionError 던짐), 나머지 4 FAIL.
+
+- [ ] **Step 3: 헬퍼 구현 확장**
+
+`uniqn-mobile/src/repositories/supabase/ApplicationRepositoryHelpers.ts:156-168` 전체 교체:
+
+```ts
+/**
+ * 공고를 로드하고 호출자가 관리 권한을 가졌는지 확인.
+ *
+ * Phase 2A.후속 (2026-05-09) — owner 외에 워크스페이스 멤버 + admin 도 통과.
+ * Phase 2A 에서 applications/job_postings RLS 가 workspace_member 분기로 풀렸으나
+ * 클라이언트 헬퍼는 owner-only 였던 부분 마이그레이션을 일치시킨다.
+ *
+ * 호출 비용: 본인 owner 면 RPC 0회, 멤버면 1회, admin 이면 2회. 권한 에러 흐름은
+ * cancellation/리뷰 같은 흔하지 않은 employer-side 액션이라 허용 가능.
+ */
+export async function loadAndVerifyJobPostingOwner(
+  jobPostingId: string,
+  callerId: string,
+  operation: string
+): Promise<JobPosting> {
+  const jobData = await loadJobPosting(jobPostingId);
+
+  // 1) owner 본인
+  if (jobData.ownerId === callerId) return jobData;
+
+  // 2) 워크스페이스 멤버 (Phase 2A backend 와 일관)
+  const memberResult = await supabase.rpc('is_workspace_member', {
+    _workspace_id: jobData.workspaceId,
+    _user_id: callerId,
+  });
+  if (memberResult.error) {
+    handleSupabaseError(memberResult.error, { operation, table: TABLES.JOB_POSTINGS });
+  }
+  if (memberResult.data === true) return jobData;
+
+  // 3) admin
+  const adminResult = await supabase.rpc('is_admin');
+  if (adminResult.error) {
+    handleSupabaseError(adminResult.error, { operation, table: TABLES.JOB_POSTINGS });
+  }
+  if (adminResult.data === true) return jobData;
+
+  throw new PermissionError(ERROR_CODES.INFRA_PERMISSION_DENIED, {
+    userMessage: `워크스페이스 멤버만 관리할 수 있습니다: ${operation}`,
+  });
+}
+```
+
+- [ ] **Step 4: 테스트 실행 → PASS 확인**
+
+```bash
+cd uniqn-mobile && npx jest src/repositories/supabase/__tests__/ApplicationRepositoryHelpers.workspace.test.ts --no-coverage
+```
+
+기대: 5 케이스 모두 PASS.
+
+- [ ] **Step 5: 헬퍼 사용처 회귀 테스트**
+
+```bash
+cd uniqn-mobile && npx jest src/repositories/supabase/__tests__ --no-coverage
+```
+
+기대: ApplicationRepository 관련 모든 테스트 PASS. 만약 owner-only 가정으로 작성된 케이스가 깨지면 mock 에 `rpc` 가 false 반환하도록 보강.
+
+- [ ] **Step 6: 타입 체크**
+
+```bash
+cd uniqn-mobile && npx tsc --noEmit
+```
+
+기대: 0 errors.
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add uniqn-mobile/src/repositories/supabase/ApplicationRepositoryHelpers.ts \
+        uniqn-mobile/src/repositories/supabase/__tests__/ApplicationRepositoryHelpers.workspace.test.ts
+git commit -m "feat(workspace): loadAndVerifyJobPostingOwner workspace_member+admin 분기 — Phase 2A.후속"
+```
+
+---
+
+### Task 2B: cancellation/리뷰 흐름 회귀 테스트
+
+**Files:** (변경 없음 — 기존 테스트 보강)
+
+- [ ] **Step 1: ApplicationRepository 테스트의 mock supabase 가 새 RPC 호출을 무시하지 않는지 확인**
+
+```bash
+cd uniqn-mobile && npx jest src/repositories/supabase/__tests__/ApplicationRepository --no-coverage
+cd uniqn-mobile && npx jest src/repositories/supabase/__tests__/ApplicationRepositoryTransactions --no-coverage
+```
+
+기대: PASS. 만약 owner-only 테스트가 새 RPC 흐름으로 깨지면 각 테스트의 supabase mock 에 `rpc: jest.fn().mockResolvedValue({ data: false, error: null })` 추가.
+
+- [ ] **Step 2: 깨진 테스트의 mock 보강**
+
+각 영향받은 테스트 파일에서 supabase mock 패턴을 다음으로 표준화:
+
+```ts
+const mockSupabase = {
+  from: jest.fn(/* 기존 chain */),
+  rpc: jest.fn().mockResolvedValue({ data: false, error: null }),
+};
+```
+
+owner-only 케이스에서는 `from` 만 사용 → `rpc` 가 호출되지 않으므로 영향 없음. 권한 거부 케이스(callerId !== ownerId)는 이제 `rpc` 호출 시 false 받고 PermissionError 던짐.
+
+- [ ] **Step 3: 전체 jest 실행 → 회귀 없음 확인**
+
+```bash
+cd uniqn-mobile && npx jest --no-coverage
+```
+
+기대: 전체 PASS. 깨진 테스트 있으면 위 mock 패턴으로 보강 후 재실행.
+
+- [ ] **Step 4: 영향받은 테스트만 따로 commit (Task 2A 와 분리)**
+
+```bash
+git add uniqn-mobile/src/repositories/supabase/__tests__/ApplicationRepository*.test.ts
+git commit -m "test(workspace): ApplicationRepository 테스트 mock 에 rpc 추가 — Phase 2A.후속"
+```
+
+---
+
+### Task 2C: dogfooding 검증 (Phase 2 마무리)
+
+**Files:** (변경 없음 — 검증만)
+
+- [ ] **Step 1: review-admin 으로 review-employer 의 공고 "234" 진입**
+
+브라우저에서 review-admin 로그인 → admin 페이지에서 공고 검색 → 공고 "234" 진입.
+
+- [ ] **Step 2: 취소 요청 검토 시도**
+
+기대: PermissionError 안 뜨고 정상 조회. (admin 분기 통과)
+
+- [ ] **Step 3: review-employer 외 워크스페이스 멤버 계정으로도 동일 시도**
+
+워크스페이스 멤버 추가 후 해당 멤버 로그인 → 공고 "234" 진입 → 취소 요청 검토.
+
+기대: 정상 조회 (workspace_member 분기 통과).
+
+- [ ] **Step 4: 외부인(어떤 워크스페이스에도 속하지 않은 staff)이 직접 URL 진입 시도**
+
+기대: PermissionError "워크스페이스 멤버만 관리할 수 있습니다".
+
+- [ ] **Step 5: 결과 표 작성 — Phase 2 PR 본문**
+
+| 호출자 | Before | After |
+|--------|--------|-------|
+| owner 본인 | OK | OK ✅ |
+| 워크스페이스 멤버 | PermissionError | OK ✅ |
+| admin | PermissionError | OK ✅ |
+| 외부인 | PermissionError | PermissionError ✅ |
+
+---
+
+## Phase 1+2 PR 통합
+
+- [ ] **Step 1: 전체 type check + jest**
+
+```bash
+cd uniqn-mobile && npm run quality && npx jest --no-coverage
+```
+
+기대: 모두 PASS.
+
+- [ ] **Step 2: PR 생성**
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "fix(workspace): active workspace 별 공고 분리 + cancellation 멤버 호환 — Phase 2A.후속" --body "$(cat <<'EOF'
+## Summary
+- 사용자 dogfooding(2026-05-09)에서 발견한 3가지 워크스페이스 누출 버그 해결
+- `getManagedJobPostings(workspaceId)` 옵션 + `useMyJobPostings` 가 activeWorkspace 의존
+- `loadAndVerifyJobPostingOwner` 가 owner OR workspace_member OR admin 분기로 확장 — cancellation/리뷰/거절/읽음/확정/확정취소 6+ 흐름 동시 해결
+
+## Background
+Phase 2A backend(applications/job_postings RLS) 가 workspace_member 분기까지 풀었으나 클라이언트 헬퍼는 owner-only → 부분 마이그레이션 상태. 본 PR 이 일치시킴.
+
+## Test plan
+- [ ] type-check + jest 전체 PASS
+- [ ] dogfooding (Task 1D + 2C 표 첨부)
+- [ ] Phase 2A backend 가 영향 없음 확인 (RLS 변경 없음)
+
+## Out of scope
+- RLS jp_select 분리 (Task 5 follow-up — 별도 plan + eng-review 필요)
+- 다른 화면 audit (Task 6 follow-up)
+- write-side `JobPostingRepository.loadAndVerifyOwner` (update/close/reopen/delete) — write-side 도 동일 패턴 적용 필요하지만 본 PR scope 밖
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Task 5 (Follow-up) — RLS jp_select 분리
+
+> 별도 plan + `/plan-eng-review` 필요. 본 plan 의 Phase 1 클라이언트 필터링은 비즈니스 요구사항(워크스페이스별 분리)이라 영구 보존, 본 task 는 보안 경계 강화(클라이언트 필터에 의존하지 않도록).
+
+**Sketch:**
+- 옵션 A: View 분리 — `job_postings_search` (active/approved/closed 공개) vs `job_postings_managed` (owner/member/admin).
+- 옵션 B (권장): SECURITY DEFINER RPC `list_managed_postings(p_workspace_id, p_status)` 추가 + jp_select 정책의 첫 분기(`status IN (...)`) 를 별도 search-only 정책으로 분리. PR #69, #70 패턴 일관.
+- migration 필요: `apply_migration` MCP, jest 4 역할 테스트.
+
+**진입 조건:** Phase 1+2 머지 후, eng-review 통과한 spec.
+
+---
+
+## Task 6 (Follow-up) — 다른 화면 audit
+
+> 별도 plan. Phase 1+2 머지 후 진행.
+
+**Audit 대상:**
+
+| 영역 | hook | repo 메서드 | 현재 workspace 인지 |
+|------|------|-------------|---------------------|
+| applications | `useMyApplications`, `useApplicationsByJobPosting` | `ApplicationRepository.getList` 등 | 미점검 |
+| work_logs | `useWorkLogsByJobPosting` 등 | `WorkLogRepository` | Phase 3B 완료(backend), client 미점검 |
+| event_qr_codes | (해당 hook) | `EventQrRepository` | Phase 3C 완료(backend), client 미점검 |
+| settlement | `useSettlements` | `settlementQuery.ts` | 미점검 |
+| schedule | `useScheduleCalendar` 등 | `ScheduleRepository` | 미점검 |
+
+각 hook 이 query key 에 `activeWorkspaceId` 포함하는지, repo 가 `workspaceId` 옵션을 받는지 점검. 누락된 곳은 Task 1A~1C 패턴 그대로 복제.
+
+---
+
+## Self-Review Checklist
+
+- [x] Phase 1 (workspace 필터) — Task 1A/1B/1C/1D 로 커버
+- [x] Phase 2 (cancellation 멤버 호환) — Task 2A/2B/2C 로 커버
+- [x] 모든 step 에 실제 코드 + 명령 + 기대 출력 포함 — placeholder 없음
+- [x] 함수 시그니처 일관성: `getManagedJobPostings(status?, workspaceId?)`, `getMyJobPostings(ownerId, options?)`, `loadAndVerifyJobPostingOwner(jobPostingId, callerId, operation)` — Task 1A → 1B → 1C → 2A 순서로 의존성 일치
+- [x] `is_workspace_member` 인자 이름 `_workspace_id`, `_user_id` — production DB pg_proc 결과와 일치
+- [x] CLAUDE.md 커밋 컨벤션(`<type>(<scope>): <한글>`) 준수
+- [x] Phase 3, 4 는 follow-up section 으로 분리 — scope creep 방지

--- a/docs/superpowers/specs/2026-05-09-workspace-tab-migration-design.md
+++ b/docs/superpowers/specs/2026-05-09-workspace-tab-migration-design.md
@@ -1,0 +1,256 @@
+# Workspace 탭 이전 — 설정센터에서 내 공고/프로필 탭으로
+
+- **작성일**: 2026-05-09
+- **상태**: 디자인 승인 (구현 대기)
+- **범위**: UNIQN Mobile (`uniqn-mobile/`)
+- **배경**: 설정센터의 "공고협업/워크스페이스/받은 초대" 3개 항목을 도메인 컨텍스트에 맞춰 재배치하고, 워크스페이스 가드를 employer role 기반에서 멤버십 기반으로 재설계.
+
+## 문제 정의
+
+### 현재 상태의 비대칭
+
+설정센터(`app/(app)/settings/index.tsx:310-330`)에 "공고협업" 섹션 3개 항목이 employer 조건부로 노출되며, 클릭 시 `/(employer)/workspace*` 경로로 진입한다. 그러나 다음과 같은 비대칭이 존재한다:
+
+1. **라우트 가드 vs 데이터 모델 불일치**
+   - `(employer)/_layout.tsx:90-92` 가드는 `hasEmployerRole=false`인 사용자를 즉시 홈으로 redirect
+   - 그러나 데이터 모델(`useInviteWorkspaceMember`의 `inviteeUserId`)은 staff 초대를 막지 않음
+   - 최근 PR #63, #64에서 `work_logs` / `event_qr_codes` RLS에 workspace 멤버 분기가 추가됨 → staff도 워크스페이스 멤버가 되는 모델로 진화 중
+   - `RouteRegistry.ts:118-120`의 workspace 경로들은 `AUTH_REQUIRED_ROUTES`에만 포함, `EMPLOYER_REQUIRED_ROUTES`에는 미포함 — 의도와 실 가드 불일치
+
+2. **staff 발견성 부재**
+   - staff가 워크스페이스 초대를 받은 시점에는 아직 멤버가 아니므로 employer 가드에 막힘
+   - push notification(`WORKSPACE_INVITATION`)으로 deep link 진입 시도해도 `(employer)` 가드가 차단
+   - "내 공고" 탭은 staff에게 NonEmployerView(구인자 등록 유도)만 보여주므로 워크스페이스 컨텍스트 부재
+
+3. **진입점 분산**
+   - 워크스페이스 관리 / 공고협업 / 받은 초대가 설정센터 안에서 평면적으로 나열
+   - 각 항목이 독립 메뉴로 보이지만 실질적으로 동일한 워크스페이스 도메인의 다른 측면
+
+## 결정사항
+
+### D1: 워크스페이스 멤버십은 employer + staff 모두 허용
+
+이번 리팩토링의 핵심 전제. workspace_members 테이블에 staff role도 멤버로 들어갈 수 있다고 본다 (최근 RLS 분기 작업이 이를 시사). 따라서 모든 가드는 role 기반이 아니라 **멤버십 기반** 또는 **인증만 필요**의 두 단계로 단순화한다.
+
+### D2: 진입점은 두 곳, 도착지는 한 곳
+
+- **employer 진입점**: "내 공고" 탭 본문 카드 (employer가 자기 워크스페이스를 자주 관리)
+- **staff 진입점**: 프로필 탭 "커뮤니티" 메뉴 아래 "워크스페이스" 항목 (staff는 멤버십 기반 access)
+- **도착지**: `/(app)/workspace` — 동일 화면, 멤버십 상태에 따라 본문 분기
+
+### D3: 받은 초대는 별도 탭 진입점으로 두지 않음
+
+받은 초대 화면은 워크스페이스 화면 헤더 우측 봉투 아이콘으로만 진입. 이유:
+- 받은 초대 자체가 "워크스페이스 도메인의 한 측면"이지 독립 도메인 아님
+- 메뉴/탭에 별도 카운터 뱃지가 떠있는 형태는 노이즈 — 워크스페이스 들어왔을 때 발견하면 충분
+- staff (멤버 0, 초대 N건)인 경우 빈 상태 화면에 골드 CTA로 강조하므로 발견성 확보
+
+### D4: settings 항목 전부 제거
+
+설정센터에서 "공고협업" 섹션 3개 항목 모두 제거. 부분 유지 안 함 — 진입점이 분산되면 사용자 혼란.
+
+## 라우트 구조 변경
+
+### 현재
+
+```
+app/(app)/settings/index.tsx              ← "공고협업" 섹션 (employer 조건부)
+  ├ → /(employer)/workspace
+  ├ → /(employer)/workspace/invite
+  └ → /(employer)/workspace/invitations
+
+app/(employer)/_layout.tsx                ← hasEmployerRole 가드 + WorkspaceRevocationGuard
+app/(employer)/workspace/
+  ├ index.tsx
+  ├ invite.tsx
+  └ invitations.tsx
+```
+
+### 변경 후
+
+```
+app/(app)/workspace/                      ← (employer) → (app) 폴더 통째 이동
+  ├ _layout.tsx (신규)                    ← Stack + WorkspaceRevocationGuard
+  ├ index.tsx                             ← 헤더 우측 봉투 아이콘 + Empty State 분기
+  ├ invite.tsx                            ← (owner only — 화면 내부 가드)
+  └ invitations.tsx                       ← 인증만 필요 (멤버십 무관)
+
+app/(app)/(tabs)/employer.tsx             ← ListHeaderComponent로 워크스페이스 카드
+app/(app)/(tabs)/profile.tsx              ← "커뮤니티" 메뉴 아래 "워크스페이스" 추가
+app/(app)/settings/index.tsx              ← "공고협업" 섹션 통째 제거
+app/(employer)/_layout.tsx                ← workspace 관련 hook 제거 (다른 employer 화면 가드는 유지)
+```
+
+## 가드 재설계
+
+### Layout 레벨 가드
+
+| 라우트 | 가드 |
+|--------|------|
+| `(app)/_layout.tsx` | 인증 (기존) |
+| `(app)/workspace/_layout.tsx` (신규) | 인증 (상위 가드 통과 가정) + WorkspaceRevocationGuard 마운트 |
+| `(employer)/_layout.tsx` | hasEmployerRole 유지 (workspace 외 화면용) |
+
+### 화면 레벨 분기
+
+`(app)/workspace/index.tsx`:
+
+```
+useActiveWorkspace().workspaces.length === 0
+  ├ true  → Empty State (받은 초대 N건 CTA 또는 회색 안내문)
+  └ false → 기존 멤버 관리 UI
+```
+
+`(app)/workspace/invite.tsx`:
+- owner 여부 체크 (활성 워크스페이스 ownerId === currentUserId)
+- 화면 내부에서 비-owner는 `Redirect` 또는 안내 메시지
+
+`(app)/workspace/invitations.tsx`:
+- 가드 없음 (인증만 통과하면 진입)
+
+### WorkspaceRevocationGuard 이동
+
+현재 `(employer)/_layout.tsx:32-54`에서 활성 워크스페이스 멤버십 회수 감지 → `WorkspaceRevocationModal` + 5초 자동 로그아웃. 이 로직을 `(app)/workspace/_layout.tsx`로 이동한다.
+
+이유:
+- staff도 멤버가 될 수 있는 새 모델에서, 회수 감지는 employer 가드가 아니라 워크스페이스 컨텍스트에서 동작해야 함
+- (app) 전체 레이아웃에 두면 워크스페이스 무관 화면(공고 둘러보기 등)에서도 모달이 떠 UX 부담
+
+## UI 진입점 명세
+
+### 진입점 A: "내 공고" 탭 본문 카드
+
+위치: `(tabs)/employer.tsx`의 공고 리스트 ListHeaderComponent.
+
+```
+┌─────────────────────────────────────────────┐
+│ [Building 24px] 워크스페이스         [3] [›] │
+│                 멤버 3명 · {활성 ws 이름}    │
+└─────────────────────────────────────────────┘
+```
+
+- 좌측 아이콘: `Building` (Lucide 24px stroke 2.0 — 프로필 메뉴 진입점과 동일 아이콘으로 일관성 확보)
+- 메인 라벨: "워크스페이스" (`text-base font-sans-semibold`)
+- 보조 라인: "멤버 N명 · {활성워크스페이스이름}" (`text-sm text-content-secondary`, `numberOfLines=1` ellipsis)
+- 우측 카운트 뱃지: 받은 초대 N≥1일 때만 (`bg-gold` + `text-on-gold`)
+- chevron-right
+- Pressed: `dark:bg-surface-hover` (Impeccable Rule 21 — 다크 밝아짐 방향)
+- min-h-[64px] (Rule 5 — 터치 44px+)
+- onPress → `router.push('/(app)/workspace')`
+
+### 진입점 B: 프로필 탭 메뉴 항목
+
+`profile.tsx:188-191` "커뮤니티" 항목 바로 아래에 추가:
+
+```tsx
+<Divider spacing="sm" />
+<MenuItem
+  icon={<BuildingIcon size={22} color={SECONDARY_PALETTE[500]} />}
+  label="워크스페이스"
+  onPress={() => router.push('/(app)/workspace')}
+/>
+```
+
+기존 MenuItem 패턴 그대로 — 별도 디자인 작업 없음. 받은 초대 카운트는 메뉴에 표시 안 함 (워크스페이스 화면 봉투 아이콘에서 노출).
+
+### 진입점 C: 워크스페이스 화면 헤더 우측 봉투 아이콘
+
+```
+┌─────────────────────────────────────────────┐
+│ ‹ 워크스페이스                          ✉ ⊙3│
+└─────────────────────────────────────────────┘
+```
+
+- 아이콘: `MailIcon` 24px stroke 2.0
+- 받은 초대 0건이면 봉투만 (`SECONDARY_PALETTE[500/400]`)
+- 받은 초대 N≥1이면 우상단 골드 dot 또는 mini 카운트 뱃지 (`bg-gold`, 8~10px)
+- `hitSlop={10}` + 시각 24px = 터치 44px (Rule 5)
+- `accessibilityRole="button"` + `accessibilityLabel={`받은 초대 ${count}건`}`
+- onPress → `router.push('/(app)/workspace/invitations')`
+
+### Empty State (멤버십 0 시 본문)
+
+```
+┌─────────────────────────────────────────────┐
+│                                             │
+│           [BuildingIcon 32px]                │
+│                                             │
+│      아직 속한 워크스페이스가 없어요          │
+│                                             │
+│   구인자가 초대하면 함께 공고를 관리할 수     │
+│            있어요                            │
+│                                             │
+│   ┌──────────────────────────┐               │
+│   │   초대 3건 확인하기        │ ← N≥1일 때만 │
+│   └──────────────────────────┘               │
+│                                             │
+└─────────────────────────────────────────────┘
+```
+
+- Impeccable Rule 9 (인지 + 가치 + 행동) 3단 구성
+- CTA는 받은 초대 N≥1일 때만 골드, 아니면 회색 안내문 "구인자에게 초대를 요청해보세요"
+- CTA 도착지: `router.push('/(app)/workspace/invitations')` (헤더 봉투 아이콘과 동일)
+- 헤더 봉투 아이콘은 그대로 노출 (Empty State CTA와 동일 도착지지만 일관성 우선)
+
+## 데이터 흐름 / Push Notification
+
+```
+[FCM/APNs WORKSPACE_INVITATION]
+  → src/services/notifications/NotificationRouteMap.ts:121-124
+     { name: 'workspace/invitations' }
+  → src/utils/route/RouteMapper.ts (1줄 갱신)
+     '(employer)/workspace/invitations' → '(app)/workspace/invitations'
+  → (app)/_layout.tsx 인증 가드만 통과 (employer 가드 없음)
+  → invitations.tsx 렌더 → 사용자 수락
+  → workspace_members INSERT (owner가 보낸 초대)
+  → useActiveWorkspace cache invalidate
+  → 다음 진입 시 자동으로 멤버 관리 모드
+```
+
+핵심: **deep link가 employer 가드를 더 이상 통과하지 않으므로 staff도 정상 진입**.
+
+## 마이그레이션 순서 (단일 PR, 커밋 분할)
+
+1. `git mv app/(employer)/workspace app/(app)/workspace` — 파일 이동
+2. `app/(app)/workspace/_layout.tsx` 신설 — Stack + WorkspaceRevocationGuard
+3. `app/(employer)/_layout.tsx` 정리 — workspace 관련 hook 제거 (hasEmployerRole 가드 유지)
+4. `app/(app)/settings/index.tsx:310-330` — "공고협업" 섹션 통째 제거
+5. `app/(app)/(tabs)/employer.tsx` — 워크스페이스 카드 컴포넌트 ListHeaderComponent로 추가
+6. `app/(app)/(tabs)/profile.tsx` — "커뮤니티" 메뉴 아래 "워크스페이스" MenuItem 추가
+7. `app/(app)/workspace/index.tsx` — 헤더 우측 봉투 아이콘 액션 + Empty State 분기 추가
+8. `src/utils/route/RouteMapper.ts` — workspace/invitations 매핑 경로 1줄 갱신
+
+`RouteRegistry.ts` 변경 없음 (이미 `EMPLOYER_REQUIRED_ROUTES`에 미포함).
+
+## 검증 체크리스트
+
+### 라우트 / 가드
+- [ ] employer (멤버 1+) → 내 공고 탭 카드 → 워크스페이스 멤버 관리 진입
+- [ ] staff (멤버 0, 초대 3건) → 프로필 → 워크스페이스 → 빈 상태 + 골드 CTA → 받은 초대 → 수락 → 자동 멤버 관리 모드
+- [ ] staff (멤버 0, 초대 0) → 프로필 → 워크스페이스 → 빈 상태 + 회색 안내문 (CTA 없음)
+- [ ] 인증 안 된 상태 push deep link → `(auth)/login` → 로그인 후 받은 초대 화면 자동 복원
+- [ ] 멤버 회수 시나리오 — `WorkspaceRevocationModal` + 5초 자동 로그아웃 (새 위치에서 동일 동작)
+
+### 진입점 leftover 검증
+- [ ] `settings/index.tsx`에 "공고협업" / "워크스페이스" / "받은 초대" 검색 결과 0건
+- [ ] 코드베이스 grep `(employer)/workspace` 참조 → `RouteMapper` 외 0건
+- [ ] `e2e/tests/p0-critical/rbac-access.spec.ts` — staff가 새 `(app)/workspace` 접근 가능
+
+### Push Notification
+- [ ] WORKSPACE_INVITATION 알림으로 진입 시 받은 초대 화면 도달 (앱 cold start / warm start 양쪽)
+- [ ] staff 계정으로 push 진입 → employer 가드 차단 없이 정상 도달
+
+## 위험 요소 / 미확정
+
+| 항목 | 위험 | 대응 |
+|------|------|------|
+| `create_workspace` RPC 자동 호출 시점 (PR #69) | employer 신규 가입 / staff에서 employer 승격 시 자동 생성되는지 미확인 | 구현 단계에서 가입 service 확인 후 결정. Empty State 노출 빈도에 영향 |
+| iPad/외부 키보드 focus ring | 봉투 아이콘 헤더 액션은 focus ring 누락 가능 | Impeccable Rule 22 outset ring 패턴 적용 |
+| 회수 가드 이동 후 staff 회수 시나리오 | `useWorkspaceRevocationGuard`가 employer 가정으로 짜여 있을 가능성 | 시그니처/구현 검증 + e2e 케이스 추가 |
+| settings 외부 진입점 (공유 링크 등) | 외부 문서/공지에 `(employer)/workspace` 참조 가능성 | RouteMapper에 구 경로 → 신 경로 alias 1주일 유지 후 제거 (선택) |
+
+## 참고
+
+- 관련 메모리: `feedback_localhost_dev_production_db.md` — 머지 전 검증 최단 경로 (localhost dev = master + prod DB)
+- 관련 PR: #63 (work_logs RLS workspace 분기), #64 (event_qr_codes RLS workspace 분기), #67 (workspace_members publication), #68 (mapWorkspaceRpcError 다중 원인), #69 (create_workspace SECURITY DEFINER RPC)
+- Impeccable 디자인 룰: 5(터치 44px), 9(빈 상태), 21(Pressed 역방향), 22(Focus ring), 27(아이콘)

--- a/uniqn-mobile/src/__tests__/hooks/useJobManagement.test.ts
+++ b/uniqn-mobile/src/__tests__/hooks/useJobManagement.test.ts
@@ -2,14 +2,27 @@ import { act, renderHook, waitFor } from '@testing-library/react-native';
 import type { CreateJobPostingInput, UpdateJobPostingInput } from '@/types';
 import {
   useCreateJobPosting,
+  useBulkUpdateStatus,
+  useCloseJobPosting,
+  useDeleteJobPosting,
   useMyJobPostings,
+  useReopenJobPosting,
   useUpdateJobPosting,
 } from '@/hooks/useJobManagement';
+import { useActiveWorkspace } from '@/hooks/workspace/useActiveWorkspace';
+
+jest.mock('@/hooks/workspace/useActiveWorkspace', () => ({
+  useActiveWorkspace: jest.fn(),
+}));
+const mockUseActiveWorkspace = useActiveWorkspace as jest.MockedFunction<typeof useActiveWorkspace>;
 
 const mockGetMyJobPostings = jest.fn();
 const mockCreateJobPosting = jest.fn();
 const mockUpdateJobPosting = jest.fn();
 const mockInvalidateQueries = jest.fn();
+const mockCancelQueries = jest.fn();
+const mockGetQueryData = jest.fn(() => undefined as unknown);
+const mockSetQueryData = jest.fn();
 const mockAddToast = jest.fn();
 
 let mockQueryData: unknown;
@@ -139,9 +152,9 @@ jest.mock('@tanstack/react-query', () => ({
   ),
   useQueryClient: () => ({
     invalidateQueries: mockInvalidateQueries,
-    cancelQueries: jest.fn(),
-    getQueryData: jest.fn(),
-    setQueryData: jest.fn(),
+    cancelQueries: mockCancelQueries,
+    getQueryData: mockGetQueryData,
+    setQueryData: mockSetQueryData,
   }),
 }));
 
@@ -182,6 +195,19 @@ describe('useJobManagement hooks', () => {
     mockQueryData = undefined;
     mockQueryError = null;
     mockQueryLoading = false;
+    // Re-set default return values for module-level spies after clearAllMocks
+    mockGetQueryData.mockReturnValue(undefined);
+    mockUseActiveWorkspace.mockReturnValue({
+      activeWorkspace: {
+        id: 'ws-default',
+        name: 'Default',
+        ownerId: 'employer-1',
+        memberCount: 1,
+      } as any,
+      workspaces: [],
+      isLoading: false,
+      setActiveWorkspaceId: jest.fn(),
+    });
   });
 
   it('returns employer postings from useMyJobPostings', () => {
@@ -199,7 +225,65 @@ describe('useJobManagement hooks', () => {
       'jobManagement',
       'myPostings',
       'employer-1',
+      'ws-default',
     ]);
+  });
+
+  it('Phase 2A.후속 — activeWorkspace 가 없으면 enabled 가 false 다', () => {
+    mockUseActiveWorkspace.mockReturnValue({
+      activeWorkspace: undefined,
+      workspaces: [],
+      isLoading: false,
+      setActiveWorkspaceId: jest.fn(),
+    });
+
+    renderHook(() => useMyJobPostings());
+
+    const { useQuery } = jest.requireMock('@tanstack/react-query') as {
+      useQuery: jest.Mock;
+    };
+
+    expect(useQuery.mock.calls[0][0].enabled).toBe(false);
+  });
+
+  it('Phase 2A.후속 — activeWorkspace.id 가 query key 에 포함된다', () => {
+    mockUseActiveWorkspace.mockReturnValue({
+      activeWorkspace: { id: 'ws-abc', name: 'Test', ownerId: 'u1', memberCount: 1 } as any,
+      workspaces: [],
+      isLoading: false,
+      setActiveWorkspaceId: jest.fn(),
+    });
+
+    renderHook(() => useMyJobPostings());
+
+    const { useQuery } = jest.requireMock('@tanstack/react-query') as {
+      useQuery: jest.Mock;
+    };
+
+    expect(useQuery.mock.calls[0][0].queryKey).toEqual(
+      expect.arrayContaining(['myPostings', 'ws-abc'])
+    );
+  });
+
+  it('Phase 2A.후속 — getMyJobPostings 호출 시 workspaceId 옵션이 전달된다', async () => {
+    mockUseActiveWorkspace.mockReturnValue({
+      activeWorkspace: { id: 'ws-abc', name: 'Test', ownerId: 'u1', memberCount: 1 } as any,
+      workspaces: [],
+      isLoading: false,
+      setActiveWorkspaceId: jest.fn(),
+    });
+    mockGetMyJobPostings.mockResolvedValue([]);
+
+    renderHook(() => useMyJobPostings());
+
+    const { useQuery } = jest.requireMock('@tanstack/react-query') as {
+      useQuery: jest.Mock;
+    };
+
+    // queryFn を直接呼び出して workspaceId が渡されていることを確認
+    await useQuery.mock.calls[0][0].queryFn();
+
+    expect(mockGetMyJobPostings).toHaveBeenCalledWith('employer-1', { workspaceId: 'ws-abc' });
   });
 
   it('submits canonical create payloads and invalidates posting queries', async () => {
@@ -265,6 +349,92 @@ describe('useJobManagement hooks', () => {
     expect(mockAddToast).toHaveBeenCalledWith({
       type: 'error',
       message: 'create failed',
+    });
+  });
+
+  describe('Phase 2A.후속 — mutation hook query key alignment', () => {
+    // Verifies that each mutation hook passes activeWorkspace.id to
+    // getMyJobPostingsQueryKey so optimistic updates target the live cache key
+    // instead of the ghost key ['jobManagement', 'myPostings', userId, 'no-workspace'].
+    //
+    // Strategy: capture the `onMutate` closure from useMutation via mockImplementationOnce,
+    // then invoke it. The module-level mockCancelQueries spy (already wired into
+    // useQueryClient above) records which queryKey was passed.
+
+    beforeEach(() => {
+      mockCancelQueries.mockClear();
+      mockGetQueryData.mockClear();
+      mockSetQueryData.mockClear();
+    });
+
+    async function captureAndRunOnMutate(
+      hookFn: () => unknown,
+      mutateArg: unknown,
+      workspaceId: string
+    ) {
+      mockUseActiveWorkspace.mockReturnValue({
+        activeWorkspace: { id: workspaceId, name: 'Test', ownerId: 'u1', memberCount: 1 } as any,
+        workspaces: [],
+        isLoading: false,
+        setActiveWorkspaceId: jest.fn(),
+      });
+
+      let capturedOnMutate: ((arg: unknown) => Promise<unknown>) | undefined;
+
+      const { useMutation } = jest.requireMock('@tanstack/react-query') as {
+        useMutation: jest.Mock;
+      };
+
+      useMutation.mockImplementationOnce(
+        (options: { onMutate?: (arg: unknown) => Promise<unknown>; mutationFn: () => void }) => {
+          capturedOnMutate = options.onMutate;
+          return { mutate: jest.fn(), mutateAsync: jest.fn(), isPending: false, error: null };
+        }
+      );
+
+      renderHook(hookFn as () => void);
+
+      if (!capturedOnMutate) {
+        throw new Error(
+          'onMutate was not captured from useMutation — hook may not call useMutation'
+        );
+      }
+
+      await act(async () => {
+        await capturedOnMutate!(mutateArg);
+      });
+
+      expect(mockCancelQueries).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: expect.arrayContaining([workspaceId]),
+        })
+      );
+    }
+
+    it('useDeleteJobPosting — onMutate 가 activeWorkspace.id 포함 key 로 cancelQueries 를 호출한다', async () => {
+      // useDeleteJobPosting gates cancelQueries on shouldApplyOptimisticUpdate()
+      const { shouldApplyOptimisticUpdate } = jest.requireMock(
+        '@/services/offline/remoteMutationGuard'
+      ) as { shouldApplyOptimisticUpdate: jest.Mock };
+      shouldApplyOptimisticUpdate.mockReturnValueOnce(true);
+
+      await captureAndRunOnMutate(() => useDeleteJobPosting(), 'job-del-1', 'ws-delete');
+    });
+
+    it('useCloseJobPosting — onMutate 가 activeWorkspace.id 포함 key 로 cancelQueries 를 호출한다', async () => {
+      await captureAndRunOnMutate(() => useCloseJobPosting(), 'job-close-1', 'ws-close');
+    });
+
+    it('useReopenJobPosting — onMutate 가 activeWorkspace.id 포함 key 로 cancelQueries 를 호출한다', async () => {
+      await captureAndRunOnMutate(() => useReopenJobPosting(), 'job-reopen-1', 'ws-reopen');
+    });
+
+    it('useBulkUpdateStatus — onMutate 가 activeWorkspace.id 포함 key 로 cancelQueries 를 호출한다', async () => {
+      await captureAndRunOnMutate(
+        () => useBulkUpdateStatus(),
+        { jobPostingIds: ['job-1'], status: 'closed' },
+        'ws-bulk'
+      );
     });
   });
 });

--- a/uniqn-mobile/src/hooks/useJobManagement.ts
+++ b/uniqn-mobile/src/hooks/useJobManagement.ts
@@ -5,6 +5,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useThrottledCallback } from '@/hooks/useThrottledCallback';
 import { getJobDetailQueryKey } from '@/hooks/useJobDetail';
+import { useActiveWorkspace } from '@/hooks/workspace/useActiveWorkspace';
 import {
   createJobPosting,
   updateJobPosting,
@@ -42,8 +43,12 @@ interface BulkStatusParams {
   status: JobPostingStatus;
 }
 
-function getMyJobPostingsQueryKey(userId?: string) {
-  return [...queryKeys.jobManagement.myPostings(), userId ?? 'anonymous'] as const;
+function getMyJobPostingsQueryKey(userId?: string, workspaceId?: string) {
+  return [
+    ...queryKeys.jobManagement.myPostings(),
+    userId ?? 'anonymous',
+    workspaceId ?? 'no-workspace',
+  ] as const;
 }
 
 function getMyJobPostingStatsQueryKey(userId?: string) {
@@ -52,12 +57,13 @@ function getMyJobPostingStatsQueryKey(userId?: string) {
 
 export function useMyJobPostings() {
   const { user } = useAuthStore();
-  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid);
+  const { activeWorkspace } = useActiveWorkspace();
+  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid, activeWorkspace?.id);
 
   return useQuery({
     queryKey: myPostingsQueryKey,
-    queryFn: () => getMyJobPostings(user!.uid),
-    enabled: !!user,
+    queryFn: () => getMyJobPostings(user!.uid, { workspaceId: activeWorkspace!.id }),
+    enabled: !!user && !!activeWorkspace?.id,
     staleTime: cachingPolicies.frequent,
   });
 }
@@ -137,7 +143,8 @@ export function useDeleteJobPosting() {
   const queryClient = useQueryClient();
   const { addToast } = useToastStore();
   const { user } = useAuthStore();
-  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid);
+  const { activeWorkspace } = useActiveWorkspace();
+  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid, activeWorkspace?.id);
 
   return useMutation({
     mutationFn: (jobPostingId: string) => {
@@ -188,7 +195,8 @@ export function useCloseJobPosting() {
   const queryClient = useQueryClient();
   const { addToast } = useToastStore();
   const { user } = useAuthStore();
-  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid);
+  const { activeWorkspace } = useActiveWorkspace();
+  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid, activeWorkspace?.id);
 
   return useMutation({
     mutationFn: (jobPostingId: string) => {
@@ -240,7 +248,8 @@ export function useReopenJobPosting() {
   const queryClient = useQueryClient();
   const { addToast } = useToastStore();
   const { user } = useAuthStore();
-  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid);
+  const { activeWorkspace } = useActiveWorkspace();
+  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid, activeWorkspace?.id);
 
   return useMutation({
     mutationFn: (jobPostingId: string) => {
@@ -292,7 +301,8 @@ export function useBulkUpdateStatus() {
   const queryClient = useQueryClient();
   const { addToast } = useToastStore();
   const { user } = useAuthStore();
-  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid);
+  const { activeWorkspace } = useActiveWorkspace();
+  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid, activeWorkspace?.id);
 
   return useMutation({
     mutationFn: (params: BulkStatusParams) => {

--- a/uniqn-mobile/src/repositories/interfaces/IJobPostingRepository.ts
+++ b/uniqn-mobile/src/repositories/interfaces/IJobPostingRepository.ts
@@ -130,14 +130,18 @@ export interface IJobPostingRepository {
   getByOwnerId(ownerId: string, status?: JobPostingStatus): Promise<JobPosting[]>;
 
   /**
-   * 호출자가 owner 이거나 활성 워크스페이스 멤버인 모든 공고를 RLS 통과로 조회.
+   * 호출자가 owner 또는 워크스페이스 멤버인 모든 공고 조회.
    *
-   * Phase 2A — 공고 공유 (editor 화면) 용도. RLS jp_select 가
-   * `owner_id = auth.uid() OR is_workspace_member(workspace_id, auth.uid())`
-   * 분기를 강제하므로 클라이언트는 status filter 만 추가하고 user_id WHERE 는
-   * 사용하지 않는다 (auth.uid() 단일 진실 — client uid 신뢰 불가).
+   * RLS jp_select 가 owner / is_workspace_member / admin 분기를 제공하지만
+   * 첫 분기 `status IN ('approved','active','closed')` 가 모든 인증 사용자에게
+   * 공개 공고 SELECT 를 허용하므로(staff 검색 의도) employer my-postings 흐름은
+   * 클라이언트에서 workspace_id 로 명시적으로 좁혀야 한다 (Phase 2A.후속 — 2026-05-09).
+   *
+   * @param status     공고 상태 필터. 미지정 시 모든 상태.
+   * @param workspaceId  활성 워크스페이스 id. 지정 시 .eq('workspace_id', id) 적용.
+   *                     미지정 시 RLS 가 허용하는 범위 전체 반환 — 레거시 / 관리자 글로벌 뷰 전용.
    */
-  getManagedJobPostings(status?: JobPostingStatus): Promise<JobPosting[]>;
+  getManagedJobPostings(status?: JobPostingStatus, workspaceId?: string): Promise<JobPosting[]>;
 
   /**
    * 공고 타입별 개수 조회

--- a/uniqn-mobile/src/repositories/supabase/ApplicationRepositoryHelpers.ts
+++ b/uniqn-mobile/src/repositories/supabase/ApplicationRepositoryHelpers.ts
@@ -153,18 +153,53 @@ export async function loadJobPosting(jobPostingId: string): Promise<JobPosting> 
   return jp;
 }
 
+/**
+ * 공고를 로드하고 호출자가 관리 권한을 가졌는지 확인.
+ *
+ * Phase 2A.후속 (2026-05-09) — owner 외에 워크스페이스 멤버 + admin 도 통과.
+ * Phase 2A 에서 applications/job_postings RLS 가 workspace_member 분기로 풀렸으나
+ * 클라이언트 헬퍼는 owner-only 였던 부분 마이그레이션을 일치시킨다.
+ *
+ * 호출 비용: owner 본인이면 RPC 0회, 멤버면 1회, admin 이면 2회. 권한 에러 흐름은
+ * cancellation/리뷰 같은 흔하지 않은 employer-side 액션이라 허용 가능.
+ */
 export async function loadAndVerifyJobPostingOwner(
   jobPostingId: string,
-  ownerId: string,
+  callerId: string,
   operation: string
 ): Promise<JobPosting> {
   const jobData = await loadJobPosting(jobPostingId);
-  if (jobData.ownerId !== ownerId) {
+
+  // 1) owner 본인
+  if (jobData.ownerId === callerId) return jobData;
+
+  // workspaceId 없는 레거시 row 방어 (M3 이후 NOT NULL 이지만 schema migration 보장 안 됨)
+  if (!jobData.workspaceId) {
     throw new PermissionError(ERROR_CODES.INFRA_PERMISSION_DENIED, {
-      userMessage: `본인 공고만 관리할 수 있습니다: ${operation}`,
+      userMessage: `공고에 워크스페이스가 지정되지 않았습니다: ${operation}`,
     });
   }
-  return jobData;
+
+  // 2) 워크스페이스 멤버 (Phase 2A backend 와 일관)
+  const memberResult = await supabase.rpc('is_workspace_member', {
+    _workspace_id: jobData.workspaceId,
+    _user_id: callerId,
+  });
+  if (memberResult.error) {
+    handleSupabaseError(memberResult.error, { operation, table: TABLES.JOB_POSTINGS });
+  }
+  if (memberResult.data === true) return jobData;
+
+  // 3) admin
+  const adminResult = await supabase.rpc('is_admin');
+  if (adminResult.error) {
+    handleSupabaseError(adminResult.error, { operation, table: TABLES.JOB_POSTINGS });
+  }
+  if (adminResult.data === true) return jobData;
+
+  throw new PermissionError(ERROR_CODES.INFRA_PERMISSION_DENIED, {
+    userMessage: `워크스페이스 멤버만 관리할 수 있습니다: ${operation}`,
+  });
 }
 
 // ============================================================================

--- a/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
@@ -299,14 +299,19 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
    * Phase 2A — 호출자가 owner 또는 워크스페이스 멤버인 모든 공고 조회.
    *
    * RLS jp_select 가 `owner_id = auth.uid() OR is_workspace_member(workspace_id, auth.uid())`
-   * 분기를 강제하므로 client 는 status filter 만 추가. user_id WHERE 는
-   * 의도적으로 사용 안 함 (client uid 와 auth.uid() 가 다를 위험 — 보안상 신뢰 불가).
+   * 분기를 제공하지만, jp_select 의 첫 분기 `status IN ('approved','active','closed')`
+   * 가 모든 인증 사용자에게 공개 공고 SELECT 권한을 주므로 employer my-postings 흐름은
+   * 클라이언트에서 workspace_id 로 명시적으로 좁혀야 한다 (Phase 2A.후속 — 2026-05-09).
    */
-  async getManagedJobPostings(status?: JobPostingStatus): Promise<JobPosting[]> {
+  async getManagedJobPostings(
+    status?: JobPostingStatus,
+    workspaceId?: string
+  ): Promise<JobPosting[]> {
     try {
-      logger.info('관리 가능 공고 조회', { status });
+      logger.info('관리 가능 공고 조회', { status, workspaceId });
       let query = supabase.from(TABLE).select(TABLE_COLUMNS);
       if (status) query = query.eq('status', status);
+      if (workspaceId) query = query.eq('workspace_id', workspaceId);
       query = query.order('created_at', { ascending: false });
       const { data, error } = await query;
       if (error) handleSupabaseError(error, { operation: '관리 가능 공고 조회', table: TABLE });
@@ -314,7 +319,7 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
       logger.info('관리 가능 공고 조회 완료', { count: items.length });
       return items;
     } catch (error) {
-      rethrowOrHandle(error, '관리 가능 공고 조회', { status });
+      rethrowOrHandle(error, '관리 가능 공고 조회', { status, workspaceId });
     }
   }
 

--- a/uniqn-mobile/src/repositories/supabase/__tests__/ApplicationRepositoryHelpers.workspace.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/ApplicationRepositoryHelpers.workspace.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Phase 2A.후속 — loadAndVerifyJobPostingOwner workspace member + admin 호환
+ */
+import { loadAndVerifyJobPostingOwner } from '../ApplicationRepositoryHelpers';
+import { supabase } from '@/lib/supabase';
+import { PermissionError } from '@/errors';
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(),
+    rpc: jest.fn(),
+  },
+}));
+
+const mockParseJobPosting = jest.fn();
+
+jest.mock('@/schemas', () => ({
+  parseApplicationDocument: jest.fn(),
+  parseJobPostingDocument: (...args: unknown[]) => mockParseJobPosting(...args),
+}));
+
+jest.mock('@/utils/supabase', () => ({
+  toCamelCase: <T>(x: T) => x,
+  handleSupabaseError: jest.fn().mockImplementation((error: unknown) => {
+    throw new Error(String((error as { message?: string })?.message ?? 'supabase error'));
+  }),
+}));
+
+const mockSupabase = supabase as jest.Mocked<typeof supabase>;
+
+const fakeJobPosting = {
+  id: 'jp-1',
+  ownerId: 'owner-uid',
+  workspaceId: 'ws-1',
+  title: '테스트 공고',
+  status: 'active' as const,
+};
+
+describe('loadAndVerifyJobPostingOwner — workspace member + admin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // loadJobPosting 내부: supabase.from(...).select(...).eq(...).maybeSingle()
+    (mockSupabase.from as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: { id: 'jp-1', owner_id: 'owner-uid', workspace_id: 'ws-1' },
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    // parseJobPostingDocument 가 fakeJobPosting 반환
+    mockParseJobPosting.mockReturnValue(fakeJobPosting);
+  });
+
+  it('owner 본인 호출 시 통과 (RPC 호출 없음)', async () => {
+    const result = await loadAndVerifyJobPostingOwner('jp-1', 'owner-uid', '취소 요청 목록 조회');
+
+    expect(result.id).toBe('jp-1');
+    expect(mockSupabase.rpc).not.toHaveBeenCalled();
+  });
+
+  it('워크스페이스 멤버 호출 시 통과 (is_workspace_member=true)', async () => {
+    (mockSupabase.rpc as jest.Mock).mockImplementation((fn: string) => {
+      if (fn === 'is_workspace_member') return Promise.resolve({ data: true, error: null });
+      return Promise.resolve({ data: false, error: null });
+    });
+
+    const result = await loadAndVerifyJobPostingOwner('jp-1', 'member-uid', '취소 요청 목록 조회');
+
+    expect(result.id).toBe('jp-1');
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('is_workspace_member', {
+      _workspace_id: 'ws-1',
+      _user_id: 'member-uid',
+    });
+  });
+
+  it('admin 호출 시 통과 (is_workspace_member=false 인데 is_admin=true)', async () => {
+    (mockSupabase.rpc as jest.Mock).mockImplementation((fn: string) => {
+      if (fn === 'is_workspace_member') return Promise.resolve({ data: false, error: null });
+      if (fn === 'is_admin') return Promise.resolve({ data: true, error: null });
+      return Promise.resolve({ data: false, error: null });
+    });
+
+    const result = await loadAndVerifyJobPostingOwner('jp-1', 'admin-uid', '취소 요청 목록 조회');
+
+    expect(result.id).toBe('jp-1');
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('is_admin');
+  });
+
+  it('외부인 호출 시 PermissionError', async () => {
+    (mockSupabase.rpc as jest.Mock).mockResolvedValue({ data: false, error: null });
+
+    await expect(
+      loadAndVerifyJobPostingOwner('jp-1', 'stranger-uid', '취소 요청 목록 조회')
+    ).rejects.toThrow(PermissionError);
+  });
+
+  it('is_workspace_member RPC 에러 시 handleSupabaseError 발생', async () => {
+    (mockSupabase.rpc as jest.Mock).mockResolvedValueOnce({
+      data: null,
+      error: { message: 'rpc error', code: 'PGRST000' },
+    });
+
+    await expect(
+      loadAndVerifyJobPostingOwner('jp-1', 'member-uid', '취소 요청 목록 조회')
+    ).rejects.toThrow();
+  });
+
+  it('is_admin RPC 에러 시 handleSupabaseError 발생', async () => {
+    (mockSupabase.rpc as jest.Mock)
+      .mockResolvedValueOnce({ data: false, error: null }) // is_workspace_member passes
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'admin rpc error', code: 'PGRST000' },
+      });
+
+    await expect(
+      loadAndVerifyJobPostingOwner('jp-1', 'admin-uid', '취소 요청 목록 조회')
+    ).rejects.toThrow();
+  });
+
+  it('Phase 2A.후속 — jobPosting.workspaceId 가 undefined 이면 PermissionError', async () => {
+    // Override loadJobPosting so the parsed posting has no workspaceId
+    (mockSupabase.from as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: { id: 'jp-1', owner_id: 'owner-uid', workspace_id: null },
+            error: null,
+          }),
+        }),
+      }),
+    });
+    mockParseJobPosting.mockReturnValueOnce({
+      ...fakeJobPosting,
+      workspaceId: undefined,
+    });
+
+    await expect(
+      loadAndVerifyJobPostingOwner('jp-1', 'someone-else', '취소 요청 목록 조회')
+    ).rejects.toThrow(PermissionError);
+
+    // RPC should NOT have been called because the guard short-circuits
+    expect(mockSupabase.rpc).not.toHaveBeenCalled();
+  });
+});

--- a/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.workspace.editor.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.workspace.editor.test.ts
@@ -135,4 +135,24 @@ describe('JobPostingRepository.getManagedJobPostings — Phase 2A editor contrac
 
     await expect(repo.getManagedJobPostings('active')).rejects.toThrow(/permission denied/);
   });
+
+  it('Phase 2A.후속 — workspaceId 가 주어지면 .eq("workspace_id", id) 를 호출한다', async () => {
+    const chain = makeChain({ data: [], error: null });
+    mockFrom.mockReturnValueOnce(chain);
+
+    await repo.getManagedJobPostings('active', 'ws-abc-123');
+
+    expect(chain.eq).toHaveBeenCalledWith('status', 'active');
+    expect(chain.eq).toHaveBeenCalledWith('workspace_id', 'ws-abc-123');
+  });
+
+  it('Phase 2A.후속 — workspaceId 가 undefined 이면 workspace_id 필터를 추가하지 않는다', async () => {
+    const chain = makeChain({ data: [], error: null });
+    mockFrom.mockReturnValueOnce(chain);
+
+    await repo.getManagedJobPostings('active');
+
+    const workspaceCall = chain.eq.mock.calls.find((c: unknown[]) => c[0] === 'workspace_id');
+    expect(workspaceCall).toBeUndefined();
+  });
 });

--- a/uniqn-mobile/src/services/jobs/__tests__/jobService.test.ts
+++ b/uniqn-mobile/src/services/jobs/__tests__/jobService.test.ts
@@ -458,8 +458,8 @@ describe('JobService', () => {
       expect(result).toHaveLength(2);
       expect(mockRepo.getManagedJobPostings).toHaveBeenCalledTimes(2);
       // Phase 2A: ownerId 파라미터 제거 — RLS auth.uid() 가 단일 진실
-      expect(mockRepo.getManagedJobPostings).toHaveBeenNthCalledWith(1, 'active');
-      expect(mockRepo.getManagedJobPostings).toHaveBeenNthCalledWith(2, 'closed');
+      expect(mockRepo.getManagedJobPostings).toHaveBeenNthCalledWith(1, 'active', undefined);
+      expect(mockRepo.getManagedJobPostings).toHaveBeenNthCalledWith(2, 'closed', undefined);
     });
 
     it('should merge active and closed postings results', async () => {
@@ -512,7 +512,7 @@ describe('JobService', () => {
       await getMyJobPostings('owner-1', { status: 'active' as any });
 
       expect(mockRepo.getManagedJobPostings).toHaveBeenCalledTimes(1);
-      expect(mockRepo.getManagedJobPostings).toHaveBeenCalledWith('active');
+      expect(mockRepo.getManagedJobPostings).toHaveBeenCalledWith('active', undefined);
     });
 
     it('should use active status as default when includeAll is false', async () => {
@@ -521,7 +521,7 @@ describe('JobService', () => {
       await getMyJobPostings('owner-1', { includeAll: false });
 
       expect(mockRepo.getManagedJobPostings).toHaveBeenCalledTimes(1);
-      expect(mockRepo.getManagedJobPostings).toHaveBeenCalledWith('active');
+      expect(mockRepo.getManagedJobPostings).toHaveBeenCalledWith('active', undefined);
     });
 
     it('should only fetch specific status when both status and includeAll are set', async () => {
@@ -530,7 +530,7 @@ describe('JobService', () => {
       await getMyJobPostings('owner-1', { status: 'closed' as any, includeAll: true });
 
       expect(mockRepo.getManagedJobPostings).toHaveBeenCalledTimes(1);
-      expect(mockRepo.getManagedJobPostings).toHaveBeenCalledWith('closed');
+      expect(mockRepo.getManagedJobPostings).toHaveBeenCalledWith('closed', undefined);
     });
 
     it('should return empty array when no postings found', async () => {
@@ -550,7 +550,7 @@ describe('JobService', () => {
       expect(mockHandleServiceError).toHaveBeenCalledWith(error, {
         operation: '관리 가능 공고 조회',
         component: 'jobService',
-        context: { ownerId: 'owner-1' },
+        context: { ownerId: 'owner-1', workspaceId: undefined },
       });
     });
 
@@ -562,6 +562,25 @@ describe('JobService', () => {
       expect(result).toEqual([]);
       // Default includeAll = true, no status => fetches both active and closed
       expect(mockRepo.getManagedJobPostings).toHaveBeenCalledTimes(2);
+    });
+
+    it('Phase 2A.후속 — workspaceId 옵션을 active/closed 두 호출 모두에 전달한다', async () => {
+      mockRepo.getManagedJobPostings.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      await getMyJobPostings('user-1', { workspaceId: 'ws-abc-123' });
+
+      expect(mockRepo.getManagedJobPostings).toHaveBeenCalledTimes(2);
+      expect(mockRepo.getManagedJobPostings).toHaveBeenNthCalledWith(1, 'active', 'ws-abc-123');
+      expect(mockRepo.getManagedJobPostings).toHaveBeenNthCalledWith(2, 'closed', 'ws-abc-123');
+    });
+
+    it('Phase 2A.후속 — workspaceId 미지정 시 두 번째 인자는 undefined 로 전달된다', async () => {
+      mockRepo.getManagedJobPostings.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      await getMyJobPostings('user-1');
+
+      expect(mockRepo.getManagedJobPostings).toHaveBeenNthCalledWith(1, 'active', undefined);
+      expect(mockRepo.getManagedJobPostings).toHaveBeenNthCalledWith(2, 'closed', undefined);
     });
   });
 
@@ -698,8 +717,8 @@ describe('JobService', () => {
       await getMyJobPostings('owner-123');
 
       const calls = mockRepo.getManagedJobPostings.mock.calls;
-      expect(calls[0]).toEqual(['active']);
-      expect(calls[1]).toEqual(['closed']);
+      expect(calls[0]).toEqual(['active', undefined]);
+      expect(calls[1]).toEqual(['closed', undefined]);
     });
 
     it('should request active and closed statuses when includeAll', async () => {
@@ -708,8 +727,8 @@ describe('JobService', () => {
       await getMyJobPostings('owner-1');
 
       const calls = mockRepo.getManagedJobPostings.mock.calls;
-      expect(calls[0]).toEqual(['active']);
-      expect(calls[1]).toEqual(['closed']);
+      expect(calls[0]).toEqual(['active', undefined]);
+      expect(calls[1]).toEqual(['closed', undefined]);
     });
   });
 });

--- a/uniqn-mobile/src/services/jobs/jobService.ts
+++ b/uniqn-mobile/src/services/jobs/jobService.ts
@@ -222,33 +222,35 @@ export async function getUrgentJobPostings(pageSize: number = 10): Promise<JobPo
 /**
  * 내 공고 목록 조회 (구인자용)
  *
- * Phase 2A — owner 본인 공고 + 소속 워크스페이스 공유 공고를 함께 반환.
- * RLS jp_select 가 (owner_id = auth.uid() OR workspace_member) 분기를 강제하므로
- * client 는 status filter 만 추가. ownerId 파라미터는 logging context 에만 사용.
+ * Phase 2A.후속 (2026-05-09) — active workspace 단위로 좁힌다. workspaceId 미지정
+ * 시 RLS 가 허용하는 범위 전체(소유 + 멤버 워크스페이스 합산)가 반환되며 이는
+ * Switcher 도입 전 레거시 호출자 호환을 위해서만 유지한다.
  */
 export async function getMyJobPostings(
   ownerId: string,
-  options?: { status?: JobPosting['status']; includeAll?: boolean }
+  options?: { status?: JobPosting['status']; includeAll?: boolean; workspaceId?: string }
 ): Promise<JobPosting[]> {
+  const { status, includeAll = true, workspaceId } = options || {};
   try {
-    const { status, includeAll = true } = options || {};
-    logger.info('관리 가능 공고 목록 조회', { ownerId, status, includeAll });
+    logger.info('관리 가능 공고 목록 조회', { ownerId, status, includeAll, workspaceId });
 
-    // includeAll이 true면 모든 상태의 공고 조회 (active, closed)
     if (includeAll && !status) {
       const results = await Promise.all([
-        jobPostingRepository.getManagedJobPostings(STATUS.JOB_POSTING.ACTIVE),
-        jobPostingRepository.getManagedJobPostings(STATUS.JOB_POSTING.CLOSED),
+        jobPostingRepository.getManagedJobPostings(STATUS.JOB_POSTING.ACTIVE, workspaceId),
+        jobPostingRepository.getManagedJobPostings(STATUS.JOB_POSTING.CLOSED, workspaceId),
       ]);
       return [...results[0], ...results[1]];
     }
 
-    return jobPostingRepository.getManagedJobPostings(status || STATUS.JOB_POSTING.ACTIVE);
+    return jobPostingRepository.getManagedJobPostings(
+      status || STATUS.JOB_POSTING.ACTIVE,
+      workspaceId
+    );
   } catch (error) {
     throw handleServiceError(error, {
       operation: '관리 가능 공고 조회',
       component: 'jobService',
-      context: { ownerId }, // ownerId 자동 마스킹
+      context: { ownerId, workspaceId },
     });
   }
 }


### PR DESCRIPTION
## Summary

사용자 dogfooding(2026-05-09)에서 발견한 워크스페이스 누출 버그 3가지 해결.

- `getManagedJobPostings(workspaceId)` 옵션 + `useMyJobPostings` 가 activeWorkspace 의존 (Switcher → React Query 자동 re-fetch)
- 4개 mutation hook(useDeleteJobPosting / useCloseJobPosting / useReopenJobPosting / useBulkUpdateStatus) 도 동일 query key 정렬 — onMutate 캐시 패치 ghost key 방지
- `loadAndVerifyJobPostingOwner` 가 owner OR workspace_member OR admin 분기 — cancellation/리뷰/거절/읽음/확정/확정취소 6+ 흐름 동시 호환

## Background

Phase 2A backend(applications/job_postings RLS workspace_member 분기)는 풀려 있었으나 클라이언트 layer 가 owner-only 였던 부분 마이그레이션 상태. 본 PR 이 일치시킴.

별개로 발견한 RC: RLS \`jp_select\` 첫 분기 \`status IN ('approved','active','closed')\` 가 모든 인증 사용자에게 active 공고 SELECT 허용(staff 검색 의도) → employer my-postings 가 RLS 만 의존하면 누출. 클라이언트 명시적 workspace 필터 필요. 본 PR 이 클라이언트 보완.

## 변경 commits

| SHA | Layer | Test |
|-----|-------|------|
| \`1dec4a034\` | Repository \`getManagedJobPostings(status?, workspaceId?)\` | +2 cases |
| \`e2aef8da7\` | Service \`getMyJobPostings\` workspaceId pass-through | +2 cases |
| \`30eddc75e\` | Hook \`useMyJobPostings\` + 4 mutation hooks activeWorkspace 의존 | +3 + 4 cases |
| \`8c1909d60\` | Helper \`loadAndVerifyJobPostingOwner\` workspace_member+admin | +7 cases (NEW file) |

총 +18 신규 테스트, 0 회귀.

## Test plan

- [x] type-check 0 errors
- [x] jest 4001 total / 3 fail (master baseline 동일 — pre-existing scheduleService + submission 무관 실패)
- [x] eslint 0 new warning
- [ ] **dogfooding (사용자 검증 필요)**:
  - [ ] review-employer / WS1(공고 보유) → 공고 1
  - [ ] review-employer / WS2(빈) → 공고 0
  - [ ] review-admin / 본인 WS → 본인 공고만 (review-employer 공고 비노출)
  - [ ] review-admin 가 review-employer 공고 진입 → 취소 요청 검토 PermissionError 없이 정상
  - [ ] 외부인(공고 미관련 staff) → PermissionError 정상

## Out of scope (follow-up plans)

- **Task 5** — RLS \`jp_select\` 분리 (\`list_managed_postings\` SECURITY DEFINER RPC + 검색용 정책 분리). 보안 경계를 RLS 로 옮기는 진짜 fix. eng-review 필요.
- **Task 6** — 다른 화면 audit (applications / work_logs / event_qr_codes / settlement / schedule). 같은 패턴 잠재 위험 일괄 점검.
- write-side \`JobPostingRepository.loadAndVerifyOwner\` (update / close / reopen / delete / settlement) — workspace member 분기 동일 적용 필요. 별도 PR.
- Mutation hook 4x \`useActiveWorkspace\` 호출 DRY refactor (\`useMyPostingsQueryKey\` 헬퍼 추출).
- Helper 함수 이름 \`loadAndVerifyJobPostingOwner\` → \`loadAndVerifyJobPostingAccess\` rename (의미와 이름 정합성).

## 핵심 파일

- \`uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts\`
- \`uniqn-mobile/src/services/jobs/jobService.ts\`
- \`uniqn-mobile/src/hooks/useJobManagement.ts\`
- \`uniqn-mobile/src/repositories/supabase/ApplicationRepositoryHelpers.ts\`
- 신규: \`uniqn-mobile/src/repositories/supabase/__tests__/ApplicationRepositoryHelpers.workspace.test.ts\`

## Plan reference

\`docs/superpowers/plans/2026-05-09-workspace-posting-filter.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)