### PR TITLE
fix(workspace): service-layer owner-only 가드 workspace member 호환 — Phase 2A.후속 P0 hotfix

### DIFF
--- a/uniqn-mobile/src/services/jobs/__tests__/applicantManagementService.test.ts
+++ b/uniqn-mobile/src/services/jobs/__tests__/applicantManagementService.test.ts
@@ -9,6 +9,7 @@ import type {
   Application,
   ApplicationStats,
   ConfirmApplicationInput,
+  JobPosting,
   RejectApplicationInput,
   StaffRole,
 } from '@/types';
@@ -26,6 +27,7 @@ import {
   subscribeToApplicants,
   subscribeToApplicantsAsync,
 } from '@/services/jobs/applicantManagementService';
+import { PermissionError, ERROR_CODES } from '@/errors';
 
 // ============================================================================
 // Mock Setup (호이스팅을 위해 파일 최상단에 배치)
@@ -38,6 +40,7 @@ const mockMarkAsRead = jest.fn();
 const mockSubscribeByJobPosting = jest.fn();
 const mockVerifyOwnership = jest.fn();
 const mockRealtimeSubscribe = jest.fn();
+const mockLoadAndVerifyJobPostingAccess = jest.fn();
 
 jest.mock('@/repositories', () => ({
   applicationRepository: {
@@ -50,6 +53,10 @@ jest.mock('@/repositories', () => ({
   jobPostingRepository: {
     verifyOwnership: (...args: unknown[]) => mockVerifyOwnership(...args),
   },
+}));
+
+jest.mock('@/repositories/supabase/ApplicationRepositoryHelpers', () => ({
+  loadAndVerifyJobPostingAccess: (...args: unknown[]) => mockLoadAndVerifyJobPostingAccess(...args),
 }));
 
 const mockConfirmApplicationWithHistory = jest.fn();
@@ -917,8 +924,15 @@ describe('applicantManagementService', () => {
   // ==========================================================================
 
   describe('subscribeToApplicantsAsync', () => {
-    it('권한 확인 후 구독을 시작해야 함', async () => {
-      mockVerifyOwnership.mockResolvedValue(true);
+    const fakeJobPosting = {
+      id: 'job-1',
+      ownerId: 'employer-1',
+      workspaceId: 'ws-1',
+      title: '테스트 공고',
+    } as unknown as JobPosting;
+
+    it('owner 본인 호출 시 권한 통과 후 구독을 시작해야 함', async () => {
+      mockLoadAndVerifyJobPostingAccess.mockResolvedValue(fakeJobPosting);
 
       const mockUnsubscribe = jest.fn();
       mockSubscribeByJobPosting.mockReturnValue(mockUnsubscribe);
@@ -930,7 +944,11 @@ describe('applicantManagementService', () => {
 
       const unsubscribe = await subscribeToApplicantsAsync('job-1', 'employer-1', callbacks);
 
-      expect(mockVerifyOwnership).toHaveBeenCalledWith('job-1', 'employer-1');
+      expect(mockLoadAndVerifyJobPostingAccess).toHaveBeenCalledWith(
+        'job-1',
+        'employer-1',
+        '지원자 구독'
+      );
       expect(mockSubscribeByJobPosting).toHaveBeenCalledWith(
         'job-1',
         'employer-1',
@@ -940,8 +958,52 @@ describe('applicantManagementService', () => {
       expect(typeof unsubscribe).toBe('function');
     });
 
-    it('권한이 없으면 에러를 호출하고 빈 unsubscribe를 반환해야 함', async () => {
-      mockVerifyOwnership.mockResolvedValue(false);
+    it('워크스페이스 멤버 호출 시 통과 (helper 가 통과하면 구독 시작)', async () => {
+      mockLoadAndVerifyJobPostingAccess.mockResolvedValue(fakeJobPosting);
+
+      const mockUnsubscribe = jest.fn();
+      mockSubscribeByJobPosting.mockReturnValue(mockUnsubscribe);
+
+      const callbacks = {
+        onUpdate: jest.fn(),
+        onError: jest.fn(),
+      };
+
+      // 호출자는 owner 가 아닌 워크스페이스 멤버 (helper 가 통과 처리)
+      const unsubscribe = await subscribeToApplicantsAsync('job-1', 'member-uid', callbacks);
+
+      expect(mockLoadAndVerifyJobPostingAccess).toHaveBeenCalledWith(
+        'job-1',
+        'member-uid',
+        '지원자 구독'
+      );
+      expect(mockSubscribeByJobPosting).toHaveBeenCalled();
+      expect(typeof unsubscribe).toBe('function');
+    });
+
+    it('admin 호출 시 통과 (helper 가 통과하면 구독 시작)', async () => {
+      mockLoadAndVerifyJobPostingAccess.mockResolvedValue(fakeJobPosting);
+
+      const mockUnsubscribe = jest.fn();
+      mockSubscribeByJobPosting.mockReturnValue(mockUnsubscribe);
+
+      const callbacks = {
+        onUpdate: jest.fn(),
+        onError: jest.fn(),
+      };
+
+      const unsubscribe = await subscribeToApplicantsAsync('job-1', 'admin-uid', callbacks);
+
+      expect(mockLoadAndVerifyJobPostingAccess).toHaveBeenCalled();
+      expect(mockSubscribeByJobPosting).toHaveBeenCalled();
+      expect(typeof unsubscribe).toBe('function');
+    });
+
+    it('외부인 호출 시 PermissionError 를 onError 로 호출하고 빈 unsubscribe 반환', async () => {
+      const permissionError = new PermissionError(ERROR_CODES.INFRA_PERMISSION_DENIED, {
+        userMessage: '워크스페이스 멤버만 관리할 수 있습니다: 지원자 구독',
+      });
+      mockLoadAndVerifyJobPostingAccess.mockRejectedValue(permissionError);
 
       const onError = jest.fn();
       const callbacks = {
@@ -949,7 +1011,7 @@ describe('applicantManagementService', () => {
         onError,
       };
 
-      const unsubscribe = await subscribeToApplicantsAsync('job-1', 'employer-1', callbacks);
+      const unsubscribe = await subscribeToApplicantsAsync('job-1', 'stranger-uid', callbacks);
 
       expect(onError).toHaveBeenCalledWith(expect.objectContaining({ name: 'PermissionError' }));
       expect(mockSubscribeByJobPosting).not.toHaveBeenCalled();
@@ -959,17 +1021,39 @@ describe('applicantManagementService', () => {
       expect(() => unsubscribe()).not.toThrow();
     });
 
-    it('onError 콜백이 없어도 동작해야 함', async () => {
-      mockVerifyOwnership.mockResolvedValue(false);
+    it('onError 콜백이 없어도 권한 거절 시 빈 unsubscribe 반환', async () => {
+      const permissionError = new PermissionError(ERROR_CODES.INFRA_PERMISSION_DENIED, {
+        userMessage: '워크스페이스 멤버만 관리할 수 있습니다: 지원자 구독',
+      });
+      mockLoadAndVerifyJobPostingAccess.mockRejectedValue(permissionError);
 
       const callbacks = {
         onUpdate: jest.fn(),
       };
 
-      const unsubscribe = await subscribeToApplicantsAsync('job-1', 'employer-1', callbacks);
+      const unsubscribe = await subscribeToApplicantsAsync('job-1', 'stranger-uid', callbacks);
 
       expect(mockSubscribeByJobPosting).not.toHaveBeenCalled();
       expect(typeof unsubscribe).toBe('function');
+    });
+
+    it('PermissionError 가 아닌 에러는 propagate (onError 로 위임 안 함)', async () => {
+      // helper 내부 supabase RPC 에러 등은 callbacks.onError 가 아니라 throw 로 전달
+      const otherError = new Error('네트워크 에러');
+      mockLoadAndVerifyJobPostingAccess.mockRejectedValue(otherError);
+
+      const onError = jest.fn();
+      const callbacks = {
+        onUpdate: jest.fn(),
+        onError,
+      };
+
+      await expect(subscribeToApplicantsAsync('job-1', 'employer-1', callbacks)).rejects.toThrow(
+        '네트워크 에러'
+      );
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(mockSubscribeByJobPosting).not.toHaveBeenCalled();
     });
   });
 });

--- a/uniqn-mobile/src/services/jobs/applicantManagementService.ts
+++ b/uniqn-mobile/src/services/jobs/applicantManagementService.ts
@@ -9,6 +9,7 @@ import { STATUS_TO_STATS_KEY } from '@/constants/statusConfig';
 import { BusinessError, ERROR_CODES, isAppError, PermissionError, ValidationError } from '@/errors';
 import { handleServiceError } from '@/errors/serviceErrorHandler';
 import { applicationRepository, jobPostingRepository } from '@/repositories';
+import { loadAndVerifyJobPostingAccess } from '@/repositories/supabase/ApplicationRepositoryHelpers';
 import { rejectApplicationSchema } from '@/schemas';
 import { RealtimeManager } from '@/shared/realtime';
 import type {
@@ -356,17 +357,17 @@ export async function subscribeToApplicantsAsync(
   ownerId: string,
   callbacks: SubscribeToApplicantsCallbacks
 ): Promise<UnsubscribeFn> {
-  const isOwner = await verifyJobPostingOwnership(jobPostingId, ownerId);
-
-  if (!isOwner) {
-    const error = new PermissionError(ERROR_CODES.INFRA_PERMISSION_DENIED, {
-      userMessage: '해당 공고의 소유자가 아닙니다.',
-    });
-
-    logger.warn('구독 전 권한 검증 실패', { jobPostingId, ownerId });
-    callbacks.onError?.(error);
-
-    return () => undefined;
+  // Phase 2A.후속 P0 hotfix (2026-05-10) — owner-only 가드 → owner|member|admin.
+  // PR #71 의 `loadAndVerifyJobPostingAccess` (read-side helper) 와 동일 시맨틱.
+  try {
+    await loadAndVerifyJobPostingAccess(jobPostingId, ownerId, '지원자 구독');
+  } catch (error) {
+    if (error instanceof PermissionError) {
+      logger.warn('구독 전 권한 검증 실패', { jobPostingId, ownerId });
+      callbacks.onError?.(error);
+      return () => undefined;
+    }
+    throw error;
   }
 
   logger.info('구독 전 권한 검증 통과, 지원자 구독 시작', { jobPostingId, ownerId });

--- a/uniqn-mobile/src/services/work/__tests__/settlementService.test.ts
+++ b/uniqn-mobile/src/services/work/__tests__/settlementService.test.ts
@@ -35,6 +35,7 @@ const mockSettleWorkLogWithTransaction = jest.fn();
 const mockBulkSettlementWithTransaction = jest.fn();
 const mockUpdatePayrollStatusWithTransaction = jest.fn();
 const mockUpdateWorkTimeWithTransaction = jest.fn();
+const mockLoadAndVerifyJobPostingAccess = jest.fn();
 
 jest.mock('@/repositories', () => ({
   jobPostingRepository: {
@@ -54,6 +55,13 @@ jest.mock('@/repositories', () => ({
     updateWorkTimeWithTransaction: (...args: unknown[]) =>
       mockUpdateWorkTimeWithTransaction(...args),
   },
+}));
+
+// P0 hotfix (PR #76) 후속: settlementQuery 가 ApplicationRepositoryHelpers 사용.
+// 기존 테스트는 mockJobPostingGetById + ownerId 비교 패턴으로 작성됐으므로
+// loadAndVerifyJobPostingAccess mock 이 그 동작을 mirror 하도록 shim.
+jest.mock('@/repositories/supabase/ApplicationRepositoryHelpers', () => ({
+  loadAndVerifyJobPostingAccess: (...args: unknown[]) => mockLoadAndVerifyJobPostingAccess(...args),
 }));
 
 // ============================================================================
@@ -166,6 +174,16 @@ jest.mock('@/constants', () => ({
     PAYROLL: {
       PENDING: 'pending',
       PROCESSING: 'processing',
+      COMPLETED: 'completed',
+    },
+    // P0 hotfix (PR #76) 후속: settlementQuery.ts → ApplicationRepositoryHelpers.ts 가
+    // STATUS.APPLICATION 의존 → transitive import 시 mock 누락으로 TypeError 회귀.
+    APPLICATION: {
+      APPLIED: 'applied',
+      CONFIRMED: 'confirmed',
+      CANCELLED: 'cancelled',
+      CANCELLATION_PENDING: 'cancellation_pending',
+      REJECTED: 'rejected',
       COMPLETED: 'completed',
     },
   },
@@ -360,6 +378,31 @@ describe('settlementService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     resetCounters();
+
+    // P0 hotfix (PR #76) shim — loadAndVerifyJobPostingAccess 가
+    // 기존 mockJobPostingGetById 흐름과 동일 시맨틱으로 동작하도록.
+    // 4 시나리오 (owner / member / admin / 외부인) 의 owner-only 경로 만 mirror —
+    // 기존 테스트가 owner 시나리오만 검증하므로 충분.
+    mockLoadAndVerifyJobPostingAccess.mockImplementation(
+      async (jobPostingId: string, callerId: string, _operation: string) => {
+        const result = await mockJobPostingGetById(jobPostingId);
+        if (!result) {
+          // BusinessError mock 재사용 (jest.mock '@/errors' factory 결과)
+          // userMessage 는 OLD 코드 ('존재하지 않는 공고입니다') 로 통일하여 회귀 테스트 보존
+          const { BusinessError, ERROR_CODES } = jest.requireMock('@/errors');
+          throw new BusinessError(ERROR_CODES.INFRA_NOT_FOUND, {
+            userMessage: '존재하지 않는 공고입니다',
+          });
+        }
+        if (result.ownerId !== callerId) {
+          const { PermissionError, ERROR_CODES } = jest.requireMock('@/errors');
+          throw new PermissionError(ERROR_CODES.INFRA_PERMISSION_DENIED, {
+            userMessage: '본인의 공고만 조회할 수 있습니다',
+          });
+        }
+        return result;
+      }
+    );
   });
 
   // ==========================================================================

--- a/uniqn-mobile/src/services/work/settlement/__tests__/settlementQuery.workspace.test.ts
+++ b/uniqn-mobile/src/services/work/settlement/__tests__/settlementQuery.workspace.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Phase 2A.후속 P0 hotfix (2026-05-10)
+ *
+ * settlementQuery 의 owner-only 가드를 loadAndVerifyJobPostingAccess (owner|member|admin) 로
+ * 교체. 4 역할 시나리오 + not-found / non-permission 에러 propagation 검증.
+ */
+
+import type { JobPosting, WorkLog } from '@/types';
+
+// Import after mocks
+import {
+  getWorkLogsByJobPosting,
+  getJobPostingSettlementSummary,
+} from '@/services/work/settlement/settlementQuery';
+import { PermissionError, BusinessError, ERROR_CODES } from '@/errors';
+
+// ============================================================================
+// Mock Setup (호이스팅)
+// ============================================================================
+
+const mockLoadAndVerifyJobPostingAccess = jest.fn();
+const mockGetByJobPostingId = jest.fn();
+const mockGetPostingSettlementContext = jest.fn();
+
+jest.mock('@/repositories/supabase/ApplicationRepositoryHelpers', () => ({
+  loadAndVerifyJobPostingAccess: (...args: unknown[]) => mockLoadAndVerifyJobPostingAccess(...args),
+}));
+
+jest.mock('@/repositories', () => ({
+  workLogRepository: {
+    getByJobPostingId: (...args: unknown[]) => mockGetByJobPostingId(...args),
+  },
+  jobPostingRepository: {
+    getManagedJobPostings: jest.fn(),
+  },
+}));
+
+jest.mock('@/domains/job-posting', () => ({
+  getPostingSettlementContext: (...args: unknown[]) => mockGetPostingSettlementContext(...args),
+}));
+
+jest.mock('@/utils/jobPostingVisibility', () => ({
+  isCanonicalDatedPosting: jest.fn(() => true),
+}));
+
+jest.mock('@/utils/settlement', () => ({
+  getEffectiveSalaryInfoFromRoles: jest.fn(() => ({ type: 'hourly', rate: 10000 })),
+  getEffectiveAllowances: jest.fn(() => []),
+  getEffectiveTaxSettings: jest.fn(() => ({ rate: 0 })),
+}));
+
+jest.mock('@/domains/settlement', () => ({
+  SettlementCalculator: {
+    calculate: jest.fn(() => ({ hoursWorked: 8, afterTaxPay: 80000 })),
+  },
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('@/errors/serviceErrorHandler', () => ({
+  handleServiceError: jest.fn((error: unknown) => {
+    if (error instanceof Error) return error;
+    return new Error(String(error));
+  }),
+}));
+
+jest.mock('@/errors', () => {
+  class BusinessError extends Error {
+    public userMessage: string;
+    public code: string;
+    constructor(code: string, options?: { userMessage?: string }) {
+      super(options?.userMessage || code);
+      this.name = 'BusinessError';
+      this.code = code;
+      this.userMessage = options?.userMessage || code;
+    }
+  }
+  class PermissionError extends Error {
+    public userMessage: string;
+    public code: string;
+    constructor(code: string, options?: { userMessage?: string }) {
+      super(options?.userMessage || code);
+      this.name = 'PermissionError';
+      this.code = code;
+      this.userMessage = options?.userMessage || code;
+    }
+  }
+  return {
+    BusinessError,
+    PermissionError,
+    ERROR_CODES: {
+      INFRA_NOT_FOUND: 'E4002',
+      INFRA_PERMISSION_DENIED: 'E4001',
+      BUSINESS_INVALID_STATE: 'E6002',
+    },
+  };
+});
+
+jest.mock('@/constants', () => ({
+  STATUS: {
+    WORK_LOG: {
+      CANCELLED: 'cancelled',
+      CHECKED_OUT: 'checked_out',
+      COMPLETED: 'completed',
+    },
+    PAYROLL: {
+      COMPLETED: 'completed',
+    },
+  },
+}));
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const fakeJobPosting = {
+  id: 'jp-1',
+  ownerId: 'owner-uid',
+  workspaceId: 'ws-1',
+  title: '테스트 공고',
+  status: 'active',
+} as unknown as JobPosting;
+
+const emptySettlementContext = {
+  roles: [],
+  defaultSalary: { type: 'hourly', rate: 10000 },
+  allowances: [],
+  taxSettings: { rate: 0 },
+};
+
+// ============================================================================
+// Tests — getWorkLogsByJobPosting
+// ============================================================================
+
+describe('getWorkLogsByJobPosting — 4 역할 권한 호환', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetByJobPostingId.mockResolvedValue([]);
+    mockGetPostingSettlementContext.mockReturnValue(emptySettlementContext);
+  });
+
+  it('owner 본인 호출 시 통과 (helper 가 posting 반환)', async () => {
+    mockLoadAndVerifyJobPostingAccess.mockResolvedValue(fakeJobPosting);
+
+    const result = await getWorkLogsByJobPosting('jp-1', 'owner-uid');
+
+    expect(mockLoadAndVerifyJobPostingAccess).toHaveBeenCalledWith(
+      'jp-1',
+      'owner-uid',
+      '공고별 근무 기록 조회'
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('워크스페이스 멤버 호출 시 통과 (Phase 2A.후속 호환)', async () => {
+    // helper 가 멤버 통과시 posting 반환
+    mockLoadAndVerifyJobPostingAccess.mockResolvedValue(fakeJobPosting);
+
+    const result = await getWorkLogsByJobPosting('jp-1', 'member-uid');
+
+    expect(mockLoadAndVerifyJobPostingAccess).toHaveBeenCalledWith(
+      'jp-1',
+      'member-uid',
+      '공고별 근무 기록 조회'
+    );
+    expect(mockGetByJobPostingId).toHaveBeenCalledWith('jp-1');
+    expect(result).toEqual([]);
+  });
+
+  it('admin 호출 시 통과', async () => {
+    mockLoadAndVerifyJobPostingAccess.mockResolvedValue(fakeJobPosting);
+
+    const result = await getWorkLogsByJobPosting('jp-1', 'admin-uid');
+
+    expect(mockLoadAndVerifyJobPostingAccess).toHaveBeenCalledWith(
+      'jp-1',
+      'admin-uid',
+      '공고별 근무 기록 조회'
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('외부인 호출 시 PermissionError propagate', async () => {
+    const permissionError = new PermissionError(ERROR_CODES.INFRA_PERMISSION_DENIED, {
+      userMessage: '워크스페이스 멤버만 관리할 수 있습니다: 공고별 근무 기록 조회',
+    });
+    mockLoadAndVerifyJobPostingAccess.mockRejectedValue(permissionError);
+
+    await expect(getWorkLogsByJobPosting('jp-1', 'stranger-uid')).rejects.toThrow(PermissionError);
+
+    expect(mockGetByJobPostingId).not.toHaveBeenCalled();
+  });
+
+  it('존재하지 않는 공고 호출 시 BusinessError(NOT_FOUND) propagate', async () => {
+    const notFoundError = new BusinessError(ERROR_CODES.INFRA_NOT_FOUND, {
+      userMessage: '공고를 찾을 수 없습니다.',
+    });
+    mockLoadAndVerifyJobPostingAccess.mockRejectedValue(notFoundError);
+
+    await expect(getWorkLogsByJobPosting('non-existent', 'owner-uid')).rejects.toThrow(
+      BusinessError
+    );
+
+    expect(mockGetByJobPostingId).not.toHaveBeenCalled();
+  });
+
+  it('필터 적용 (workspace member 가 dateRange 필터로 조회)', async () => {
+    mockLoadAndVerifyJobPostingAccess.mockResolvedValue(fakeJobPosting);
+    mockGetByJobPostingId.mockResolvedValue([
+      {
+        id: 'wl-1',
+        date: '2026-05-10',
+        status: 'checked_out',
+        role: 'dealer',
+        checkInTime: '2026-05-10T10:00:00Z',
+        checkOutTime: '2026-05-10T18:00:00Z',
+      } as unknown as WorkLog,
+    ]);
+
+    const result = await getWorkLogsByJobPosting('jp-1', 'member-uid', {
+      dateRange: { start: '2026-05-01', end: '2026-05-31' },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('wl-1');
+  });
+});
+
+// ============================================================================
+// Tests — getJobPostingSettlementSummary
+// ============================================================================
+
+describe('getJobPostingSettlementSummary — 4 역할 권한 호환', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetByJobPostingId.mockResolvedValue([]);
+    mockGetPostingSettlementContext.mockReturnValue(emptySettlementContext);
+  });
+
+  it('owner 본인 호출 시 통과', async () => {
+    mockLoadAndVerifyJobPostingAccess.mockResolvedValue(fakeJobPosting);
+
+    const summary = await getJobPostingSettlementSummary('jp-1', 'owner-uid');
+
+    expect(mockLoadAndVerifyJobPostingAccess).toHaveBeenCalledWith(
+      'jp-1',
+      'owner-uid',
+      '공고별 정산 요약 조회'
+    );
+    expect(summary.jobPostingId).toBe('jp-1');
+    expect(summary.totalWorkLogs).toBe(0);
+  });
+
+  it('워크스페이스 멤버 호출 시 통과', async () => {
+    mockLoadAndVerifyJobPostingAccess.mockResolvedValue(fakeJobPosting);
+
+    const summary = await getJobPostingSettlementSummary('jp-1', 'member-uid');
+
+    expect(mockLoadAndVerifyJobPostingAccess).toHaveBeenCalledWith(
+      'jp-1',
+      'member-uid',
+      '공고별 정산 요약 조회'
+    );
+    expect(summary.jobPostingTitle).toBe('테스트 공고');
+  });
+
+  it('admin 호출 시 통과', async () => {
+    mockLoadAndVerifyJobPostingAccess.mockResolvedValue(fakeJobPosting);
+
+    const summary = await getJobPostingSettlementSummary('jp-1', 'admin-uid');
+
+    expect(mockLoadAndVerifyJobPostingAccess).toHaveBeenCalledWith(
+      'jp-1',
+      'admin-uid',
+      '공고별 정산 요약 조회'
+    );
+    expect(summary).toBeDefined();
+  });
+
+  it('외부인 호출 시 PermissionError propagate', async () => {
+    const permissionError = new PermissionError(ERROR_CODES.INFRA_PERMISSION_DENIED, {
+      userMessage: '워크스페이스 멤버만 관리할 수 있습니다: 공고별 정산 요약 조회',
+    });
+    mockLoadAndVerifyJobPostingAccess.mockRejectedValue(permissionError);
+
+    await expect(getJobPostingSettlementSummary('jp-1', 'stranger-uid')).rejects.toThrow(
+      PermissionError
+    );
+
+    expect(mockGetByJobPostingId).not.toHaveBeenCalled();
+  });
+
+  it('존재하지 않는 공고 호출 시 BusinessError(NOT_FOUND) propagate', async () => {
+    const notFoundError = new BusinessError(ERROR_CODES.INFRA_NOT_FOUND, {
+      userMessage: '공고를 찾을 수 없습니다.',
+    });
+    mockLoadAndVerifyJobPostingAccess.mockRejectedValue(notFoundError);
+
+    await expect(getJobPostingSettlementSummary('non-existent', 'owner-uid')).rejects.toThrow(
+      BusinessError
+    );
+
+    expect(mockGetByJobPostingId).not.toHaveBeenCalled();
+  });
+});

--- a/uniqn-mobile/src/services/work/settlement/settlementQuery.ts
+++ b/uniqn-mobile/src/services/work/settlement/settlementQuery.ts
@@ -11,7 +11,6 @@
 import { getPostingSettlementContext } from '@/domains/job-posting';
 import { logger } from '@/utils/logger';
 import { isCanonicalDatedPosting } from '@/utils/jobPostingVisibility';
-import { BusinessError, PermissionError, ERROR_CODES } from '@/errors';
 import { handleServiceError } from '@/errors/serviceErrorHandler';
 import { SettlementCalculator } from '@/domains/settlement';
 import {
@@ -20,6 +19,7 @@ import {
   getEffectiveTaxSettings,
 } from '@/utils/settlement';
 import { jobPostingRepository, workLogRepository } from '@/repositories';
+import { loadAndVerifyJobPostingAccess } from '@/repositories/supabase/ApplicationRepositoryHelpers';
 import { STATUS } from '@/constants';
 import type { WorkLog } from '@/types';
 import {
@@ -50,20 +50,12 @@ export async function getWorkLogsByJobPosting(
   try {
     logger.info('공고별 근무 기록 조회', { jobPostingId, ownerId, filters });
 
-    // 1. 공고 소유권 확인 (Repository 사용)
-    const jobPosting = await jobPostingRepository.getById(jobPostingId);
-
-    if (!jobPosting) {
-      throw new BusinessError(ERROR_CODES.INFRA_NOT_FOUND, {
-        userMessage: '존재하지 않는 공고입니다',
-      });
-    }
-
-    if (jobPosting.ownerId !== ownerId) {
-      throw new PermissionError(ERROR_CODES.INFRA_PERMISSION_DENIED, {
-        userMessage: '본인의 공고만 조회할 수 있습니다',
-      });
-    }
+    // 1. 공고 로드 + 관리 권한 확인 (owner|member|admin) — Phase 2A.후속 P0 hotfix (2026-05-10)
+    const jobPosting = await loadAndVerifyJobPostingAccess(
+      jobPostingId,
+      ownerId,
+      '공고별 근무 기록 조회'
+    );
 
     // 2. 근무 기록 조회 (Repository 사용)
     const parsedWorkLogs = (await workLogRepository.getByJobPostingId(jobPostingId)).filter(
@@ -152,20 +144,12 @@ export async function getJobPostingSettlementSummary(
   try {
     logger.info('공고별 정산 요약 조회', { jobPostingId, ownerId });
 
-    // 1. 공고 조회 및 소유권 확인 (Repository 사용)
-    const jobPosting = await jobPostingRepository.getById(jobPostingId);
-
-    if (!jobPosting) {
-      throw new BusinessError(ERROR_CODES.INFRA_NOT_FOUND, {
-        userMessage: '존재하지 않는 공고입니다',
-      });
-    }
-
-    if (jobPosting.ownerId !== ownerId) {
-      throw new PermissionError(ERROR_CODES.INFRA_PERMISSION_DENIED, {
-        userMessage: '본인의 공고만 조회할 수 있습니다',
-      });
-    }
+    // 1. 공고 로드 + 관리 권한 확인 (owner|member|admin) — Phase 2A.후속 P0 hotfix (2026-05-10)
+    const jobPosting = await loadAndVerifyJobPostingAccess(
+      jobPostingId,
+      ownerId,
+      '공고별 정산 요약 조회'
+    );
 
     // 2. 근무 기록 조회 (Repository 사용)
     const workLogs = (await workLogRepository.getByJobPostingId(jobPostingId)).filter(


### PR DESCRIPTION
## Summary

- PR #71/#73 가 Repository helper / write-side mutation 가드는 owner|member|admin 으로 풀었으나 service layer read-side 잔류 가드 3 곳이 owner-only 인 채로 남아 워크스페이스 멤버가 자기 멤버십 공고 진입 시 PermissionError 차단되는 회귀 hotfix.
- 3 위치 모두 PR #71 의 \`loadAndVerifyJobPostingAccess\` (read-side helper) 패턴으로 통일.
- 합산 17 신규 시나리오 + 기존 회귀 0건 (66/66 PASS), typecheck/lint clean.

## 증상

dogfooding 중 콘솔 로그:
\`\`\`
PermissionError: 해당 공고의 소유자가 아닙니다 — applicantManagementService.subscribeToApplicantsAsync:366
PermissionError: 본인의 공고만 조회할 수 있습니다 — settlementQuery.getWorkLogsByJobPosting + getJobPostingSettlementSummary
\`\`\`
시나리오: review-employer (\`b2222222\`) 가 \`c3333333\` 소유 공고에 워크스페이스 멤버 자격으로 진입 → RLS 통과 → service 가드 거절.

## Changes

| 파일 | Before | After |
|------|--------|-------|
| \`applicantManagementService.subscribeToApplicantsAsync\` | \`verifyJobPostingOwnership\` (boolean owner-only) | \`loadAndVerifyJobPostingAccess\` (throw, owner\|member\|admin). PermissionError 만 \`callbacks.onError\` 로 위임, 타 에러 propagate |
| \`settlementQuery.getWorkLogsByJobPosting\` | \`jobPostingRepository.getById\` + manual ownerId 비교 + 2 throw | helper 단일 호출 |
| \`settlementQuery.getJobPostingSettlementSummary\` | 동일 | 동일 |

\`loadJobPosting\` (helper 내부 호출) 가 not-found 시 BusinessError(INFRA_NOT_FOUND) throw 보장 — 시맨틱 동일.

## Test plan

- [x] \`npx jest src/services/jobs/__tests__/applicantManagementService src/services/work/settlement/__tests__\` → 3 suites, 66 tests PASS
- [x] \`npx tsc --noEmit\` → 0 에러
- [x] \`npx eslint\` → 0 에러
- [ ] dogfooding (사용자): review-employer / review-admin 으로 멤버십 공고 진입 → 정산 탭 / 지원자 탭 정상 작동
- [ ] dogfooding 회귀: 외부 staff 계정으로 타인 공고 service 호출 → PermissionError 유지

## 신규 테스트 시나리오

**applicantManagementService.subscribeToApplicantsAsync** (6 신규):
- owner / workspace member / admin 호출 시 helper 통과 후 구독 시작
- 외부인 호출 시 PermissionError 를 \`callbacks.onError\` 로 위임 + 빈 unsubscribe 반환
- onError 콜백 없는 경우 동작 보장
- non-permission 에러 (네트워크 등) 는 propagate (onError 위임 안 함)

**settlementQuery.workspace.test.ts 신규** (11 신규):
- 두 함수 각각 4 역할 (owner / member / admin / 외부인) + not-found
- workspace member 가 dateRange 필터로 조회

## 영향 범위

- service layer 내 owner-only 가드 잔류 — 본 PR 로 read-side 0 위치, write-side 0 위치 (PR #73 완료) 가 됩니다.
- 후속 (P1): \`useMonthlyPayroll\` / \`useSettlementDashboard\` / schedule dual-mode hook 의 query workspace 필터 추가 (별도 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)