### PR TITLE
refactor(workspace): loadAndVerifyJobPostingOwner→Access rename + mutation hook DRY — Phase 2A.후속

### DIFF
--- a/uniqn-mobile/__tests__/integration/applicationCapacityRace.test.ts
+++ b/uniqn-mobile/__tests__/integration/applicationCapacityRace.test.ts
@@ -33,7 +33,7 @@ jest.mock('@/repositories/supabase/ApplicationRepositoryHelpers', () => ({
     throw error;
   },
   loadApplication: jest.fn(),
-  loadAndVerifyJobPostingOwner: jest.fn(),
+  loadAndVerifyJobPostingAccess: jest.fn(),
 }));
 
 jest.mock('@/domains/application', () => ({
@@ -178,7 +178,7 @@ describe('WF-06: 지원 정원 race condition', () => {
 
   // mock 함수 참조 — 런타임에 jest.mocked 없이 캐스팅
   let mockLoadApplication: MockFn;
-  let mockLoadAndVerifyJobPostingOwner: MockFn;
+  let mockLoadAndVerifyJobPostingAccess: MockFn;
   let mockValidateAssignmentSlotCapacity: MockFn;
 
   beforeEach(() => {
@@ -187,7 +187,7 @@ describe('WF-06: 지원 정원 race condition', () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const helpers = require('@/repositories/supabase/ApplicationRepositoryHelpers');
     mockLoadApplication = helpers.loadApplication as MockFn;
-    mockLoadAndVerifyJobPostingOwner = helpers.loadAndVerifyJobPostingOwner as MockFn;
+    mockLoadAndVerifyJobPostingAccess = helpers.loadAndVerifyJobPostingAccess as MockFn;
 
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const domain = require('@/domains/application');
@@ -205,7 +205,7 @@ describe('WF-06: 지원 정원 race condition', () => {
       .mockResolvedValueOnce(makeApplication('app-1'))
       .mockResolvedValueOnce(makeApplication('app-2'));
 
-    mockLoadAndVerifyJobPostingOwner.mockResolvedValue(makeJobPosting(1, 0));
+    mockLoadAndVerifyJobPostingAccess.mockResolvedValue(makeJobPosting(1, 0));
 
     // 첫 번째 validateAssignmentSlotCapacity 호출: 정원 여유 있음
     // 두 번째 호출: 첫 번째가 이미 정원을 소비했다고 가정 (race 시뮬레이션)
@@ -256,7 +256,7 @@ describe('WF-06: 지원 정원 race condition', () => {
     let filledPositions = 0;
 
     mockLoadApplication.mockResolvedValue(makeApplication('app-1'));
-    mockLoadAndVerifyJobPostingOwner.mockImplementation(async () =>
+    mockLoadAndVerifyJobPostingAccess.mockImplementation(async () =>
       makeJobPosting(1, filledPositions)
     );
 
@@ -284,7 +284,7 @@ describe('WF-06: 지원 정원 race condition', () => {
       .mockResolvedValueOnce(makeApplication('app-2'))
       .mockResolvedValueOnce(makeApplication('app-3'));
 
-    mockLoadAndVerifyJobPostingOwner.mockImplementation(async () =>
+    mockLoadAndVerifyJobPostingAccess.mockImplementation(async () =>
       makeJobPosting(CAPACITY, filledPositions)
     );
 
@@ -321,7 +321,7 @@ describe('WF-06: 지원 정원 race condition', () => {
       .mockResolvedValueOnce(makeApplication('app-2'))
       .mockResolvedValueOnce(makeApplication('app-3'));
 
-    mockLoadAndVerifyJobPostingOwner.mockResolvedValue(makeJobPosting(CAPACITY, 0));
+    mockLoadAndVerifyJobPostingAccess.mockResolvedValue(makeJobPosting(CAPACITY, 0));
 
     // 처음 2번은 통과, 3번째는 정원 초과
     let validateCallCount = 0;
@@ -372,7 +372,7 @@ describe('WF-06: 지원 정원 race condition', () => {
   // ─────────────────────────────────────────────────────────────────────────
   it('validateAssignmentSlotCapacity unavailable 반환 시 capacity 에러 throw', async () => {
     mockLoadApplication.mockResolvedValue(makeApplication('app-1'));
-    mockLoadAndVerifyJobPostingOwner.mockResolvedValue(makeJobPosting(1, 1));
+    mockLoadAndVerifyJobPostingAccess.mockResolvedValue(makeJobPosting(1, 1));
 
     mockValidateAssignmentSlotCapacity.mockReturnValue({
       available: false,

--- a/uniqn-mobile/__tests__/integration/confirmCreatesWorkLog.test.ts
+++ b/uniqn-mobile/__tests__/integration/confirmCreatesWorkLog.test.ts
@@ -10,7 +10,7 @@
 import { executeConfirmWithHistory } from '@/repositories/supabase/ApplicationRepositoryTransactions';
 import {
   loadApplication,
-  loadAndVerifyJobPostingOwner,
+  loadAndVerifyJobPostingAccess,
 } from '@/repositories/supabase/ApplicationRepositoryHelpers';
 import { BusinessError } from '@/errors';
 
@@ -37,7 +37,7 @@ jest.mock('@/repositories/supabase/ApplicationRepositoryHelpers', () => ({
     throw error;
   },
   loadApplication: jest.fn(),
-  loadAndVerifyJobPostingOwner: jest.fn(),
+  loadAndVerifyJobPostingAccess: jest.fn(),
 }));
 
 jest.mock('@/domains/application', () => ({
@@ -136,8 +136,8 @@ const OWNER_ID = 'employer-333';
 
 describe('executeConfirmWithHistory — confirm_application RPC work_log 원자성', () => {
   const mockLoadApplication = loadApplication as jest.MockedFunction<typeof loadApplication>;
-  const mockLoadAndVerify = loadAndVerifyJobPostingOwner as jest.MockedFunction<
-    typeof loadAndVerifyJobPostingOwner
+  const mockLoadAndVerify = loadAndVerifyJobPostingAccess as jest.MockedFunction<
+    typeof loadAndVerifyJobPostingAccess
   >;
 
   beforeEach(() => {
@@ -219,7 +219,7 @@ describe('executeConfirmWithHistory — confirm_application RPC work_log 원자�
       status: 'confirmed',
     };
     mockLoadApplication.mockResolvedValueOnce(confirmedApplication as never);
-    // loadAndVerifyJobPostingOwner는 호출되지 않아야 함
+    // loadAndVerifyJobPostingAccess는 호출되지 않아야 함
 
     // Act & Assert
     await expect(executeConfirmWithHistory(APPLICATION_ID, undefined, OWNER_ID)).rejects.toThrow(

--- a/uniqn-mobile/__tests__/repositories/applicationCancellation.test.ts
+++ b/uniqn-mobile/__tests__/repositories/applicationCancellation.test.ts
@@ -40,7 +40,7 @@ jest.mock('@/repositories/supabase/ApplicationRepositoryHelpers', () => ({
     throw error;
   },
   loadApplication: jest.fn(),
-  loadAndVerifyJobPostingOwner: jest.fn(),
+  loadAndVerifyJobPostingAccess: jest.fn(),
 }));
 
 describe('executeCancelConfirmation — cancel_application_atomically RPC', () => {

--- a/uniqn-mobile/src/hooks/useJobManagement.ts
+++ b/uniqn-mobile/src/hooks/useJobManagement.ts
@@ -55,6 +55,19 @@ function getMyJobPostingStatsQueryKey(userId?: string) {
   return [...queryKeys.jobManagement.stats(), userId ?? 'anonymous'] as const;
 }
 
+/**
+ * mutation hook 들이 optimistic update 의 cancel/get/set/rollback 에 사용하는 queryKey 헬퍼.
+ *
+ * 4 mutation hook (delete/close/reopen/bulkUpdate) 가 동일한 user.uid + activeWorkspace.id
+ * 조합으로 queryKey 를 만들었던 보일러플레이트를 추출. activeWorkspace 가 미전달인
+ * 호출자 (admin global view 등) 에서도 fallback 'no-workspace' 키로 ghost cache 회피.
+ */
+function useMyPostingsQueryKey() {
+  const { user } = useAuthStore();
+  const { activeWorkspace } = useActiveWorkspace();
+  return getMyJobPostingsQueryKey(user?.uid, activeWorkspace?.id);
+}
+
 export function useMyJobPostings() {
   const { user } = useAuthStore();
   const { activeWorkspace } = useActiveWorkspace();
@@ -143,8 +156,7 @@ export function useDeleteJobPosting() {
   const queryClient = useQueryClient();
   const { addToast } = useToastStore();
   const { user } = useAuthStore();
-  const { activeWorkspace } = useActiveWorkspace();
-  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid, activeWorkspace?.id);
+  const myPostingsQueryKey = useMyPostingsQueryKey();
 
   return useMutation({
     mutationFn: (jobPostingId: string) => {
@@ -195,8 +207,7 @@ export function useCloseJobPosting() {
   const queryClient = useQueryClient();
   const { addToast } = useToastStore();
   const { user } = useAuthStore();
-  const { activeWorkspace } = useActiveWorkspace();
-  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid, activeWorkspace?.id);
+  const myPostingsQueryKey = useMyPostingsQueryKey();
 
   return useMutation({
     mutationFn: (jobPostingId: string) => {
@@ -248,8 +259,7 @@ export function useReopenJobPosting() {
   const queryClient = useQueryClient();
   const { addToast } = useToastStore();
   const { user } = useAuthStore();
-  const { activeWorkspace } = useActiveWorkspace();
-  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid, activeWorkspace?.id);
+  const myPostingsQueryKey = useMyPostingsQueryKey();
 
   return useMutation({
     mutationFn: (jobPostingId: string) => {
@@ -301,8 +311,7 @@ export function useBulkUpdateStatus() {
   const queryClient = useQueryClient();
   const { addToast } = useToastStore();
   const { user } = useAuthStore();
-  const { activeWorkspace } = useActiveWorkspace();
-  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid, activeWorkspace?.id);
+  const myPostingsQueryKey = useMyPostingsQueryKey();
 
   return useMutation({
     mutationFn: (params: BulkStatusParams) => {

--- a/uniqn-mobile/src/repositories/supabase/ApplicationRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/ApplicationRepository.ts
@@ -61,7 +61,7 @@ import {
   rethrowOrHandle,
   loadApplication,
   loadJobPosting,
-  loadAndVerifyJobPostingOwner,
+  loadAndVerifyJobPostingAccess,
   buildCanonicalFixedAssignment,
   buildApplicantListWithStats,
 } from './ApplicationRepositoryHelpers';
@@ -318,7 +318,7 @@ export class SupabaseApplicationRepository implements IApplicationRepository {
     try {
       logger.info('취소 요청 목록 조회', { jobPostingId, ownerId });
 
-      const jobData = await loadAndVerifyJobPostingOwner(
+      const jobData = await loadAndVerifyJobPostingAccess(
         jobPostingId,
         ownerId,
         '취소 요청 목록 조회'
@@ -643,7 +643,7 @@ export class SupabaseApplicationRepository implements IApplicationRepository {
       logger.info('지원 거절 시작', { applicationId: input.applicationId, reviewerId });
 
       const applicationData = await loadApplication(input.applicationId);
-      const jobData = await loadAndVerifyJobPostingOwner(
+      const jobData = await loadAndVerifyJobPostingAccess(
         applicationData.jobPostingId,
         reviewerId,
         '지원 거절'
@@ -686,7 +686,7 @@ export class SupabaseApplicationRepository implements IApplicationRepository {
       logger.info('지원 읽음 처리 시작', { applicationId, ownerId });
 
       const applicationData = await loadApplication(applicationId);
-      await loadAndVerifyJobPostingOwner(applicationData.jobPostingId, ownerId, '지원 읽음 처리');
+      await loadAndVerifyJobPostingAccess(applicationData.jobPostingId, ownerId, '지원 읽음 처리');
 
       const { error } = await supabase
         .from(TABLES.APPLICATIONS)
@@ -734,7 +734,7 @@ export class SupabaseApplicationRepository implements IApplicationRepository {
     try {
       logger.info('지원자 목록 조회', { jobPostingId, ownerId, statusFilter });
 
-      const jobPosting = await loadAndVerifyJobPostingOwner(
+      const jobPosting = await loadAndVerifyJobPostingAccess(
         jobPostingId,
         ownerId,
         '지원자 목록 조회'
@@ -778,7 +778,7 @@ export class SupabaseApplicationRepository implements IApplicationRepository {
     const handleUpdate = async () => {
       try {
         if (!isOwnerVerified) {
-          cachedJobPosting = await loadAndVerifyJobPostingOwner(
+          cachedJobPosting = await loadAndVerifyJobPostingAccess(
             jobPostingId,
             ownerId,
             '지원자 실시간 구독'

--- a/uniqn-mobile/src/repositories/supabase/ApplicationRepositoryHelpers.ts
+++ b/uniqn-mobile/src/repositories/supabase/ApplicationRepositoryHelpers.ts
@@ -154,16 +154,20 @@ export async function loadJobPosting(jobPostingId: string): Promise<JobPosting> 
 }
 
 /**
- * 공고를 로드하고 호출자가 관리 권한을 가졌는지 확인.
+ * 공고를 로드하고 호출자가 관리 권한(access)을 가졌는지 확인.
  *
  * Phase 2A.후속 (2026-05-09) — owner 외에 워크스페이스 멤버 + admin 도 통과.
  * Phase 2A 에서 applications/job_postings RLS 가 workspace_member 분기로 풀렸으나
  * 클라이언트 헬퍼는 owner-only 였던 부분 마이그레이션을 일치시킨다.
  *
+ * Rename (2026-05-10) — owner-only 시절의 `loadAndVerifyJobPostingOwner` 에서 access
+ * 의미가 명확해진 `loadAndVerifyJobPostingAccess` 로 변경. 함수 의미와 시그니처는 동일,
+ * 호출자도 단순 import 변경.
+ *
  * 호출 비용: owner 본인이면 RPC 0회, 멤버면 1회, admin 이면 2회. 권한 에러 흐름은
  * cancellation/리뷰 같은 흔하지 않은 employer-side 액션이라 허용 가능.
  */
-export async function loadAndVerifyJobPostingOwner(
+export async function loadAndVerifyJobPostingAccess(
   jobPostingId: string,
   callerId: string,
   operation: string

--- a/uniqn-mobile/src/repositories/supabase/ApplicationRepositoryTransactions.ts
+++ b/uniqn-mobile/src/repositories/supabase/ApplicationRepositoryTransactions.ts
@@ -22,7 +22,7 @@ import {
   TABLES,
   rethrowOrHandle,
   loadApplication,
-  loadAndVerifyJobPostingOwner,
+  loadAndVerifyJobPostingAccess,
 } from './ApplicationRepositoryHelpers';
 
 // ============================================================================
@@ -56,7 +56,7 @@ export async function executeConfirmWithHistory(
       }
     }
 
-    const jobData = await loadAndVerifyJobPostingOwner(
+    const jobData = await loadAndVerifyJobPostingAccess(
       applicationData.jobPostingId,
       ownerId,
       '지원 확정'
@@ -162,7 +162,7 @@ export async function executeReviewCancellation(
     }
 
     const applicationData = await loadApplication(input.applicationId);
-    const jobData = await loadAndVerifyJobPostingOwner(
+    const jobData = await loadAndVerifyJobPostingAccess(
       applicationData.jobPostingId,
       reviewerId,
       '취소 요청 검토'

--- a/uniqn-mobile/src/repositories/supabase/__tests__/ApplicationRepositoryHelpers.workspace.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/ApplicationRepositoryHelpers.workspace.test.ts
@@ -1,7 +1,7 @@
 /**
- * Phase 2A.후속 — loadAndVerifyJobPostingOwner workspace member + admin 호환
+ * Phase 2A.후속 — loadAndVerifyJobPostingAccess workspace member + admin 호환
  */
-import { loadAndVerifyJobPostingOwner } from '../ApplicationRepositoryHelpers';
+import { loadAndVerifyJobPostingAccess } from '../ApplicationRepositoryHelpers';
 import { supabase } from '@/lib/supabase';
 import { PermissionError } from '@/errors';
 
@@ -36,7 +36,7 @@ const fakeJobPosting = {
   status: 'active' as const,
 };
 
-describe('loadAndVerifyJobPostingOwner — workspace member + admin', () => {
+describe('loadAndVerifyJobPostingAccess — workspace member + admin', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -57,7 +57,7 @@ describe('loadAndVerifyJobPostingOwner — workspace member + admin', () => {
   });
 
   it('owner 본인 호출 시 통과 (RPC 호출 없음)', async () => {
-    const result = await loadAndVerifyJobPostingOwner('jp-1', 'owner-uid', '취소 요청 목록 조회');
+    const result = await loadAndVerifyJobPostingAccess('jp-1', 'owner-uid', '취소 요청 목록 조회');
 
     expect(result.id).toBe('jp-1');
     expect(mockSupabase.rpc).not.toHaveBeenCalled();
@@ -69,7 +69,7 @@ describe('loadAndVerifyJobPostingOwner — workspace member + admin', () => {
       return Promise.resolve({ data: false, error: null });
     });
 
-    const result = await loadAndVerifyJobPostingOwner('jp-1', 'member-uid', '취소 요청 목록 조회');
+    const result = await loadAndVerifyJobPostingAccess('jp-1', 'member-uid', '취소 요청 목록 조회');
 
     expect(result.id).toBe('jp-1');
     expect(mockSupabase.rpc).toHaveBeenCalledWith('is_workspace_member', {
@@ -85,7 +85,7 @@ describe('loadAndVerifyJobPostingOwner — workspace member + admin', () => {
       return Promise.resolve({ data: false, error: null });
     });
 
-    const result = await loadAndVerifyJobPostingOwner('jp-1', 'admin-uid', '취소 요청 목록 조회');
+    const result = await loadAndVerifyJobPostingAccess('jp-1', 'admin-uid', '취소 요청 목록 조회');
 
     expect(result.id).toBe('jp-1');
     expect(mockSupabase.rpc).toHaveBeenCalledWith('is_admin');
@@ -95,7 +95,7 @@ describe('loadAndVerifyJobPostingOwner — workspace member + admin', () => {
     (mockSupabase.rpc as jest.Mock).mockResolvedValue({ data: false, error: null });
 
     await expect(
-      loadAndVerifyJobPostingOwner('jp-1', 'stranger-uid', '취소 요청 목록 조회')
+      loadAndVerifyJobPostingAccess('jp-1', 'stranger-uid', '취소 요청 목록 조회')
     ).rejects.toThrow(PermissionError);
   });
 
@@ -106,7 +106,7 @@ describe('loadAndVerifyJobPostingOwner — workspace member + admin', () => {
     });
 
     await expect(
-      loadAndVerifyJobPostingOwner('jp-1', 'member-uid', '취소 요청 목록 조회')
+      loadAndVerifyJobPostingAccess('jp-1', 'member-uid', '취소 요청 목록 조회')
     ).rejects.toThrow();
   });
 
@@ -119,7 +119,7 @@ describe('loadAndVerifyJobPostingOwner — workspace member + admin', () => {
       });
 
     await expect(
-      loadAndVerifyJobPostingOwner('jp-1', 'admin-uid', '취소 요청 목록 조회')
+      loadAndVerifyJobPostingAccess('jp-1', 'admin-uid', '취소 요청 목록 조회')
     ).rejects.toThrow();
   });
 
@@ -141,7 +141,7 @@ describe('loadAndVerifyJobPostingOwner — workspace member + admin', () => {
     });
 
     await expect(
-      loadAndVerifyJobPostingOwner('jp-1', 'someone-else', '취소 요청 목록 조회')
+      loadAndVerifyJobPostingAccess('jp-1', 'someone-else', '취소 요청 목록 조회')
     ).rejects.toThrow(PermissionError);
 
     // RPC should NOT have been called because the guard short-circuits


### PR DESCRIPTION
## Summary
PR #71 follow-up. Behavior change 0건, 정합성/가독성 cleanup.

- **Rename**: `ApplicationRepositoryHelpers.loadAndVerifyJobPostingOwner` → `loadAndVerifyJobPostingAccess`. owner-only 시절 명명이 owner|member|admin access check 로 확장된 의미와 misleading.
- **DRY**: useJobManagement 4 mutation hook (delete/close/reopen/bulkUpdate) 의 보일러플레이트 (useActiveWorkspace + getMyJobPostingsQueryKey 3 줄) 를 `useMyPostingsQueryKey` 헬퍼로 추출. PR #71 ghost cache key 회귀의 진앙(소비자가 user.uid + activeWorkspace.id 조합 직접 재구성)을 구조적으로 제거.

## Background
PR #71 에서 Phase 2A backend(applications/job_postings RLS 의 workspace_member 분기)와 클라이언트 헬퍼 정합성을 맞췄으나:
1. 함수명이 owner-only 시절 그대로라 신규 contributor 가 RLS 분기 의미 파악 어려움
2. 4 mutation hook 가 동일 보일러플레이트 반복 → 신규 mutation 추가 시 ghost cache key 위험 재발 가능

본 PR 은 이 두 부분을 정합성 차원에서 정리.

## Files Modified
- src/repositories/supabase/ApplicationRepositoryHelpers.ts (정의 + JSDoc)
- src/repositories/supabase/ApplicationRepository.ts (5 callsite + 1 import)
- src/repositories/supabase/ApplicationRepositoryTransactions.ts (2 callsite + 1 import)
- src/repositories/supabase/__tests__/ApplicationRepositoryHelpers.workspace.test.ts (describe + 7 callsite)
- __tests__/repositories/applicationCancellation.test.ts (mock)
- __tests__/integration/confirmCreatesWorkLog.test.ts (3 ref)
- __tests__/integration/applicationCapacityRace.test.ts (mock + 7 ref)
- src/hooks/useJobManagement.ts (DRY: useMyPostingsQueryKey 헬퍼 추가, 4 mutation hook 적용)

## Test plan
- [x] jest 4001 total / 3 fail — master baseline 동일 (scheduleService + submission 사전 알려진 실패)
- [x] ApplicationRepositoryHelpers.workspace.test 7/7 PASS
- [x] useJobManagement.test 11/11 PASS (Phase 2A.후속 mutation hook key alignment 4 케이스 포함)
- [ ] 사용자 dogfooding: 4 mutation 흐름 (삭제/마감/재오픈/일괄상태) workspace 전환 시 정상 작동 — 시각적 확인만 (behavior change 없음)

## Out of scope
- write-side `JobPostingRepository.loadAndVerifyOwner` 의 동일 패턴 적용 — PR2 별도
- Task 6 audit (applications/work_logs/event_qr_codes/settlement/schedule) — PR3 별도
- Task 5 RLS jp_select 분리 — PR4 (eng-review + production migration confirm 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)