### PR TITLE
docs(workspace): useScheduleStats / useCalendarView staff-only 검증 — Phase 2A.후속 PR3-D

### DIFF
--- a/docs/superpowers/plans/2026-05-10-task6-workspace-audit.md
+++ b/docs/superpowers/plans/2026-05-10-task6-workspace-audit.md
@@ -183,3 +183,17 @@ PR #71 (read-side workspace + cancellation 멤버)
 - 본 ADR 만 (코드 변경 0)
 - 다음 세션의 Sub-PR 진입점 명시
 - RLS 정책 매트릭스 snapshot (2026-05-10 기준)
+
+## PR3-D Resolution (2026-05-10)
+
+`useScheduleStats` (L570) 와 `useCalendarView` (L600) 의 employer 분기 audit 항목 검증 완료.
+
+**결론:** 두 hook 모두 **staff-only**. 코드 검증으로 확인:
+- `useScheduleStats` → `getScheduleStats(staffId)` (scheduleService.ts:727) — `staff_id` 로만 query.
+- `useCalendarView` → `useSchedulesByMonth` (L203) → `getSchedulesByMonth(staffId, year, month)` (scheduleService.ts:462) — `staff_id` 로만 query.
+
+employer 분기는 존재하지 않음. audit ADR §3.schedule 의 "dual (staff or employer 분기)" 분류는 잘못된 것이었음. RLS 가 staff 본인 work_logs 만 노출하므로 workspace 필터 불필요.
+
+**조치:** PR3-D 는 코드 변경 없이 staff-only 의도를 JSDoc + 테스트로 잠금. 실제 employer 스케줄 hook 이 향후 도입되면 그때 active workspace 필터 검토.
+
+(See PR #[NUMBER] for the verification + JSDoc + test additions.)

--- a/uniqn-mobile/src/__tests__/hooks/useSchedules.test.ts
+++ b/uniqn-mobile/src/__tests__/hooks/useSchedules.test.ts
@@ -717,6 +717,64 @@ describe('useSchedules hooks', () => {
     });
   });
 
