### PR TITLE
feat(workspace): useSettlementDashboard workspace 별 분리 — Phase 2A.후속 PR3-C

### DIFF
--- a/uniqn-mobile/src/__tests__/hooks/useSettlement.test.ts
+++ b/uniqn-mobile/src/__tests__/hooks/useSettlement.test.ts
@@ -28,6 +28,12 @@ import {
   useSettlement,
   useSettlementDashboard,
 } from '@/hooks/useSettlement';
+import { useActiveWorkspace } from '@/hooks/workspace/useActiveWorkspace';
+
+jest.mock('@/hooks/workspace/useActiveWorkspace', () => ({
+  useActiveWorkspace: jest.fn(),
+}));
+const mockUseActiveWorkspace = useActiveWorkspace as jest.MockedFunction<typeof useActiveWorkspace>;
 
 // createMockJobPosting is available for future tests
 // NOTE: Dynamic imports removed due to Jest compatibility issues
@@ -313,6 +319,17 @@ describe('useSettlement Hooks', () => {
     mockIsPending = false;
     mockData = undefined;
     mockError = null;
+    mockUseActiveWorkspace.mockReturnValue({
+      activeWorkspace: {
+        id: 'ws-default',
+        name: 'Default',
+        ownerId: 'employer-1',
+        memberCount: 1,
+      } as any,
+      workspaces: [],
+      isLoading: false,
+      setActiveWorkspaceId: jest.fn(),
+    });
   });
 
   // ==========================================================================
@@ -771,7 +788,7 @@ describe('useSettlement Hooks', () => {
       expect(result.current.data).toEqual(mockSummary);
     });
 
-    it('should scope my settlement summary query by user and date range', () => {
+    it('should scope my settlement summary query by user, date range, and active workspace', () => {
       const { useQuery } = jest.requireMock('@tanstack/react-query') as { useQuery: jest.Mock };
 
       renderHook(() =>
@@ -791,6 +808,7 @@ describe('useSettlement Hooks', () => {
           end: '2024-01-31',
           start: '2024-01-01',
         },
+        'ws-default',
       ]);
     });
 
@@ -802,6 +820,76 @@ describe('useSettlement Hooks', () => {
 
       expect(result.current.data).toBeUndefined();
       expect(result.current.isLoading).toBe(false);
+    });
+
+    // ========================================================================
+    // Phase 2A.후속 PR3-C — workspace 별 분리 contract 테스트
+    // ========================================================================
+
+    it('Phase 2A.후속 PR3-C — activeWorkspace 가 없으면 enabled 가 false 다', () => {
+      mockUseActiveWorkspace.mockReturnValue({
+        activeWorkspace: undefined,
+        workspaces: [],
+        isLoading: false,
+        setActiveWorkspaceId: jest.fn(),
+      });
+
+      renderHook(() => useMySettlementSummary());
+
+      const { useQuery } = jest.requireMock('@tanstack/react-query') as {
+        useQuery: jest.Mock;
+      };
+
+      expect(useQuery.mock.calls.at(-1)?.[0]?.enabled).toBe(false);
+    });
+
+    it('Phase 2A.후속 PR3-C — activeWorkspace.id 가 query key 에 포함된다', () => {
+      mockUseActiveWorkspace.mockReturnValue({
+        activeWorkspace: { id: 'ws-abc', name: 'Test', ownerId: 'u1', memberCount: 1 } as any,
+        workspaces: [],
+        isLoading: false,
+        setActiveWorkspaceId: jest.fn(),
+      });
+
+      renderHook(() => useMySettlementSummary());
+
+      const { useQuery } = jest.requireMock('@tanstack/react-query') as {
+        useQuery: jest.Mock;
+      };
+
+      expect(useQuery.mock.calls.at(-1)?.[0]?.queryKey).toEqual(
+        expect.arrayContaining(['mySummary', 'ws-abc'])
+      );
+    });
+
+    it('Phase 2A.후속 PR3-C — getMySettlementSummary 호출 시 workspaceId 가 3번째 인자로 전달된다', async () => {
+      mockUseActiveWorkspace.mockReturnValue({
+        activeWorkspace: { id: 'ws-abc', name: 'Test', ownerId: 'u1', memberCount: 1 } as any,
+        workspaces: [],
+        isLoading: false,
+        setActiveWorkspaceId: jest.fn(),
+      });
+      mockGetMySettlementSummary.mockResolvedValue({
+        totalJobPostings: 0,
+        totalWorkLogs: 0,
+        totalPendingAmount: 0,
+        totalCompletedAmount: 0,
+        summariesByJobPosting: [],
+      });
+
+      renderHook(() => useMySettlementSummary({ start: '2024-01-01', end: '2024-01-31' }));
+
+      const { useQuery } = jest.requireMock('@tanstack/react-query') as {
+        useQuery: jest.Mock;
+      };
+
+      await useQuery.mock.calls.at(-1)?.[0]?.queryFn();
+
+      expect(mockGetMySettlementSummary).toHaveBeenCalledWith(
+        'employer-1',
+        { start: '2024-01-01', end: '2024-01-31' },
+        'ws-abc'
+      );
     });
   });
 

