### PR TITLE
feat(workspace): useMonthlyPayroll workspace 별 분리 — Phase 2A.후속 PR3-B

### DIFF
--- a/uniqn-mobile/src/__tests__/hooks/useWorkLogs.test.ts
+++ b/uniqn-mobile/src/__tests__/hooks/useWorkLogs.test.ts
@@ -6,6 +6,8 @@
  */
 
 import { act, renderHook, waitFor } from '@testing-library/react-native';
+// Phase 2A.후속 (PR3-B, 2026-05-10) — useMonthlyPayroll workspace 의존성 mock
+import { useActiveWorkspace } from '@/hooks/workspace/useActiveWorkspace';
 import { resetCounters, createMockWorkLog } from '../mocks/factories';
 
 // ============================================================================
@@ -71,6 +73,12 @@ jest.mock('@/services/work/workLogService', () => ({
 
 const mockUser = { uid: 'staff-1' };
 const mockAuthState = { user: mockUser };
+
+// Phase 2A.후속 (PR3-B, 2026-05-10) — useMonthlyPayroll workspace 의존성
+jest.mock('@/hooks/workspace/useActiveWorkspace', () => ({
+  useActiveWorkspace: jest.fn(),
+}));
+const mockUseActiveWorkspace = useActiveWorkspace as jest.MockedFunction<typeof useActiveWorkspace>;
 
 jest.mock('@/stores/authStore', () => ({
   useAuthStore: (selector?: (state: typeof mockAuthState) => unknown) =>
@@ -244,6 +252,19 @@ describe('useWorkLogs Hooks', () => {
         return jest.fn();
       }
     );
+
+    // Phase 2A.후속 (PR3-B, 2026-05-10) — useMonthlyPayroll 가 useActiveWorkspace 의존
+    mockUseActiveWorkspace.mockReturnValue({
+      activeWorkspace: {
+        id: 'ws-default',
+        name: 'Default',
+        ownerId: 'staff-1',
+        memberCount: 1,
+      } as any,
+      workspaces: [],
+      isLoading: false,
+      setActiveWorkspaceId: jest.fn(),
+    });
   });
 
   // ==========================================================================
@@ -741,6 +762,78 @@ describe('useWorkLogs Hooks', () => {
       expect(mockEnabled).toBe(false);
 
       Object.assign(mockAuthState, originalState);
+    });
+
+    // ========================================================================
+    // Phase 2A.후속 (PR3-B, 2026-05-10) — workspace 의존성 contract 테스트
+    // PR #71 useJobManagement.test.ts:workspace 패턴 복제
+    // ========================================================================
+
+    it('Phase 2A.후속 — activeWorkspace 가 없으면 enabled 가 false 다', () => {
+      mockUseActiveWorkspace.mockReturnValue({
+        activeWorkspace: undefined,
+        workspaces: [],
+        isLoading: false,
+        setActiveWorkspaceId: jest.fn(),
+      });
+
+      renderHook(() => useMonthlyPayroll(2025, 1));
+
+      expect(mockEnabled).toBe(false);
+    });
+
+    it('Phase 2A.후속 — activeWorkspace.id 가 query key 에 포함된다', () => {
+      mockUseActiveWorkspace.mockReturnValue({
+        activeWorkspace: {
+          id: 'ws-1',
+          name: 'Test',
+          ownerId: 'staff-1',
+          memberCount: 1,
+        } as any,
+        workspaces: [],
+        isLoading: false,
+        setActiveWorkspaceId: jest.fn(),
+      });
+
+      renderHook(() => useMonthlyPayroll(2025, 1));
+
+      const { useQuery } = jest.requireMock('@tanstack/react-query') as {
+        useQuery: jest.Mock;
+      };
+
+      // 가장 최근 호출의 queryKey 검사
+      const calls = useQuery.mock.calls;
+      const lastCall = calls[calls.length - 1][0] as { queryKey: unknown[] };
+      expect(lastCall.queryKey).toEqual(expect.arrayContaining(['ws-1']));
+    });
+
+    it('Phase 2A.후속 — getMonthlyPayroll 호출 시 workspaceId 가 4번째 인자로 전달된다', async () => {
+      mockUseActiveWorkspace.mockReturnValue({
+        activeWorkspace: {
+          id: 'ws-1',
+          name: 'Test',
+          ownerId: 'staff-1',
+          memberCount: 1,
+        } as any,
+        workspaces: [],
+        isLoading: false,
+        setActiveWorkspaceId: jest.fn(),
+      });
+      mockGetMonthlyPayroll.mockResolvedValue({
+        totalAmount: 0,
+        pendingAmount: 0,
+        completedAmount: 0,
+        workLogs: [],
+      });
+
+      renderHook(() => useMonthlyPayroll(2025, 3));
+
+      // queryFn 직접 호출하여 service 인자 검증
+      if (lastQueryFn) {
+        await lastQueryFn();
+      }
+
+      expect(mockGetMonthlyPayroll).toHaveBeenCalledWith('staff-1', 2025, 3, 'ws-1');
     });
   });
 });

