### PR TITLE
fix(test): scheduleService.test.ts mock 의 isAppError export 누락 보강

### DIFF
--- a/uniqn-mobile/src/services/work/__tests__/scheduleService.test.ts
+++ b/uniqn-mobile/src/services/work/__tests__/scheduleService.test.ts
@@ -166,6 +166,12 @@ jest.mock('@/errors', () => ({
     NETWORK_REQUEST_FAILED: 'E1002',
   },
   toError: (error: unknown) => (error instanceof Error ? error : new Error(String(error))),
+  // scheduleService.ts:629 가 isAppError(error) 호출 — duck-typed 체크로 충분
+  // (실제 AppError.isAppError 는 instanceof AppError 또는 __isAppError 마커 검사)
+  isAppError: (error: unknown): boolean =>
+    error !== null &&
+    typeof error === 'object' &&
+    ('__isAppError' in error || 'isRetryable' in error || 'code' in error),
 }));
 
 jest.mock('@/utils/date', () => ({


### PR DESCRIPTION
## Summary

- master pre-existing 테스트 실패 (2/82) hotfix.
- `scheduleService.test.ts:157-169` mock factory `jest.mock('@/errors', ...)` 가 `isAppError` 를 export 하지 않아 `_errors.isAppError is not a function` TypeError 로 실패.
- 본 PR 머지 후 #76/#77/#78/#79 의 Tests CI 자동 그린 예상.

## 원인

\`scheduleService.ts:629\`:
\`\`\`ts
if (isAppError(error) && error.isRetryable) { ... }
\`\`\`

테스트의 \`@/errors\` mock 은 \`NetworkError\`, \`ERROR_CODES\`, \`toError\` 만 정의 → \`isAppError\` 호출 시 undefined → TypeError.

## Fix

mock factory 에 \`isAppError\` 추가. 실제 \`AppError.isAppError\` 시맨틱 (instanceof AppError 또는 \`__isAppError\` 마커 검사) 충실히 mirror — duck-typed 체크로 \`__isAppError | isRetryable | code\` 어느 하나 보유 시 true.

## Verification

\`\`\`
npx jest src/services/work/__tests__/scheduleService
→ Test Suites: 2 passed, 2 total
→ Tests: 82 passed, 82 total
\`\`\`

이전: 80/82 (2 fail)
이후: 82/82 PASS

## Test plan

- [x] jest 영역 테스트 0 fail
- [x] master 의 다른 테스트 회귀 0 (mock 은 per-file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)