### PR TITLE
fix(test): submission.test 의 round-trip 테스트 workspaceId 누락 회귀 수정

### DIFF
--- a/uniqn-mobile/src/utils/job-posting/__tests__/submission.test.ts
+++ b/uniqn-mobile/src/utils/job-posting/__tests__/submission.test.ts
@@ -325,6 +325,10 @@ describe('job posting submission helpers', () => {
     const serialized = serializeJobPostingV3(createInput, {
       ownerId: 'employer-1',
       ownerName: 'Owner',
+      // jobPostingDocumentSchema 가 workspaceId 를 required v4 uuid 로 요구.
+      // serializeJobPostingV3 는 options.workspaceId 미지정 시 필드 omit → zod 검증 실패.
+      // version digit 4, variant digit 8 인 valid uuid v4 사용.
+      workspaceId: '11111111-1111-4111-8111-111111111111',
       createdAt: new Date(),
       updatedAt: new Date(),
     });


### PR DESCRIPTION
## Summary

- master pre-existing 테스트 실패 hotfix.
- \`src/utils/job-posting/__tests__/submission.test.ts:323\` 의 'preserves canonical location data through serialize -> parse -> form round-trip' 테스트가 \`parsed=null\` 로 실패 (1/8).
- 본 PR 머지 후 #76/#77/#78/#79 의 Tests CI 영향 해제.

## 원인

\`jobPostingDocumentSchema:465\` 가 \`workspaceId\` 를 required v4 uuid 로 선언:
\`\`\`ts
workspaceId: z.string().uuid({ message: '올바른 워크스페이스 ID 가 아닙니다' }),
\`\`\`

\`serializeJobPostingV3\` 는 \`options.workspaceId\` truthy 일 때만 필드 포함 (\`serialization.ts:228-238\`):
\`\`\`ts
const resolvedWorkspaceId = options.workspaceId || current?.workspaceId || undefined;
return {
  ...
  ...(resolvedWorkspaceId ? { workspaceId: resolvedWorkspaceId } : {}),
  ...
};
\`\`\`

본 round-trip 테스트는 options 에 \`workspaceId\` 미전달 → 결과에서 omit → \`parseJobPostingDocument\` 의 zod safeParse 실패 → \`null\` 반환.

## Fix

테스트의 \`serializeJobPostingV3\` 옵션에 valid v4 UUID 추가:

\`\`\`ts
workspaceId: '11111111-1111-4111-8111-111111111111',
\`\`\`

zod 의 strict UUID 검증 (version digit \`[1-8]\`, variant \`[89abAB]\`) 호환 형식.

## Verification

\`\`\`
npx jest src/utils/job-posting/__tests__/submission
→ 8 passed, 8 total (이전: 1 fail / 7 pass)
\`\`\`

## Test plan

- [x] jest 영역 테스트 0 fail
- [x] zod schema 검증 통과 (debug script 로 issues 직접 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)