--- a/uniqn-mobile/src/hooks/useSettlement.ts
+++ b/uniqn-mobile/src/hooks/useSettlement.ts
@@ -8,6 +8,7 @@
 import { useMemo } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useThrottledCallback } from '@/hooks/useThrottledCallback';
+import { useActiveWorkspace } from '@/hooks/workspace/useActiveWorkspace';
 import {
   getWorkLogsByJobPosting,
   calculateSettlement,
@@ -84,20 +85,27 @@ export function useSettlementSummary(jobPostingId: string) {
 
 /**
  * 내 전체 정산 요약 조회 훅
+ *
+ * Phase 2A.후속 PR3-C — useActiveWorkspace 의존. multi-workspace employer/admin 이
+ * 정산 대시보드를 workspace 별로 분리해서 보도록 query key + queryFn 모두
+ * activeWorkspace.id 를 포함. activeWorkspace 가 미선택이면 enabled=false 로
+ * cross-workspace aggregation 회피.
  */
 export function useMySettlementSummary(dateRange?: { start: string; end: string }) {
   const { user } = useAuthStore();
+  const { activeWorkspace } = useActiveWorkspace();
   const normalizedDateRange = stableFilters(dateRange);
   const mySummaryQueryKey = [
     ...queryKeys.settlement.mySummary(),
     user?.uid ?? 'anonymous',
     normalizedDateRange,
+    activeWorkspace?.id ?? 'no-workspace',
   ] as const;
 
   return useQuery({
     queryKey: mySummaryQueryKey,
-    queryFn: () => getMySettlementSummary(user!.uid, dateRange),
-    enabled: !!user,
+    queryFn: () => getMySettlementSummary(user!.uid, dateRange, activeWorkspace?.id),
+    enabled: !!user && !!activeWorkspace?.id,
     staleTime: queryCachingOptions.settlement.staleTime,
     gcTime: queryCachingOptions.settlement.gcTime,
   });
@@ -483,6 +491,10 @@ export function useSettlement(jobPostingId: string) {
 
 /**
  * 전체 정산 현황 훅 (대시보드용)
+ *
+ * Phase 2A.후속 PR3-C — workspace 별 분리 (useMySettlementSummary 통해).
+ * 본 훅은 thin wrapper 라 직접 변경 없음, upstream useMySettlementSummary 가
+ * useActiveWorkspace 에 의존하므로 자동으로 active workspace 기준으로 분리됨.
  */
 export function useSettlementDashboard() {
   const summaryQuery = useMySettlementSummary();

--- a/uniqn-mobile/src/services/work/__tests__/settlementService.test.ts
+++ b/uniqn-mobile/src/services/work/__tests__/settlementService.test.ts
@@ -20,6 +20,7 @@ import {
   bulkSettlement,
   updateSettlementStatus,
   getJobPostingSettlementSummary,
+  getMySettlementSummary,
 } from '@/services/work/settlement';
 import type { Allowances, SalaryInfo } from '@/types';
 
@@ -29,6 +30,7 @@ import type { Allowances, SalaryInfo } from '@/types';
 
 const mockJobPostingGetById = jest.fn();
 const mockJobPostingGetByOwnerId = jest.fn();
+const mockJobPostingGetManagedJobPostings = jest.fn();
 const mockWorkLogGetById = jest.fn();
 const mockWorkLogGetByJobPostingId = jest.fn();
 const mockSettleWorkLogWithTransaction = jest.fn();
@@ -40,6 +42,7 @@ jest.mock('@/repositories', () => ({
   jobPostingRepository: {
     getById: (...args: unknown[]) => mockJobPostingGetById(...args),
     getByOwnerId: (...args: unknown[]) => mockJobPostingGetByOwnerId(...args),
+    getManagedJobPostings: (...args: unknown[]) => mockJobPostingGetManagedJobPostings(...args),
   },
   workLogRepository: {
     getById: (...args: unknown[]) => mockWorkLogGetById(...args),
@@ -763,6 +766,28 @@ describe('settlementService', () => {
       await expect(getJobPostingSettlementSummary('job-1', 'employer-1')).rejects.toThrow(
         '본인의 공고만 조회할 수 있습니다'
       );
+    });
+  });
+
+  // ==========================================================================
+  // getMySettlementSummary — Phase 2A.후속 PR3-C workspace 별 분리
+  // ==========================================================================
+
+  describe('getMySettlementSummary', () => {
+    it('Phase 2A.후속 PR3-C — workspaceId 가 jobPostingRepository.getManagedJobPostings 에 pass-through 된다', async () => {
+      mockJobPostingGetManagedJobPostings.mockResolvedValue([]);
+
+      await getMySettlementSummary('employer-1', undefined, 'ws-abc');
+
+      expect(mockJobPostingGetManagedJobPostings).toHaveBeenCalledWith(undefined, 'ws-abc');
+    });
+
+    it('Phase 2A.후속 PR3-C — workspaceId 미전달 시 getManagedJobPostings 가 undefined 로 호출된다 (admin global view 호환)', async () => {
+      mockJobPostingGetManagedJobPostings.mockResolvedValue([]);
+
+      await getMySettlementSummary('employer-1');
+
+      expect(mockJobPostingGetManagedJobPostings).toHaveBeenCalledWith(undefined, undefined);
     });
   });
 });

--- a/uniqn-mobile/src/services/work/settlement/settlementQuery.ts
+++ b/uniqn-mobile/src/services/work/settlement/settlementQuery.ts
@@ -287,10 +287,17 @@ export async function getJobPostingSettlementSummary(
  * 내 전체 정산 요약 조회 (구인자용)
  *
  * @description 구인자의 모든 공고에 대한 정산 현황 요약
+ *
+ * Phase 2A.후속 PR3-C — multi-workspace employer/admin 이 정산 대시보드를
+ * workspace 별로 분리해서 보도록 workspaceId 인자를 받아 repo 에 pass-through.
+ * RLS jp_select 첫 분기가 모든 인증 사용자에게 active/closed 공고 SELECT 권한을
+ * 주므로, 클라이언트에서 workspace_id 를 명시적으로 좁혀야 cross-workspace
+ * aggregation 이 발생하지 않는다.
  */
 export async function getMySettlementSummary(
   ownerId: string,
-  dateRange?: { start: string; end: string }
+  dateRange?: { start: string; end: string },
+  workspaceId?: string
 ): Promise<{
   totalJobPostings: number;
   totalWorkLogs: number;
@@ -299,13 +306,14 @@ export async function getMySettlementSummary(
   summariesByJobPosting: JobPostingSettlementSummary[];
 }> {
   try {
-    logger.info('전체 정산 요약 조회', { ownerId, dateRange });
+    logger.info('전체 정산 요약 조회', { ownerId, dateRange, workspaceId });
 
     // 1. 관리 가능 공고 조회 — owner 본인 + 워크스페이스 멤버 공고 (RLS 통과)
     // Phase 2A: getByOwnerId → getManagedJobPostings 로 전환
-    const jobPostings = (await jobPostingRepository.getManagedJobPostings()).filter(
-      isCanonicalDatedPosting
-    );
+    // Phase 2A.후속 PR3-C: workspaceId 로 active workspace 범위로 좁힘
+    const jobPostings = (
+      await jobPostingRepository.getManagedJobPostings(undefined, workspaceId)
+    ).filter(isCanonicalDatedPosting);
 
     // 2. 각 공고별 정산 요약 조회
     const summaries: JobPostingSettlementSummary[] = [];


### PR DESCRIPTION
## Summary

PR #71 패턴 복제. `useMySettlementSummary` (정산 대시보드 upstream) 가 `useActiveWorkspace` 에 의존하도록 변경. multi-workspace employer/admin 이 정산 대시보드를 active workspace 별로 분리해서 보도록 함.

`useSettlementDashboard` 자체는 thin wrapper 라 직접 변경 없음 — upstream `useMySettlementSummary` 가 workspace-aware 로 바뀌면서 자동으로 분리됨.

## Why

audit ADR PR3-C 항목, `docs/superpowers/plans/2026-05-10-task6-workspace-audit.md` §5.PR3-C 참조.

`getManagedJobPostings` 는 PR #71 에서 이미 workspace-aware 로 전환되었으나 (jp_select 첫 분기가 모든 인증 사용자에게 active/closed 공고 SELECT 권한을 주므로 클라이언트에서 workspace_id 명시 필요), service `getMySettlementSummary` 는 인자를 pass-through 하지 않았고 hook `useMySettlementSummary` 는 `useActiveWorkspace` 에 의존하지 않았다. 이로 인해 multi-workspace employer/admin 의 정산 대시보드는 모든 워크스페이스의 공고를 한 버킷으로 aggregate 하는 cross-workspace leakage 가 있었음.

## Changes

| 파일 | 변경 |
|------|------|
| `src/services/work/settlement/settlementQuery.ts` | `getMySettlementSummary` 시그니처에 `workspaceId?: string` 3번째 인자 추가, `getManagedJobPostings(undefined, workspaceId)` pass-through |
| `src/hooks/useSettlement.ts` | `useMySettlementSummary`: `useActiveWorkspace` 의존 추가, query key 에 `activeWorkspace?.id ?? 'no-workspace'` 포함, `enabled: !!user && !!activeWorkspace?.id`, queryFn 에 `activeWorkspace?.id` 전달. `useSettlementDashboard`: JSDoc 만 업데이트 (upstream 통해 자동 분리) |
| `src/__tests__/hooks/useSettlement.test.ts` | `useActiveWorkspace` mock 추가, 기존 query key assertion 업데이트, Phase 2A.후속 PR3-C contract 테스트 3건 추가 (enabled=false / queryKey / queryFn workspaceId 전달) |
| `src/services/work/__tests__/settlementService.test.ts` | `jobPostingRepository.getManagedJobPostings` mock 추가, Phase 2A.후속 PR3-C service pass-through 테스트 2건 추가 (workspaceId 전달 / undefined 호환) |

## Verification

```
$ npx tsc --noEmit
EXIT=0  (0 errors)

$ npx eslint src/hooks/useSettlement.ts src/services/work/settlement \
    src/__tests__/hooks/useSettlement.test.ts \
    src/services/work/__tests__/settlementService.test.ts
EXIT=0  (0 errors)

$ npx jest src/__tests__/hooks/useSettlement.test.ts
Test Suites: 1 passed, 1 total
Tests:       48 passed, 48 total

$ npx jest src/services/work/__tests__/settlementService.test.ts
Test Suites: 1 passed, 1 total
Tests:       24 passed, 24 total
```

## Test plan

- [x] `useMySettlementSummary` query key 가 `activeWorkspace.id` 를 포함
- [x] `useMySettlementSummary` enabled 가 `activeWorkspace` 미선택 시 false
- [x] `useMySettlementSummary` queryFn 이 `getMySettlementSummary` 에 workspaceId 를 3번째 인자로 전달
- [x] `getMySettlementSummary` service 가 `getManagedJobPostings(undefined, workspaceId)` pass-through
- [x] 기존 useSettlement 테스트 48건 모두 통과 (regression 없음)
- [x] 기존 settlementService 테스트 24건 모두 통과
- [ ] 수동 검증: multi-workspace employer 로그인 후 active workspace 전환 시 정산 대시보드 totals 가 워크스페이스별로 분리됨 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)