### PR TITLE
fix(migration): increment_board_post_view_count RPC text=uuid 비교 캐스팅 보강

### DIFF
--- a/uniqn-mobile/supabase/migrations/20260412181156_add_board_comment_reactions_and_rpcs.sql
+++ b/uniqn-mobile/supabase/migrations/20260412181156_add_board_comment_reactions_and_rpcs.sql
@@ -33,6 +33,11 @@ CREATE POLICY "reaction_delete" ON public.board_comment_reactions
   FOR DELETE USING (user_id = auth.uid());
 
 -- 2. increment_board_post_view_count RPC
+-- Fix (2026-05-10): board_posts.id 는 base_schema 부터 text 타입.
+-- check_function_bodies=on 환경 (CI fresh apply) 에서 text=uuid 비교
+-- 검증 실패하던 SQLSTATE 42883 해결을 위해 ::text 캐스팅 추가.
+-- 후속 migration 20260417123441 가 파라미터 자체를 text 로 재정의하므로
+-- 본 캐스팅은 fresh apply 의 첫 단계에서만 의미 있으며 functional 동일.
 CREATE OR REPLACE FUNCTION public.increment_board_post_view_count(p_post_id uuid)
 RETURNS void
 LANGUAGE sql
@@ -42,7 +47,7 @@ SET search_path = 'public'
 AS $$
   UPDATE public.board_posts
   SET view_count = COALESCE(view_count, 0) + 1
-  WHERE id = p_post_id;
+  WHERE id = p_post_id::text;
 $$;
 
 -- 3. toggle_comment_reaction RPC


### PR DESCRIPTION
## Summary

- master pre-existing E2E 실패 hotfix — \`supabase start\` migration apply 실패 unblock.
- \`SQLSTATE 42883: operator does not exist: text = uuid\` (board_posts.id text vs RPC param uuid).
- 본 PR 머지 후 #76/#77/#78/#79 의 E2E CI 자동 그린 예상.

## 원인

- \`board_posts.id\` 는 base_schema (\`20260409000000\`) 부터 \`text\` 타입.
- migration \`20260412181156_add_board_comment_reactions_and_rpcs.sql\` 의 RPC:
  \`\`\`sql
  CREATE OR REPLACE FUNCTION public.increment_board_post_view_count(p_post_id uuid)
  ...
  WHERE id = p_post_id;  -- text = uuid 비교 시도
  \`\`\`
- \`check_function_bodies = on\` 환경 (CI fresh apply) 에서 CREATE FUNCTION 검증 시 즉시 실패.

후속 migration \`20260417123441_fix_board_view_count_rpc_text.sql\` 가 파라미터를 \`text\` 로 재정의하지만, 첫 migration 이 fresh apply 시 fail 하므로 후속이 도달하지 못함.

## Fix

본문에 \`::text\` 캐스팅 추가:
\`\`\`sql
WHERE id = p_post_id::text
\`\`\`
후속 migration 이 파라미터 자체를 text 로 재정의하므로 functional 영향 없음.

## Production 영향

production prod registry 확인 결과:
- prod 등록 timestamp: \`20260412090751\` (name: \`add_board_comment_reactions_and_missing_rpcs\`)
- 로컬 파일 timestamp: \`20260412181156\` (name: \`add_board_comment_reactions_and_rpcs\`)

MCP \`apply_migration\` 으로 prod 등록 시 timestamp 가 분기되는 알려진 패턴 (project memory: \`feedback_supabase_migration_workflow\`). prod 는 본 파일과 무관한 SQL 이 적용된 상태이며, 본 fix 는 fresh CI / 로컬 dev 의 첫 apply 만 unblock — **prod 미영향**.

## Verification

CI 머지 후 4 PR 의 E2E Tests 가 fresh local Supabase 부팅 단계 통과 확인 예정.

## Test plan

- [x] migration SQL 문법 검증 (Edit 후 syntax 정상)
- [ ] CI E2E 머지 후 fresh apply 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)