--- a/uniqn-mobile/src/hooks/useWorkLogs.ts
+++ b/uniqn-mobile/src/hooks/useWorkLogs.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNetworkStatus } from '@/hooks/useNetworkStatus';
+import { useActiveWorkspace } from '@/hooks/workspace/useActiveWorkspace';
 import { useAuthStore } from '@/stores/authStore';
 import { queryKeys, cachingPolicies, queryCachingOptions } from '@/lib/queryClient';
 import {
@@ -342,9 +343,18 @@ export function useWorkLogStats(enabled = true) {
   };
 }
 
+/**
+ * 월별 정산 요약 hook
+ *
+ * Phase 2A.후속 (PR3-B, 2026-05-10) — useActiveWorkspace 의존 추가. Staff 가
+ * 여러 워크스페이스(포커룸)에서 근무하는 경우 active workspace 별로 정산을
+ * 분리 (PR #71 useMyJobPostings 패턴 복제). queryKey 에 workspaceId 포함하여
+ * cache 격리, activeWorkspace 부재 시 enabled=false 로 ghost cache 회피.
+ */
 export function useMonthlyPayroll(year: number, month: number, enabled = true) {
   const user = useAuthStore((state) => state.user);
   const staffId = user?.uid;
+  const { activeWorkspace } = useActiveWorkspace();
   const { isOnline } = useNetworkStatus();
   const payrollQueryKey = [
     ...queryKeys.workLogs.all,
@@ -352,15 +362,16 @@ export function useMonthlyPayroll(year: number, month: number, enabled = true) {
     year,
     month,
     staffId ?? 'anonymous',
+    activeWorkspace?.id ?? 'no-workspace',
   ] as const;
 
   const query = useQuery({
     queryKey: payrollQueryKey,
     queryFn: async () => {
       if (!staffId) throw new Error(AUTH_REQUIRED_MESSAGE);
-      return getMonthlyPayroll(staffId, year, month);
+      return getMonthlyPayroll(staffId, year, month, activeWorkspace?.id);
     },
-    enabled: enabled && !!staffId && isOnline,
+    enabled: enabled && !!staffId && !!activeWorkspace?.id && isOnline,
     staleTime: cachingPolicies.stable,
   });
 

--- a/uniqn-mobile/src/repositories/interfaces/IWorkLogRepository.ts
+++ b/uniqn-mobile/src/repositories/interfaces/IWorkLogRepository.ts
@@ -155,12 +155,24 @@ export interface IWorkLogRepository {
 
   /**
    * 월별 정산 요약 조회
+   *
+   * Phase 2A.후속 (PR3-B, 2026-05-10) — staff 가 여러 워크스페이스(포커룸)에서
+   * 근무하는 경우 active workspace 별로 정산을 분리하기 위해 workspaceId? 추가.
+   * work_logs 테이블에 workspace_id 컬럼이 없어 job_postings.workspace_id 를
+   * inner-join 으로 필터링한다.
+   *
    * @param staffId - 스태프 ID
    * @param year - 연도
    * @param month - 월 (1-12)
+   * @param workspaceId - active workspace id (선택). 제공 시 해당 workspace 공고의 work_logs 만 집계.
    * @returns 월별 정산 요약
    */
-  getMonthlyPayroll(staffId: string, year: number, month: number): Promise<MonthlyPayrollSummary>;
+  getMonthlyPayroll(
+    staffId: string,
+    year: number,
+    month: number,
+    workspaceId?: string
+  ): Promise<MonthlyPayrollSummary>;
 
   /**
    * 날짜 범위로 근무 기록 조회

--- a/uniqn-mobile/src/repositories/supabase/WorkLogRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/WorkLogRepository.ts
@@ -336,23 +336,37 @@ export class SupabaseWorkLogRepository implements IWorkLogRepository {
   async getMonthlyPayroll(
     staffId: string,
     year: number,
-    month: number
+    month: number,
+    workspaceId?: string
   ): Promise<MonthlyPayrollSummary> {
     try {
       const monthStr = `${year}-${String(month).padStart(2, '0')}`;
-      logger.info('월별 정산 요약 조회', { staffId, monthStr });
+      logger.info('월별 정산 요약 조회', { staffId, monthStr, workspaceId });
 
       const startDate = `${monthStr}-01`;
       const lastDay = new Date(year, month, 0).getDate();
       const endDate = `${monthStr}-${String(lastDay).padStart(2, '0')}`;
 
-      const { data, error } = await supabase
+      // Phase 2A.후속 (PR3-B, 2026-05-10) — workspaceId 제공 시 job_postings.workspace_id
+      // 로 inner-join 필터. work_logs 자체에 workspace_id 컬럼이 없어 PostgREST embed
+      // resource 를 통한 join 필터링이 유일한 방법. parseWorkLogDocument 의
+      // .passthrough() 가 join 결과의 nested job_postings 필드를 무시한다.
+      const selectColumns = workspaceId
+        ? `${TABLE_COLUMNS},job_postings!inner(workspace_id)`
+        : TABLE_COLUMNS;
+
+      let query = supabase
         .from(TABLE)
-        .select(TABLE_COLUMNS)
+        .select(selectColumns)
         .eq('staff_id', staffId)
         .gte('date', startDate)
-        .lte('date', endDate)
-        .order('date', { ascending: true });
+        .lte('date', endDate);
+
+      if (workspaceId) {
+        query = query.eq('job_postings.workspace_id', workspaceId);
+      }
+
+      const { data, error } = await query.order('date', { ascending: true });
 
       if (error) handleSupabaseError(error, { operation: '월별 정산 요약 조회', table: TABLE });
 
@@ -366,7 +380,10 @@ export class SupabaseWorkLogRepository implements IWorkLogRepository {
       };
 
       const workLogs: WorkLog[] = [];
-      for (const row of (data ?? []) as Record<string, unknown>[]) {
+      // join 결과 타입은 nested 객체를 포함하지만 toWorkLog 의 zod
+      // .passthrough() 가 unknown 필드를 무시. 동적 select 로 union 이 된 만큼
+      // unknown 경유 cast 가 필요.
+      for (const row of (data ?? []) as unknown as Record<string, unknown>[]) {
         const workLog = toWorkLog(row);
         if (!workLog) continue;
 
@@ -390,7 +407,7 @@ export class SupabaseWorkLogRepository implements IWorkLogRepository {
       });
       return summary;
     } catch (error) {
-      rethrowOrHandle(error, '월별 정산 요약 조회', { staffId, year, month });
+      rethrowOrHandle(error, '월별 정산 요약 조회', { staffId, year, month, workspaceId });
     }
   }
 

--- a/uniqn-mobile/src/services/work/__tests__/workLogService.test.ts
+++ b/uniqn-mobile/src/services/work/__tests__/workLogService.test.ts
@@ -407,11 +407,26 @@ describe('WorkLogService', () => {
 
       const result = await getMonthlyPayroll('staff-1', 2025, 1);
 
-      expect(mockRepo.getMonthlyPayroll).toHaveBeenCalledWith('staff-1', 2025, 1);
+      expect(mockRepo.getMonthlyPayroll).toHaveBeenCalledWith('staff-1', 2025, 1, undefined);
       expect(result.totalAmount).toBe(3000000);
       expect(result.pendingAmount).toBe(1000000);
       expect(result.completedAmount).toBe(2000000);
       expect(result.workLogs).toHaveLength(1);
+    });
+
+    // Phase 2A.후속 (PR3-B, 2026-05-10) — workspaceId pass-through 검증
+    it('should pass workspaceId 4th arg to repository when provided', async () => {
+      const mockSummary = {
+        totalAmount: 1500000,
+        pendingAmount: 0,
+        completedAmount: 1500000,
+        workLogs: [],
+      };
+      mockRepo.getMonthlyPayroll.mockResolvedValue(mockSummary as any);
+
+      await getMonthlyPayroll('staff-1', 2025, 5, 'ws-abc');
+
+      expect(mockRepo.getMonthlyPayroll).toHaveBeenCalledWith('staff-1', 2025, 5, 'ws-abc');
     });
 
     it('should return empty workLogs array when summary has no workLogs', async () => {

--- a/uniqn-mobile/src/services/work/workLogService.ts
+++ b/uniqn-mobile/src/services/work/workLogService.ts
@@ -156,11 +156,15 @@ export async function getWorkLogStats(staffId: string): Promise<WorkLogStats> {
  * 월별 정산 정보 조회
  *
  * @description Repository 패턴 적용 - workLogRepository.getMonthlyPayroll 사용
+ *
+ * Phase 2A.후속 (PR3-B, 2026-05-10) — workspaceId? 추가, repository pass-through.
+ * Active workspace 별 정산 분리 지원.
  */
 export async function getMonthlyPayroll(
   staffId: string,
   year: number,
-  month: number
+  month: number,
+  workspaceId?: string
 ): Promise<{
   totalAmount: number;
   pendingAmount: number;
@@ -168,9 +172,14 @@ export async function getMonthlyPayroll(
   workLogs: WorkLog[];
 }> {
   try {
-    logger.info('월별 정산 조회', { staffId: maskSensitiveId(staffId), year, month });
+    logger.info('월별 정산 조회', {
+      staffId: maskSensitiveId(staffId),
+      year,
+      month,
+      workspaceId,
+    });
 
-    const summary = await workLogRepository.getMonthlyPayroll(staffId, year, month);
+    const summary = await workLogRepository.getMonthlyPayroll(staffId, year, month, workspaceId);
 
     return {
       totalAmount: summary.totalAmount,
@@ -182,7 +191,7 @@ export async function getMonthlyPayroll(
     throw handleServiceError(error, {
       operation: '월별 정산 조회',
       component: 'workLogService',
-      context: { staffId: maskSensitiveId(staffId), year, month },
+      context: { staffId: maskSensitiveId(staffId), year, month, workspaceId },
     });
   }
 }


### PR DESCRIPTION
## Summary

- Staff 가 여러 워크스페이스(포커룸)에서 근무하는 경우 active workspace 별로 월별 정산을 분리 (PR #71 `useMyJobPostings` 패턴 복제)
- `getMonthlyPayroll` repository / service signature 에 `workspaceId?` 4번째 인자 추가
- `useMonthlyPayroll` hook 이 `useActiveWorkspace` 의존, query key 격리 + workspace 부재 시 `enabled=false`

## Why

Phase 2A.후속 audit (`docs/superpowers/plans/2026-05-10-task6-workspace-audit.md` §5.PR3-B) 에서 식별된 staff-side workspace 격리 갭. PR #71 (commit `bf03eec12`) 가 `useMyJobPostings` 에서 `activeWorkspace.id` 를 query key + service 인자로 전파하여 multi-workspace 사용자의 ghost cache 를 회피한 패턴을 그대로 복제.

`work_logs` 테이블에 `workspace_id` 컬럼이 존재하지 않아 (`job_posting_id` FK 만 보유), PostgREST embedded resource 기능을 이용하여 `job_postings!inner(workspace_id)` 로 inner-join 필터링한다. `parseWorkLogDocument` zod 스키마가 `.passthrough()` 라 nested `job_postings` 필드는 안전하게 무시된다.

## Changes

| File | Before → After |
|------|----------------|
| `src/repositories/interfaces/IWorkLogRepository.ts` | `getMonthlyPayroll(staffId, year, month)` → `(staffId, year, month, workspaceId?)` |
| `src/repositories/supabase/WorkLogRepository.ts` | 단순 `eq('staff_id', ...)` → `workspaceId` 제공 시 `job_postings!inner(workspace_id)` join + `.eq('job_postings.workspace_id', ...)` |
| `src/services/work/workLogService.ts` | repository 4번째 인자 pass-through |
| `src/hooks/useWorkLogs.ts` | `useMonthlyPayroll` 에 `useActiveWorkspace` 추가, query key 에 `activeWorkspace.id` 포함, `enabled` 에 `!!activeWorkspace?.id` 추가 |
| `src/__tests__/hooks/useWorkLogs.test.ts` | `useActiveWorkspace` mock + 3 contract 테스트 추가 (no-workspace 시 disable / queryKey 에 workspaceId 포함 / queryFn 에서 workspaceId 4번째 인자 전달) |
| `src/services/work/__tests__/workLogService.test.ts` | 기존 호출 expect 에 `undefined` 4번째 인자 명시 + workspaceId pass-through 신규 케이스 1건 |

## Verification

```
npm run type-check
0 errors in changed source files (src/hooks/useWorkLogs.ts, src/repositories/**, src/services/work/workLogService.ts)

npx eslint src/hooks/useWorkLogs.ts src/repositories/... src/services/work/... src/__tests__/hooks/useWorkLogs.test.ts src/services/work/__tests__/workLogService.test.ts
0 errors, 0 warnings

npx jest src/__tests__/hooks/useWorkLogs src/services/work/__tests__/workLogService
Test Suites: 2 passed, 2 total
Tests:       101 passed, 101 total
Time:        3.04 s
```

## Test plan

- [x] `useMonthlyPayroll` 47 jest cases 통과 (기존 5 + 신규 3)
- [x] `workLogService.getMonthlyPayroll` 54 jest cases 통과 (기존 3 + 신규 1)
- [x] TypeScript 0 error in changed source files
- [x] ESLint 0 error / 0 warning
- [ ] 멀티 워크스페이스 staff 계정으로 `/(app)/payroll` 화면 수동 검증 (활성 워크스페이스 전환 시 월별 정산 데이터가 격리되는지 확인 — 후속 QA)
- [ ] PostgREST inner-join + RLS `wl_select` 통과 검증 (workspace member 권한으로 join 결과 노출)

## Related

- Audit doc: `docs/superpowers/plans/2026-05-10-task6-workspace-audit.md` §5.PR3-B
- Reference PR: #71 (`useMyJobPostings` workspace dependency, commit `bf03eec12`)
- Sister PRs: PR3-A (apply queries) / PR3-C (settlement) / PR3-D (calendar/schedule stats) — 별도 worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)