### PR TITLE
feat(workspace): write-side mutation 권한 owner|member|admin 호환 — Phase 2A.후속

### DIFF
--- a/uniqn-mobile/__tests__/integration/applicationCapacityRace.test.ts
+++ b/uniqn-mobile/__tests__/integration/applicationCapacityRace.test.ts
@@ -33,7 +33,7 @@ jest.mock('@/repositories/supabase/ApplicationRepositoryHelpers', () => ({
     throw error;
   },
   loadApplication: jest.fn(),
-  loadAndVerifyJobPostingOwner: jest.fn(),
+  loadAndVerifyJobPostingAccess: jest.fn(),
 }));
 
 jest.mock('@/domains/application', () => ({
@@ -178,7 +178,7 @@ describe('WF-06: 지원 정원 race condition', () => {
 
   // mock 함수 참조 — 런타임에 jest.mocked 없이 캐스팅
   let mockLoadApplication: MockFn;
-  let mockLoadAndVerifyJobPostingOwner: MockFn;
+  let mockLoadAndVerifyJobPostingAccess: MockFn;
   let mockValidateAssignmentSlotCapacity: MockFn;
 
   beforeEach(() => {
@@ -187,7 +187,7 @@ describe('WF-06: 지원 정원 race condition', () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const helpers = require('@/repositories/supabase/ApplicationRepositoryHelpers');
     mockLoadApplication = helpers.loadApplication as MockFn;
-    mockLoadAndVerifyJobPostingOwner = helpers.loadAndVerifyJobPostingOwner as MockFn;
+    mockLoadAndVerifyJobPostingAccess = helpers.loadAndVerifyJobPostingAccess as MockFn;
 
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const domain = require('@/domains/application');
@@ -205,7 +205,7 @@ describe('WF-06: 지원 정원 race condition', () => {
       .mockResolvedValueOnce(makeApplication('app-1'))
       .mockResolvedValueOnce(makeApplication('app-2'));
 
-    mockLoadAndVerifyJobPostingOwner.mockResolvedValue(makeJobPosting(1, 0));
+    mockLoadAndVerifyJobPostingAccess.mockResolvedValue(makeJobPosting(1, 0));
 
     // 첫 번째 validateAssignmentSlotCapacity 호출: 정원 여유 있음
     // 두 번째 호출: 첫 번째가 이미 정원을 소비했다고 가정 (race 시뮬레이션)
@@ -256,7 +256,7 @@ describe('WF-06: 지원 정원 race condition', () => {
     let filledPositions = 0;
 
     mockLoadApplication.mockResolvedValue(makeApplication('app-1'));
-    mockLoadAndVerifyJobPostingOwner.mockImplementation(async () =>
+    mockLoadAndVerifyJobPostingAccess.mockImplementation(async () =>
       makeJobPosting(1, filledPositions)
     );
 
@@ -284,7 +284,7 @@ describe('WF-06: 지원 정원 race condition', () => {
       .mockResolvedValueOnce(makeApplication('app-2'))
       .mockResolvedValueOnce(makeApplication('app-3'));
 
-    mockLoadAndVerifyJobPostingOwner.mockImplementation(async () =>
+    mockLoadAndVerifyJobPostingAccess.mockImplementation(async () =>
       makeJobPosting(CAPACITY, filledPositions)
     );
 
@@ -321,7 +321,7 @@ describe('WF-06: 지원 정원 race condition', () => {
       .mockResolvedValueOnce(makeApplication('app-2'))
       .mockResolvedValueOnce(makeApplication('app-3'));
 
-    mockLoadAndVerifyJobPostingOwner.mockResolvedValue(makeJobPosting(CAPACITY, 0));
+    mockLoadAndVerifyJobPostingAccess.mockResolvedValue(makeJobPosting(CAPACITY, 0));
 
     // 처음 2번은 통과, 3번째는 정원 초과
     let validateCallCount = 0;
@@ -372,7 +372,7 @@ describe('WF-06: 지원 정원 race condition', () => {
   // ─────────────────────────────────────────────────────────────────────────
   it('validateAssignmentSlotCapacity unavailable 반환 시 capacity 에러 throw', async () => {
     mockLoadApplication.mockResolvedValue(makeApplication('app-1'));
-    mockLoadAndVerifyJobPostingOwner.mockResolvedValue(makeJobPosting(1, 1));
+    mockLoadAndVerifyJobPostingAccess.mockResolvedValue(makeJobPosting(1, 1));
 
     mockValidateAssignmentSlotCapacity.mockReturnValue({
       available: false,

--- a/uniqn-mobile/__tests__/integration/confirmCreatesWorkLog.test.ts
+++ b/uniqn-mobile/__tests__/integration/confirmCreatesWorkLog.test.ts
@@ -10,7 +10,7 @@
 import { executeConfirmWithHistory } from '@/repositories/supabase/ApplicationRepositoryTransactions';
 import {
   loadApplication,
-  loadAndVerifyJobPostingOwner,
+  loadAndVerifyJobPostingAccess,
 } from '@/repositories/supabase/ApplicationRepositoryHelpers';
 import { BusinessError } from '@/errors';
 
@@ -37,7 +37,7 @@ jest.mock('@/repositories/supabase/ApplicationRepositoryHelpers', () => ({
     throw error;
   },
   loadApplication: jest.fn(),
-  loadAndVerifyJobPostingOwner: jest.fn(),
+  loadAndVerifyJobPostingAccess: jest.fn(),
 }));
 
 jest.mock('@/domains/application', () => ({
@@ -136,8 +136,8 @@ const OWNER_ID = 'employer-333';
 
 describe('executeConfirmWithHistory — confirm_application RPC work_log 원자성', () => {
   const mockLoadApplication = loadApplication as jest.MockedFunction<typeof loadApplication>;
-  const mockLoadAndVerify = loadAndVerifyJobPostingOwner as jest.MockedFunction<
-    typeof loadAndVerifyJobPostingOwner
+  const mockLoadAndVerify = loadAndVerifyJobPostingAccess as jest.MockedFunction<
+    typeof loadAndVerifyJobPostingAccess
   >;
 
   beforeEach(() => {
@@ -219,7 +219,7 @@ describe('executeConfirmWithHistory — confirm_application RPC work_log 원자�
       status: 'confirmed',
     };
     mockLoadApplication.mockResolvedValueOnce(confirmedApplication as never);
-    // loadAndVerifyJobPostingOwner는 호출되지 않아야 함
+    // loadAndVerifyJobPostingAccess는 호출되지 않아야 함
 
     // Act & Assert
     await expect(executeConfirmWithHistory(APPLICATION_ID, undefined, OWNER_ID)).rejects.toThrow(

--- a/uniqn-mobile/__tests__/repositories/applicationCancellation.test.ts
+++ b/uniqn-mobile/__tests__/repositories/applicationCancellation.test.ts
@@ -40,7 +40,7 @@ jest.mock('@/repositories/supabase/ApplicationRepositoryHelpers', () => ({
     throw error;
   },
   loadApplication: jest.fn(),
-  loadAndVerifyJobPostingOwner: jest.fn(),
+  loadAndVerifyJobPostingAccess: jest.fn(),
 }));
 
 describe('executeCancelConfirmation — cancel_application_atomically RPC', () => {

--- a/uniqn-mobile/src/hooks/useJobManagement.ts
+++ b/uniqn-mobile/src/hooks/useJobManagement.ts
@@ -55,6 +55,19 @@ function getMyJobPostingStatsQueryKey(userId?: string) {
   return [...queryKeys.jobManagement.stats(), userId ?? 'anonymous'] as const;
 }
 
+/**
+ * mutation hook 들이 optimistic update 의 cancel/get/set/rollback 에 사용하는 queryKey 헬퍼.
+ *
+ * 4 mutation hook (delete/close/reopen/bulkUpdate) 가 동일한 user.uid + activeWorkspace.id
+ * 조합으로 queryKey 를 만들었던 보일러플레이트를 추출. activeWorkspace 가 미전달인
+ * 호출자 (admin global view 등) 에서도 fallback 'no-workspace' 키로 ghost cache 회피.
+ */
+function useMyPostingsQueryKey() {
+  const { user } = useAuthStore();
+  const { activeWorkspace } = useActiveWorkspace();
+  return getMyJobPostingsQueryKey(user?.uid, activeWorkspace?.id);
+}
+
 export function useMyJobPostings() {
   const { user } = useAuthStore();
   const { activeWorkspace } = useActiveWorkspace();
@@ -143,8 +156,7 @@ export function useDeleteJobPosting() {
   const queryClient = useQueryClient();
   const { addToast } = useToastStore();
   const { user } = useAuthStore();
-  const { activeWorkspace } = useActiveWorkspace();
-  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid, activeWorkspace?.id);
+  const myPostingsQueryKey = useMyPostingsQueryKey();
 
   return useMutation({
     mutationFn: (jobPostingId: string) => {
@@ -195,8 +207,7 @@ export function useCloseJobPosting() {
   const queryClient = useQueryClient();
   const { addToast } = useToastStore();
   const { user } = useAuthStore();
-  const { activeWorkspace } = useActiveWorkspace();
-  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid, activeWorkspace?.id);
+  const myPostingsQueryKey = useMyPostingsQueryKey();
 
   return useMutation({
     mutationFn: (jobPostingId: string) => {
@@ -248,8 +259,7 @@ export function useReopenJobPosting() {
   const queryClient = useQueryClient();
   const { addToast } = useToastStore();
   const { user } = useAuthStore();
-  const { activeWorkspace } = useActiveWorkspace();
-  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid, activeWorkspace?.id);
+  const myPostingsQueryKey = useMyPostingsQueryKey();
 
   return useMutation({
     mutationFn: (jobPostingId: string) => {
@@ -301,8 +311,7 @@ export function useBulkUpdateStatus() {
   const queryClient = useQueryClient();
   const { addToast } = useToastStore();
   const { user } = useAuthStore();
-  const { activeWorkspace } = useActiveWorkspace();
-  const myPostingsQueryKey = getMyJobPostingsQueryKey(user?.uid, activeWorkspace?.id);
+  const myPostingsQueryKey = useMyPostingsQueryKey();
 
   return useMutation({
     mutationFn: (params: BulkStatusParams) => {

--- a/uniqn-mobile/src/repositories/supabase/ApplicationRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/ApplicationRepository.ts
@@ -61,7 +61,7 @@ import {
   rethrowOrHandle,
   loadApplication,
   loadJobPosting,
-  loadAndVerifyJobPostingOwner,
+  loadAndVerifyJobPostingAccess,
   buildCanonicalFixedAssignment,
   buildApplicantListWithStats,
 } from './ApplicationRepositoryHelpers';
@@ -318,7 +318,7 @@ export class SupabaseApplicationRepository implements IApplicationRepository {
     try {
       logger.info('취소 요청 목록 조회', { jobPostingId, ownerId });
 
-      const jobData = await loadAndVerifyJobPostingOwner(
+      const jobData = await loadAndVerifyJobPostingAccess(
         jobPostingId,
         ownerId,
         '취소 요청 목록 조회'
@@ -643,7 +643,7 @@ export class SupabaseApplicationRepository implements IApplicationRepository {
       logger.info('지원 거절 시작', { applicationId: input.applicationId, reviewerId });
 
       const applicationData = await loadApplication(input.applicationId);
-      const jobData = await loadAndVerifyJobPostingOwner(
+      const jobData = await loadAndVerifyJobPostingAccess(
         applicationData.jobPostingId,
         reviewerId,
         '지원 거절'
@@ -686,7 +686,7 @@ export class SupabaseApplicationRepository implements IApplicationRepository {
       logger.info('지원 읽음 처리 시작', { applicationId, ownerId });
 
       const applicationData = await loadApplication(applicationId);
-      await loadAndVerifyJobPostingOwner(applicationData.jobPostingId, ownerId, '지원 읽음 처리');
+      await loadAndVerifyJobPostingAccess(applicationData.jobPostingId, ownerId, '지원 읽음 처리');
 
       const { error } = await supabase
         .from(TABLES.APPLICATIONS)
@@ -734,7 +734,7 @@ export class SupabaseApplicationRepository implements IApplicationRepository {
     try {
       logger.info('지원자 목록 조회', { jobPostingId, ownerId, statusFilter });
 
-      const jobPosting = await loadAndVerifyJobPostingOwner(
+      const jobPosting = await loadAndVerifyJobPostingAccess(
         jobPostingId,
         ownerId,
         '지원자 목록 조회'
@@ -778,7 +778,7 @@ export class SupabaseApplicationRepository implements IApplicationRepository {
     const handleUpdate = async () => {
       try {
         if (!isOwnerVerified) {
-          cachedJobPosting = await loadAndVerifyJobPostingOwner(
+          cachedJobPosting = await loadAndVerifyJobPostingAccess(
             jobPostingId,
             ownerId,
             '지원자 실시간 구독'

--- a/uniqn-mobile/src/repositories/supabase/ApplicationRepositoryHelpers.ts
+++ b/uniqn-mobile/src/repositories/supabase/ApplicationRepositoryHelpers.ts
@@ -154,16 +154,20 @@ export async function loadJobPosting(jobPostingId: string): Promise<JobPosting> 
 }
 
 /**
- * 공고를 로드하고 호출자가 관리 권한을 가졌는지 확인.
+ * 공고를 로드하고 호출자가 관리 권한(access)을 가졌는지 확인.
  *
  * Phase 2A.후속 (2026-05-09) — owner 외에 워크스페이스 멤버 + admin 도 통과.
  * Phase 2A 에서 applications/job_postings RLS 가 workspace_member 분기로 풀렸으나
  * 클라이언트 헬퍼는 owner-only 였던 부분 마이그레이션을 일치시킨다.
  *
+ * Rename (2026-05-10) — owner-only 시절의 `loadAndVerifyJobPostingOwner` 에서 access
+ * 의미가 명확해진 `loadAndVerifyJobPostingAccess` 로 변경. 함수 의미와 시그니처는 동일,
+ * 호출자도 단순 import 변경.
+ *
  * 호출 비용: owner 본인이면 RPC 0회, 멤버면 1회, admin 이면 2회. 권한 에러 흐름은
  * cancellation/리뷰 같은 흔하지 않은 employer-side 액션이라 허용 가능.
  */
-export async function loadAndVerifyJobPostingOwner(
+export async function loadAndVerifyJobPostingAccess(
   jobPostingId: string,
   callerId: string,
   operation: string

--- a/uniqn-mobile/src/repositories/supabase/ApplicationRepositoryTransactions.ts
+++ b/uniqn-mobile/src/repositories/supabase/ApplicationRepositoryTransactions.ts
@@ -22,7 +22,7 @@ import {
   TABLES,
   rethrowOrHandle,
   loadApplication,
-  loadAndVerifyJobPostingOwner,
+  loadAndVerifyJobPostingAccess,
 } from './ApplicationRepositoryHelpers';
 
 // ============================================================================
@@ -56,7 +56,7 @@ export async function executeConfirmWithHistory(
       }
     }
 
-    const jobData = await loadAndVerifyJobPostingOwner(
+    const jobData = await loadAndVerifyJobPostingAccess(
       applicationData.jobPostingId,
       ownerId,
       '지원 확정'
@@ -162,7 +162,7 @@ export async function executeReviewCancellation(
     }
 
     const applicationData = await loadApplication(input.applicationId);
-    const jobData = await loadAndVerifyJobPostingOwner(
+    const jobData = await loadAndVerifyJobPostingAccess(
       applicationData.jobPostingId,
       reviewerId,
       '취소 요청 검토'

--- a/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
@@ -98,9 +98,8 @@ function rethrowOrHandle(
   handleSupabaseError(error, { operation, table: TABLE });
 }
 
-async function loadAndVerifyOwner(
+async function loadJobPostingForVerify(
   jobPostingId: string,
-  ownerId: string,
   operation: string
 ): Promise<JobPosting> {
   const { data, error } = await supabase
@@ -112,23 +111,95 @@ async function loadAndVerifyOwner(
   if (error) handleSupabaseError(error, { operation, table: TABLE });
   if (!data) {
     throw new BusinessError(ERROR_CODES.INFRA_NOT_FOUND, {
-      userMessage: 'Job posting does not exist.',
+      userMessage: '공고를 찾을 수 없습니다.',
     });
   }
 
   const jobPosting = toJobPosting(data as Record<string, unknown>);
   if (!jobPosting) {
     throw new BusinessError(ERROR_CODES.BUSINESS_INVALID_STATE, {
-      userMessage: 'Job posting data is invalid.',
-    });
-  }
-
-  if (jobPosting.ownerId !== ownerId) {
-    throw new PermissionError(ERROR_CODES.INFRA_PERMISSION_DENIED, {
-      userMessage: `Only the owner can perform this action: ${operation}`,
+      userMessage: '공고 데이터가 올바르지 않습니다.',
     });
   }
   return jobPosting;
+}
+
+/**
+ * 공고를 로드하고 호출자가 update-style mutation 권한을 가졌는지 확인.
+ *
+ * Phase 2A.후속 (2026-05-10) — RLS jp_update_workspace_member (USING + WITH CHECK
+ * 모두 `is_workspace_member(workspace_id, auth.uid()) OR is_admin()`) 와 일치.
+ * 4 mutation flow (수정/마감/재오픈/정산설정) 가 본 헬퍼를 사용. owner-only 였던
+ * 이전 동작에서 editor + admin 까지 풀어 Phase 1A editor role 활성화.
+ *
+ * 호출 비용: owner 본인이면 RPC 0회, 멤버면 1회, admin 이면 2회.
+ *
+ * @see ApplicationRepositoryHelpers.loadAndVerifyJobPostingAccess (read-side 와 동일 분기)
+ */
+async function loadAndVerifyMutateAccess(
+  jobPostingId: string,
+  callerId: string,
+  operation: string
+): Promise<JobPosting> {
+  const jobPosting = await loadJobPostingForVerify(jobPostingId, operation);
+  if (jobPosting.ownerId === callerId) return jobPosting;
+
+  // workspaceId 없는 레거시 row 방어
+  if (!jobPosting.workspaceId) {
+    throw new PermissionError(ERROR_CODES.INFRA_PERMISSION_DENIED, {
+      userMessage: `공고에 워크스페이스가 지정되지 않았습니다: ${operation}`,
+    });
+  }
+
+  const memberResult = await supabase.rpc('is_workspace_member', {
+    _workspace_id: jobPosting.workspaceId,
+    _user_id: callerId,
+  });
+  if (memberResult.error) {
+    handleSupabaseError(memberResult.error, { operation, table: TABLE });
+  }
+  if (memberResult.data === true) return jobPosting;
+
+  const adminResult = await supabase.rpc('is_admin');
+  if (adminResult.error) {
+    handleSupabaseError(adminResult.error, { operation, table: TABLE });
+  }
+  if (adminResult.data === true) return jobPosting;
+
+  throw new PermissionError(ERROR_CODES.INFRA_PERMISSION_DENIED, {
+    userMessage: `워크스페이스 멤버만 수행할 수 있습니다: ${operation}`,
+  });
+}
+
+/**
+ * 공고를 로드하고 호출자가 delete 권한(더 엄격)을 가졌는지 확인.
+ *
+ * Phase 2A.후속 (2026-05-10) — RLS jp_delete_workspace_owner 의 의도(`workspace 소유자
+ * 또는 admin`) 를 본 클라이언트는 `job posting owner 또는 admin` 으로 근사. 워크스페이스
+ * 소유자와 공고 소유자가 일치하는 일반 케이스 모두 통과. member 는 거절(soft-delete
+ * 도 거부).
+ *
+ * 알려진 갭(out-of-scope): 본 클라이언트가 UPDATE status=cancelled (soft-delete) 를
+ * 쓰므로 RLS 는 jp_update_workspace_member 를 평가 → API 직접 호출 시 member 가 우회
+ * 가능. DB-level enforcement 는 별도 status 전이 trigger/함수로 강화 필요.
+ */
+async function loadAndVerifyDeleteAccess(
+  jobPostingId: string,
+  callerId: string,
+  operation: string
+): Promise<JobPosting> {
+  const jobPosting = await loadJobPostingForVerify(jobPostingId, operation);
+  if (jobPosting.ownerId === callerId) return jobPosting;
+
+  const adminResult = await supabase.rpc('is_admin');
+  if (adminResult.error) {
+    handleSupabaseError(adminResult.error, { operation, table: TABLE });
+  }
+  if (adminResult.data === true) return jobPosting;
+
+  throw new PermissionError(ERROR_CODES.INFRA_PERMISSION_DENIED, {
+    userMessage: `공고 소유자만 삭제할 수 있습니다: ${operation}`,
+  });
 }
 
 // ── Settlement Helpers ───────────────────────────────────────────────────────
@@ -485,7 +556,7 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
   ): Promise<JobPosting> {
     try {
       logger.info('공고 수정', { jobPostingId, ownerId });
-      const cur = await loadAndVerifyOwner(jobPostingId, ownerId, '공고 수정');
+      const cur = await loadAndVerifyMutateAccess(jobPostingId, ownerId, '공고 수정');
 
       if (
         (cur.filledPositions ?? 0) > 0 &&
@@ -516,11 +587,7 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
       const { id: _id, ...rest } = removeUndefined(
         serialized as unknown as Record<string, unknown>
       );
-      const { error } = await supabase
-        .from(TABLE)
-        .update(toSnakeCase(rest))
-        .eq('id', jobPostingId)
-        .eq('owner_id', ownerId);
+      const { error } = await supabase.from(TABLE).update(toSnakeCase(rest)).eq('id', jobPostingId);
       if (error) handleSupabaseError(error, { operation: '공고 수정', table: TABLE });
       logger.info('공고 수정 완료', { jobPostingId });
       return validated;
@@ -532,7 +599,7 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
   async deleteWithTransaction(jobPostingId: string, ownerId: string): Promise<void> {
     try {
       logger.info('공고 삭제', { jobPostingId, ownerId });
-      const cur = await loadAndVerifyOwner(jobPostingId, ownerId, '공고 삭제');
+      const cur = await loadAndVerifyDeleteAccess(jobPostingId, ownerId, '공고 삭제');
       if ((cur.filledPositions ?? 0) > 0) {
         throw new BusinessError(ERROR_CODES.BUSINESS_INVALID_STATE, {
           userMessage: 'Cannot delete a posting with confirmed applicants. Close it instead.',
@@ -541,8 +608,7 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
       const { error } = await supabase
         .from(TABLE)
         .update({ status: STATUS.JOB_POSTING.CANCELLED, updated_at: new Date().toISOString() })
-        .eq('id', jobPostingId)
-        .eq('owner_id', ownerId);
+        .eq('id', jobPostingId);
       if (error) handleSupabaseError(error, { operation: '공고 삭제', table: TABLE });
       logger.info('공고 삭제 완료', { jobPostingId });
     } catch (error) {
@@ -553,7 +619,7 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
   async closeWithTransaction(jobPostingId: string, ownerId: string): Promise<void> {
     try {
       logger.info('공고 마감', { jobPostingId, ownerId });
-      const cur = await loadAndVerifyOwner(jobPostingId, ownerId, '공고 마감');
+      const cur = await loadAndVerifyMutateAccess(jobPostingId, ownerId, '공고 마감');
       if (cur.status === STATUS.JOB_POSTING.CLOSED) {
         throw new BusinessError(ERROR_CODES.BUSINESS_INVALID_STATE, {
           userMessage: 'Job posting is already closed.',
@@ -568,8 +634,7 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
           closed_reason: 'manual',
           updated_at: now,
         })
-        .eq('id', jobPostingId)
-        .eq('owner_id', ownerId);
+        .eq('id', jobPostingId);
       if (error) handleSupabaseError(error, { operation: '공고 마감', table: TABLE });
       logger.info('공고 마감 완료', { jobPostingId });
     } catch (error) {
@@ -580,7 +645,7 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
   async reopenWithTransaction(jobPostingId: string, ownerId: string): Promise<void> {
     try {
       logger.info('공고 재오픈', { jobPostingId, ownerId });
-      const cur = await loadAndVerifyOwner(jobPostingId, ownerId, '공고 재오픈');
+      const cur = await loadAndVerifyMutateAccess(jobPostingId, ownerId, '공고 재오픈');
 
       if (cur.status === STATUS.JOB_POSTING.ACTIVE) {
         throw new BusinessError(ERROR_CODES.BUSINESS_INVALID_STATE, {
@@ -605,8 +670,7 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
       const { error } = await supabase
         .from(TABLE)
         .update({ status: STATUS.JOB_POSTING.ACTIVE, updated_at: new Date().toISOString() })
-        .eq('id', jobPostingId)
-        .eq('owner_id', ownerId);
+        .eq('id', jobPostingId);
       if (error) handleSupabaseError(error, { operation: '공고 재오픈', table: TABLE });
       logger.info('공고 재오픈 완료', { jobPostingId });
     } catch (error) {
@@ -686,7 +750,7 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
   ): Promise<void> {
     try {
       logger.info('정산 설정 업데이트', { jobPostingId, ownerId });
-      const cur = await loadAndVerifyOwner(jobPostingId, ownerId, '정산 설정 업데이트');
+      const cur = await loadAndVerifyMutateAccess(jobPostingId, ownerId, '정산 설정 업데이트');
 
       const merged: CreateJobPostingInput = mergeJobPostingInput(cur, {
         roleCatalog: mergeSettlementRoles(cur.roleCatalog, data.roles),
@@ -715,11 +779,7 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
       const { id: _id, ...rest } = removeUndefined(
         serialized as unknown as Record<string, unknown>
       );
-      const { error } = await supabase
-        .from(TABLE)
-        .update(toSnakeCase(rest))
-        .eq('id', jobPostingId)
-        .eq('owner_id', ownerId);
+      const { error } = await supabase.from(TABLE).update(toSnakeCase(rest)).eq('id', jobPostingId);
       if (error) handleSupabaseError(error, { operation: '정산 설정 업데이트', table: TABLE });
       logger.info('정산 설정 업데이트 완료', { jobPostingId });
     } catch (error) {

--- a/uniqn-mobile/src/repositories/supabase/__tests__/ApplicationRepositoryHelpers.workspace.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/ApplicationRepositoryHelpers.workspace.test.ts
@@ -1,7 +1,7 @@
 /**
- * Phase 2A.후속 — loadAndVerifyJobPostingOwner workspace member + admin 호환
+ * Phase 2A.후속 — loadAndVerifyJobPostingAccess workspace member + admin 호환
  */
-import { loadAndVerifyJobPostingOwner } from '../ApplicationRepositoryHelpers';
+import { loadAndVerifyJobPostingAccess } from '../ApplicationRepositoryHelpers';
 import { supabase } from '@/lib/supabase';
 import { PermissionError } from '@/errors';
 
@@ -36,7 +36,7 @@ const fakeJobPosting = {
   status: 'active' as const,
 };
 
-describe('loadAndVerifyJobPostingOwner — workspace member + admin', () => {
+describe('loadAndVerifyJobPostingAccess — workspace member + admin', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -57,7 +57,7 @@ describe('loadAndVerifyJobPostingOwner — workspace member + admin', () => {
   });
 
   it('owner 본인 호출 시 통과 (RPC 호출 없음)', async () => {
-    const result = await loadAndVerifyJobPostingOwner('jp-1', 'owner-uid', '취소 요청 목록 조회');
+    const result = await loadAndVerifyJobPostingAccess('jp-1', 'owner-uid', '취소 요청 목록 조회');
 
     expect(result.id).toBe('jp-1');
     expect(mockSupabase.rpc).not.toHaveBeenCalled();
@@ -69,7 +69,7 @@ describe('loadAndVerifyJobPostingOwner — workspace member + admin', () => {
       return Promise.resolve({ data: false, error: null });
     });
 
-    const result = await loadAndVerifyJobPostingOwner('jp-1', 'member-uid', '취소 요청 목록 조회');
+    const result = await loadAndVerifyJobPostingAccess('jp-1', 'member-uid', '취소 요청 목록 조회');
 
     expect(result.id).toBe('jp-1');
     expect(mockSupabase.rpc).toHaveBeenCalledWith('is_workspace_member', {
@@ -85,7 +85,7 @@ describe('loadAndVerifyJobPostingOwner — workspace member + admin', () => {
       return Promise.resolve({ data: false, error: null });
     });
 
-    const result = await loadAndVerifyJobPostingOwner('jp-1', 'admin-uid', '취소 요청 목록 조회');
+    const result = await loadAndVerifyJobPostingAccess('jp-1', 'admin-uid', '취소 요청 목록 조회');
 
     expect(result.id).toBe('jp-1');
     expect(mockSupabase.rpc).toHaveBeenCalledWith('is_admin');
@@ -95,7 +95,7 @@ describe('loadAndVerifyJobPostingOwner — workspace member + admin', () => {
     (mockSupabase.rpc as jest.Mock).mockResolvedValue({ data: false, error: null });
 
     await expect(
-      loadAndVerifyJobPostingOwner('jp-1', 'stranger-uid', '취소 요청 목록 조회')
+      loadAndVerifyJobPostingAccess('jp-1', 'stranger-uid', '취소 요청 목록 조회')
     ).rejects.toThrow(PermissionError);
   });
 
@@ -106,7 +106,7 @@ describe('loadAndVerifyJobPostingOwner — workspace member + admin', () => {
     });
 
     await expect(
-      loadAndVerifyJobPostingOwner('jp-1', 'member-uid', '취소 요청 목록 조회')
+      loadAndVerifyJobPostingAccess('jp-1', 'member-uid', '취소 요청 목록 조회')
     ).rejects.toThrow();
   });
 
@@ -119,7 +119,7 @@ describe('loadAndVerifyJobPostingOwner — workspace member + admin', () => {
       });
 
     await expect(
-      loadAndVerifyJobPostingOwner('jp-1', 'admin-uid', '취소 요청 목록 조회')
+      loadAndVerifyJobPostingAccess('jp-1', 'admin-uid', '취소 요청 목록 조회')
     ).rejects.toThrow();
   });
 
@@ -141,7 +141,7 @@ describe('loadAndVerifyJobPostingOwner — workspace member + admin', () => {
     });
 
     await expect(
-      loadAndVerifyJobPostingOwner('jp-1', 'someone-else', '취소 요청 목록 조회')
+      loadAndVerifyJobPostingAccess('jp-1', 'someone-else', '취소 요청 목록 조회')
     ).rejects.toThrow(PermissionError);
 
     // RPC should NOT have been called because the guard short-circuits

--- a/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.write.workspace.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.write.workspace.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Phase 2A.후속 — write-side workspace member + admin 호환
+ *
+ * @description JobPostingRepository.{update,delete,close,reopen,updateSettlementSettings}
+ *              의 access verification 분기 검증. RLS jp_update_workspace_member 와 일치하는
+ *              loadAndVerifyMutateAccess (owner|member|admin) 와 더 엄격한
+ *              loadAndVerifyDeleteAccess (owner|admin only) 의 권한 매트릭스를 contract level
+ *              에서 검증.
+ *
+ * 권한 매트릭스 (RLS 미러):
+ * | flow              | owner | member | admin | outsider |
+ * |-------------------|-------|--------|-------|----------|
+ * | updateWith        | OK    | OK     | OK    | reject   |
+ * | closeWith         | OK    | OK     | OK    | reject   |
+ * | reopenWith        | OK    | OK     | OK    | reject   |
+ * | updateSettlement  | OK    | OK     | OK    | reject   |
+ * | deleteWith        | OK    | reject | OK    | reject   |
+ */
+
+import { SupabaseJobPostingRepository } from '../JobPostingRepository';
+import { PermissionError } from '@/errors';
+
+// ── Mock Supabase ────────────────────────────────────────────────────────────
+const mockFrom = jest.fn();
+const mockRpc = jest.fn();
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    rpc: (...args: unknown[]) => mockRpc(...args),
+    channel: jest.fn(),
+  },
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('@/utils/supabase', () => {
+  const actual = jest.requireActual('@/utils/supabase');
+  return {
+    ...actual,
+    handleSupabaseError: (error: { message?: string } | null) => {
+      if (error) throw new Error(`supabase: ${error.message ?? 'unknown'}`);
+    },
+  };
+});
+
+jest.mock('@sentry/react-native', () => ({
+  __esModule: true,
+  addBreadcrumb: jest.fn(),
+}));
+
+// 핵심: parseJobPostingDocument 가 fakeJobPosting 을 반환하도록 mock
+const mockParseJobPosting = jest.fn();
+jest.mock('@/schemas', () => {
+  const actual = jest.requireActual('@/schemas');
+  return {
+    ...actual,
+    parseJobPostingDocument: (...args: unknown[]) => mockParseJobPosting(...args),
+  };
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+const OWNER_ID = '11111111-1111-4111-8111-111111111111';
+const MEMBER_ID = '22222222-2222-4222-8222-222222222222';
+const ADMIN_ID = '33333333-3333-4333-8333-333333333333';
+const OUTSIDER_ID = '44444444-4444-4444-8444-444444444444';
+const POSTING_ID = '55555555-5555-4555-8555-555555555555';
+const WORKSPACE_ID = '66666666-6666-4666-8666-666666666666';
+
+function makeChain(returnValue: { data: unknown; error: unknown }) {
+  const chain: Record<string, unknown> = {};
+  for (const m of [
+    'select',
+    'eq',
+    'in',
+    'is',
+    'order',
+    'limit',
+    'range',
+    'update',
+    'insert',
+    'delete',
+    'upsert',
+  ]) {
+    chain[m] = jest.fn(() => chain);
+  }
+  for (const m of ['single', 'maybeSingle']) {
+    chain[m] = jest.fn(() => Promise.resolve(returnValue));
+  }
+  (chain as { then?: unknown }).then = function then<TResult1 = unknown, TResult2 = never>(
+    onfulfilled?: ((value: unknown) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): PromiseLike<TResult1 | TResult2> {
+    return Promise.resolve(returnValue).then(onfulfilled, onrejected);
+  };
+  return chain as Record<string, jest.Mock> & PromiseLike<unknown>;
+}
+
+const fakePosting = {
+  id: POSTING_ID,
+  ownerId: OWNER_ID,
+  workspaceId: WORKSPACE_ID,
+  title: '234',
+  status: 'active' as const,
+  schemaVersion: 3,
+  workDate: '2026-05-09',
+  workDates: ['2026-05-09'],
+  roleKeys: ['dealer'],
+  totalPositions: 1,
+  filledPositions: 0,
+  viewCount: 0,
+  createdAt: new Date('2026-05-09T00:00:00Z'),
+  updatedAt: new Date('2026-05-09T00:00:00Z'),
+  ownerName: 'Owner',
+  postingType: 'regular',
+  location: { name: '강남' },
+  schedule: {
+    kind: 'dated' as const,
+    primaryDate: '2026-05-09',
+    allDates: ['2026-05-09'],
+    requirements: [],
+  },
+  roleCatalog: [{ role: 'dealer' }],
+  compensation: { mode: 'shared' },
+  questions: { items: [] },
+};
+
+function setupLoadAndUpdate() {
+  // 1st from() — loadJobPostingForVerify (.select.eq.maybeSingle)
+  // 2nd from() — actual UPDATE (.update.eq).then resolves to {error: null}
+  const loadChain = makeChain({
+    data: { id: POSTING_ID, owner_id: OWNER_ID, workspace_id: WORKSPACE_ID },
+    error: null,
+  });
+  const updateChain = makeChain({ data: null, error: null });
+  mockFrom.mockReturnValueOnce(loadChain).mockReturnValue(updateChain);
+  mockParseJobPosting.mockReturnValue(fakePosting);
+  return { loadChain, updateChain };
+}
+
+beforeEach(() => {
+  mockFrom.mockReset();
+  mockRpc.mockReset();
+  mockParseJobPosting.mockReset();
+});
+
+// ============================================================================
+// Mutate access (update/close/reopen/settlement)
+// ============================================================================
+
+describe('JobPostingRepository write-side — loadAndVerifyMutateAccess (owner|member|admin)', () => {
+  const repo = new SupabaseJobPostingRepository();
+
+  it('owner 본인의 close 호출은 RPC 0회로 통과한다', async () => {
+    setupLoadAndUpdate();
+
+    await repo.closeWithTransaction(POSTING_ID, OWNER_ID).catch(() => {
+      // 본 테스트는 access 분기만 검증 — 후속 비즈니스 로직 fail 여부는 무관
+    });
+
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it('워크스페이스 멤버의 close 호출은 is_workspace_member RPC 통과 후 진행', async () => {
+    setupLoadAndUpdate();
+    mockRpc.mockImplementation((fn: string) => {
+      if (fn === 'is_workspace_member') return Promise.resolve({ data: true, error: null });
+      return Promise.resolve({ data: false, error: null });
+    });
+
+    await repo.closeWithTransaction(POSTING_ID, MEMBER_ID).catch(() => {});
+
+    expect(mockRpc).toHaveBeenCalledWith('is_workspace_member', {
+      _workspace_id: WORKSPACE_ID,
+      _user_id: MEMBER_ID,
+    });
+    // is_workspace_member 가 true 면 is_admin 안 부름
+    expect(mockRpc).toHaveBeenCalledTimes(1);
+  });
+
+  it('admin 호출 시 is_workspace_member=false → is_admin=true 분기로 통과', async () => {
+    setupLoadAndUpdate();
+    mockRpc.mockImplementation((fn: string) => {
+      if (fn === 'is_workspace_member') return Promise.resolve({ data: false, error: null });
+      if (fn === 'is_admin') return Promise.resolve({ data: true, error: null });
+      return Promise.resolve({ data: false, error: null });
+    });
+
+    await repo.closeWithTransaction(POSTING_ID, ADMIN_ID).catch(() => {});
+
+    expect(mockRpc).toHaveBeenCalledWith('is_workspace_member', expect.any(Object));
+    expect(mockRpc).toHaveBeenCalledWith('is_admin');
+  });
+
+  it('외부인의 close 호출은 PermissionError 로 거절된다', async () => {
+    setupLoadAndUpdate();
+    mockRpc.mockResolvedValue({ data: false, error: null });
+
+    await expect(repo.closeWithTransaction(POSTING_ID, OUTSIDER_ID)).rejects.toThrow(
+      PermissionError
+    );
+  });
+
+  it('reopenWithTransaction 도 동일 분기 (member 통과)', async () => {
+    setupLoadAndUpdate();
+    mockRpc.mockImplementation((fn: string) =>
+      Promise.resolve({ data: fn === 'is_workspace_member', error: null })
+    );
+
+    await repo.reopenWithTransaction(POSTING_ID, MEMBER_ID).catch(() => {});
+
+    expect(mockRpc).toHaveBeenCalledWith('is_workspace_member', expect.any(Object));
+  });
+
+  it('updateSettlementSettings 도 동일 분기 (admin 통과)', async () => {
+    setupLoadAndUpdate();
+    mockRpc.mockImplementation((fn: string) => {
+      if (fn === 'is_workspace_member') return Promise.resolve({ data: false, error: null });
+      if (fn === 'is_admin') return Promise.resolve({ data: true, error: null });
+      return Promise.resolve({ data: false, error: null });
+    });
+
+    await repo
+      .updateSettlementSettings(
+        POSTING_ID,
+        { roles: [], allowances: {}, taxSettings: {} as never },
+        ADMIN_ID
+      )
+      .catch(() => {});
+
+    expect(mockRpc).toHaveBeenCalledWith('is_admin');
+  });
+
+  it('workspaceId 가 undefined 인 레거시 row 는 PermissionError', async () => {
+    const loadChain = makeChain({
+      data: { id: POSTING_ID, owner_id: OWNER_ID, workspace_id: null },
+      error: null,
+    });
+    mockFrom.mockReturnValueOnce(loadChain);
+    mockParseJobPosting.mockReturnValue({ ...fakePosting, workspaceId: undefined });
+
+    await expect(repo.closeWithTransaction(POSTING_ID, MEMBER_ID)).rejects.toThrow(PermissionError);
+    // workspaceId guard 가 short-circuit → RPC 호출 없음
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// Delete access (더 엄격: owner|admin only, member 차단)
+// ============================================================================
+
+describe('JobPostingRepository write-side — loadAndVerifyDeleteAccess (owner|admin only)', () => {
+  const repo = new SupabaseJobPostingRepository();
+
+  it('owner 본인의 delete 호출은 RPC 0회로 통과', async () => {
+    setupLoadAndUpdate();
+
+    await repo.deleteWithTransaction(POSTING_ID, OWNER_ID).catch(() => {});
+
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it('워크스페이스 멤버의 delete 호출은 PermissionError (member 차단)', async () => {
+    setupLoadAndUpdate();
+    mockRpc.mockResolvedValue({ data: false, error: null });
+
+    await expect(repo.deleteWithTransaction(POSTING_ID, MEMBER_ID)).rejects.toThrow(
+      PermissionError
+    );
+    // delete 헬퍼는 is_workspace_member 분기 자체가 없으므로 호출 안 함
+    expect(mockRpc).not.toHaveBeenCalledWith('is_workspace_member', expect.any(Object));
+  });
+
+  it('admin 호출 시 is_admin RPC 만 호출하여 통과 (is_workspace_member 미호출)', async () => {
+    setupLoadAndUpdate();
+    mockRpc.mockImplementation((fn: string) =>
+      Promise.resolve({ data: fn === 'is_admin', error: null })
+    );
+
+    await repo.deleteWithTransaction(POSTING_ID, ADMIN_ID).catch(() => {});
+
+    expect(mockRpc).toHaveBeenCalledWith('is_admin');
+    expect(mockRpc).not.toHaveBeenCalledWith('is_workspace_member', expect.any(Object));
+  });
+
+  it('외부인의 delete 호출은 PermissionError', async () => {
+    setupLoadAndUpdate();
+    mockRpc.mockResolvedValue({ data: false, error: null });
+
+    await expect(repo.deleteWithTransaction(POSTING_ID, OUTSIDER_ID)).rejects.toThrow(
+      PermissionError
+    );
+  });
+});
+
+// ============================================================================
+// owner_id 필터 제거 회귀 가드 — RLS 단일 진실 (PR2 핵심)
+// ============================================================================
+
+describe('JobPostingRepository write-side — owner_id 필터 회귀 가드', () => {
+  const repo = new SupabaseJobPostingRepository();
+
+  it('closeWithTransaction 의 UPDATE 는 owner_id 필터를 사용하지 않는다 (RLS 의존)', async () => {
+    const { updateChain } = setupLoadAndUpdate();
+
+    await repo.closeWithTransaction(POSTING_ID, OWNER_ID).catch(() => {});
+
+    // .eq 호출 인자 — id 만 있어야 하고 owner_id 는 없어야 함
+    const eqCalls = (updateChain.eq as jest.Mock).mock.calls.map((c) => c[0]);
+    expect(eqCalls).toContain('id');
+    expect(eqCalls).not.toContain('owner_id');
+  });
+
+  it('reopenWithTransaction 도 동일 — owner_id 필터 없음', async () => {
+    // reopen 은 status='active' 면 BusinessError 던지므로 closed 상태 fake 필요
+    const loadChain = makeChain({
+      data: { id: POSTING_ID, owner_id: OWNER_ID, workspace_id: WORKSPACE_ID, status: 'closed' },
+      error: null,
+    });
+    const updateChain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(loadChain).mockReturnValue(updateChain);
+    mockParseJobPosting.mockReturnValue({ ...fakePosting, status: 'closed' });
+
+    await repo.reopenWithTransaction(POSTING_ID, OWNER_ID).catch(() => {});
+
+    const eqCalls = (updateChain.eq as jest.Mock).mock.calls.map((c) => c[0]);
+    expect(eqCalls).toContain('id');
+    expect(eqCalls).not.toContain('owner_id');
+  });
+
+  it('deleteWithTransaction 도 동일 — owner_id 필터 없음 (helper 가 owner|admin gate)', async () => {
+    const { updateChain } = setupLoadAndUpdate();
+
+    await repo.deleteWithTransaction(POSTING_ID, OWNER_ID).catch(() => {});
+
+    const eqCalls = (updateChain.eq as jest.Mock).mock.calls.map((c) => c[0]);
+    expect(eqCalls).toContain('id');
+    expect(eqCalls).not.toContain('owner_id');
+  });
+});


### PR DESCRIPTION
## Summary
PR #71/#72 follow-up — write-side helper RLS 일관성. `read-side 만 풀고 write-side 가 owner-only 였던 부분 마이그레이션` 종결.

> **Stacked on top of #72** — base = `worktree-workspace-cleanup-rename-dry`. #72 머지 후 자동으로 base 가 master 로 변경.

## Background — RLS 검사 결과
| 정책 | USING/WITH CHECK |
|------|-----------------|
| jp_update_workspace_member | `is_workspace_member OR is_admin` |
| jp_delete_workspace_owner | `workspace_owner OR is_admin` (member 차단) |
| jp_select | public(approved/active/closed) OR owner OR member OR admin |

그러나 client `loadAndVerifyOwner` 는 `ownerId !== ownerId` 만 체크 → editor + admin 무조건 차단. RLS 가 풀려있어도 client gate 가 통과 못 함.

## 설계
- **`loadAndVerifyMutateAccess` (owner|member|admin)** — 4 update flow (수정/마감/재오픈/정산설정) 가 사용. RLS jp_update_workspace_member 와 일치.
- **`loadAndVerifyDeleteAccess` (owner|admin only, member 차단)** — delete flow. RLS jp_delete_workspace_owner 의 의도(workspace 소유자 OR admin) 를 client 에서는 job posting owner OR admin 으로 근사.
- **5 callsite** 가 `.eq('owner_id', ownerId)` 추가 필터링 했던 것 제거 → RLS 단일 진실. helper 가 client gate 를 책임지므로 owner_id 필터 중복 불필요.

## 권한 매트릭스 (RLS 미러)

| flow | owner | member | admin | outsider |
|------|-------|--------|-------|----------|
| updateWith | OK | OK ✨ | OK ✨ | reject |
| closeWith | OK | OK ✨ | OK ✨ | reject |
| reopenWith | OK | OK ✨ | OK ✨ | reject |
| updateSettlement | OK | OK ✨ | OK ✨ | reject |
| deleteWith | OK | reject | OK ✨ | reject |

✨ = Phase 2A.후속 신규 통과 (이전엔 owner-only 만)

## 알려진 갭 (Out of scope)
- delete 가 UPDATE status=cancelled (soft-delete) 를 쓰므로 RLS 는 jp_update_workspace_member 평가 → API 직접 호출 시 member 가 우회 가능. **DB-level enforcement** 는 별도 status 전이 trigger/함수로 강화 필요 (별도 PR).
- `bulkUpdateStatus` 는 여전히 owner_id 필터 — bulk 의 cross-owner 영향 범위가 넓어 별도 검토 필요.

## Test plan
- [x] 신규 14 테스트 PASS (mutate access 7 + delete access 4 + owner_id 회귀 가드 3)
- [x] jest 4015 total / 3 fail — master baseline 동일 (scheduleService + submission)
- [x] 기존 `JobPostingRepository.update.regression.test.ts` 회귀 0건
- [ ] 사용자 dogfooding:
  - [ ] review-employer 워크스페이스 멤버 (editor) 가 공고 수정/마감/재오픈/정산설정 가능
  - [ ] editor 가 공고 삭제 시도 → "공고 소유자만 삭제할 수 있습니다" 에러 표시
  - [ ] admin 이 다른 owner 공고 수정/삭제 가능

## Related
- PR #71: 4 layer + 클라이언트 active workspace 필터 (Phase 2A.후속 시작)
- PR #72: rename + DRY (정합성 cleanup)
- 본 PR: write-side 동일 분기 적용 (Phase 2A.후속 종결)

🤖 Generated with [Claude Code](https://claude.com/claude-code)