+  // Phase 2A.후속 PR3-D 검증 (2026-05-10):
+  // useScheduleStats / useSchedulesByMonth 는 staff-only scope.
+  // queryKey 가 staffId 만 포함하고 workspace/employer dimension 이 없음을 잠금.
+  // service call 도 staffId 단일 인자 (workspace/owner 인자 없음).
+  describe('staff-only scope contract (PR3-D)', () => {
+    it('useScheduleStats query key contains staffId and no workspace dimension', () => {
+      mockQueryData = createMockStats();
+
+      renderHook(() => useScheduleStats());
+
+      const queryOptions = mockUseQuery.mock.calls.at(-1)?.[0] as
+        | { queryKey: readonly unknown[] }
+        | undefined;
+      expect(queryOptions?.queryKey).toEqual(['schedules', 'stats', 'staff-1']);
+      // workspace / ownerId / employer 같은 추가 차원이 없어야 함
+      expect(queryOptions?.queryKey).toHaveLength(3);
+    });
+
+    it('useScheduleStats queryFn calls service with staffId only (no workspace/owner)', async () => {
+      mockQueryData = createMockStats();
+
+      renderHook(() => useScheduleStats());
+
+      await waitFor(() => {
+        expect(mockGetScheduleStats).toHaveBeenCalled();
+      });
+      // staffId 단일 인자 — workspaceId / ownerId 추가 인자 없음
+      expect(mockGetScheduleStats).toHaveBeenCalledWith('staff-1');
+      expect(mockGetScheduleStats.mock.calls[0]).toHaveLength(1);
+    });
+
+    it('useSchedulesByMonth query key contains staffId and no workspace dimension', () => {
+      mockQueryData = { schedules: [], stats: createMockStats() };
+
+      renderHook(() => useSchedulesByMonth({ year: 2024, month: 2 }));
+
+      const monthCall = mockUseQuery.mock.calls.find((call) => {
+        const opts = call[0] as { queryKey: readonly unknown[] };
+        return Array.isArray(opts.queryKey) && opts.queryKey[1] === 'byMonth';
+      });
+      const queryOptions = monthCall?.[0] as { queryKey: readonly unknown[] } | undefined;
+      expect(queryOptions?.queryKey).toEqual(['schedules', 'byMonth', 2024, 2, 'staff-1']);
+      expect(queryOptions?.queryKey).toHaveLength(5);
+    });
+
+    it('useSchedulesByMonth queryFn calls service with (staffId, year, month) only', async () => {
+      mockQueryData = { schedules: [], stats: createMockStats() };
+
+      renderHook(() => useSchedulesByMonth({ year: 2024, month: 2 }));
+
+      await waitFor(() => {
+        expect(mockGetSchedulesByMonth).toHaveBeenCalled();
+      });
+      expect(mockGetSchedulesByMonth).toHaveBeenCalledWith('staff-1', 2024, 2);
+      expect(mockGetSchedulesByMonth.mock.calls[0]).toHaveLength(3);
+    });
+  });
+
   describe('useCalendarView', () => {
     it('builds grouped calendar state from monthly schedules', async () => {
       const schedules = [

--- a/uniqn-mobile/src/hooks/useSchedules.ts
+++ b/uniqn-mobile/src/hooks/useSchedules.ts
@@ -200,6 +200,13 @@ export function useSchedules(options: UseSchedulesOptions = {}) {
   };
 }
 
+/**
+ * 월별 스케줄 조회 hook.
+ *
+ * Phase 2A.후속 PR3-D 검증 (2026-05-10): staff-only scope. user.uid 기반 본인 work_logs 만 조회.
+ * active workspace 필터 불필요 — RLS 가 본인 work_logs 만 노출 + service 가 staff_id 로 query.
+ * staff 가 다른 워크스페이스 공고에 지원했어도 본인 work_logs 라면 모두 보임 (의도된 동작).
+ */
 export function useSchedulesByMonth(options: UseSchedulesByMonthOptions) {
   const { year, month, enabled = true, realtime = false } = options;
   const queryClient = useQueryClient();
@@ -567,6 +574,13 @@ export function useUpcomingSchedules(days = 7, enabled = true) {
   };
 }
 
+/**
+ * 스케줄 통계 조회 hook.
+ *
+ * Phase 2A.후속 PR3-D 검증 (2026-05-10): staff-only scope. user.uid 기반 본인 work_logs 만 조회.
+ * active workspace 필터 불필요 — RLS 가 본인 work_logs 만 노출 + service 가 staff_id 로 query.
+ * staff 가 다른 워크스페이스 공고에 지원했어도 본인 work_logs 라면 모두 보임 (의도된 동작).
+ */
 export function useScheduleStats(enabled = true) {
   const user = useAuthStore((state) => state.user);
   const staffId = user?.uid;
@@ -597,6 +611,14 @@ interface UseCalendarViewOptions {
   realtime?: boolean;
 }
 
+/**
+ * 캘린더 뷰 상태 + 월별 스케줄 hook.
+ *
+ * Phase 2A.후속 PR3-D 검증 (2026-05-10): staff-only scope. 내부적으로 useSchedulesByMonth 를
+ * 사용하므로 user.uid 기반 본인 work_logs 만 조회.
+ * active workspace 필터 불필요 — RLS 가 본인 work_logs 만 노출 + service 가 staff_id 로 query.
+ * staff 가 다른 워크스페이스 공고에 지원했어도 본인 work_logs 라면 모두 보임 (의도된 동작).
+ */
 export function useCalendarView(options: UseCalendarViewOptions | CalendarView = 'month') {
   const normalizedOptions: UseCalendarViewOptions =
     typeof options === 'string' ? { initialView: options } : options;


### PR DESCRIPTION
## Summary

Task 6 audit ADR (`docs/superpowers/plans/2026-05-10-task6-workspace-audit.md`) §3.schedule 의 "dual (staff or employer 분기)" 분류가 **오분류** 였음을 코드 검증으로 확인. 두 hook 모두 **staff-only** 로 RLS + service query 가 staff_id 로 강제하므로 workspace 필터 불필요.

**코드 변경 0건, JSDoc + 테스트 + ADR 업데이트만.**

## Audit Discrepancy

| audit 분류 (잘못됨) | 코드 검증 결과 (정확) |
|---|---|
| `useScheduleStats` (L570) — dual (staff or employer 분기) | `getScheduleStats(staffId)` (scheduleService.ts:727) — staff-only |
| `useCalendarView` (L600) — dual | `useSchedulesByMonth` 경유 → `getSchedulesByMonth(staffId, year, month)` (scheduleService.ts:462) — staff-only |

employer 분기는 **존재하지 않음**. RLS 가 staff 본인 work_logs 만 노출하므로 의도된 동작이며 active workspace 필터 불필요.

## Changes

| 파일 | 변경 |
|---|---|
| `src/hooks/useSchedules.ts` | 3개 hook (`useSchedulesByMonth` / `useScheduleStats` / `useCalendarView`) JSDoc 으로 staff-only contract 명시 |
| `src/__tests__/hooks/useSchedules.test.ts` | `staff-only scope contract (PR3-D)` describe 추가 — queryKey staffId 만 포함 / queryFn staffId 단일 인자 (workspace/owner 차원 없음) 4 테스트 |
| `docs/superpowers/plans/2026-05-10-task6-workspace-audit.md` | `## PR3-D Resolution (2026-05-10)` 섹션 추가 — audit 오분류 + 검증 결과 + 향후 employer hook 도입 시 재검토 메모 |

## Verification

- `npx jest src/__tests__/hooks/useSchedules.test.ts` → **27 passed, 0 failed** (기존 23 + PR3-D 신규 4)
- `npx eslint src/hooks/useSchedules.ts src/__tests__/hooks/useSchedules.test.ts` → **0 errors**
- `npx tsc --noEmit` → **0 errors** (canonical uniqn-mobile 위치에서 검증; worktree 환경의 junction 기반 module resolution 한계는 환경 이슈로, 동일 변경을 master uniqn-mobile 에 적용해 별도 검증)

## Test plan

- [x] PR3-D 신규 4 테스트 추가 (queryKey staffId 만 / queryFn staffId 단일 인자)
- [x] 기존 23 테스트 모두 통과 유지
- [x] JSDoc 추가 후 ESLint 0 errors
- [x] tsc 0 errors

## Constraints (지켜진 항목)

- 코드 로직 변경 0건 — JSDoc + 테스트 + ADR 만
- `useMonthlyPayroll` (PR3-B) / `useSettlementDashboard` (PR3-C) 미수정
- workspace 필터 로직 추가 안함 (staff-only scope 이므로 불필요)

## Resolution

PR3-D 의 원래 목표 (employer 분기 검증 + workspace 필터 추가) 는 audit 오분류로 인해 **불필요**. 실제 employer 스케줄 hook 이 향후 도입되면 그 때 active workspace 필터 검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)