### PR TITLE
feat(workspace): jp status 전이 trigger + home settlement widgets + bulk ADR

### DIFF
--- a/docs/decisions/2026-05-11-bulk-update-status-permission.md
+++ b/docs/decisions/2026-05-11-bulk-update-status-permission.md
@@ -1,0 +1,69 @@
+# ADR — useBulkUpdateStatus Permission Model
+
+> **Status:** Proposed (2026-05-11)
+> **Predecessors:** PR #71 (read-side workspace), PR #72 (helper rename), PR #73 (write-side mutate vs delete split), PR #74 (audit roadmap), migration `20260514050000_enforce_jp_status_transition` (status 전이 trigger)
+> **Successors:** TBD — see "Follow-up tasks" below
+
+## Context
+
+PR #73 (commit `4383e8ee9`) 가 4 mutation hook 중 단일 row 변형 (`update`/`close`/`reopen`/`settlement settings` via `loadAndVerifyMutateAccess`; `delete` via `loadAndVerifyDeleteAccess`) 의 workspace 호환을 닫았으나 `bulkUpdateStatus` 는 명시적으로 deferred:
+
+> bulkUpdateStatus 는 여전히 owner_id 필터 — bulk 의 cross-owner 영향 범위가 넓어 별도 검토 필요.
+
+현재 구현 (`uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts:717-738`):
+- 단일 multi-row UPDATE 에 `.in('id', jobPostingIds)` + `.eq('owner_id', ownerId)` 로 raw 컬럼 필터
+- `loadAndVerify*Access` helper 호출 0건
+- `successCount` 는 `RETURNING id` 카운트, 미일치 row 는 silent 드롭
+
+PR #74 audit (commit `2e4019db9`) 의 PR3-A~E 로드맵에는 `bulkUpdateStatus` 가 들어 있지 않음 — 가장 가까운 placeholder 는 "client write helper 통일" (low priority). 이 ADR 은 audit 로드맵과 충돌하지 않는 보완 결정.
+
+**UI 상태**: `useBulkUpdateStatus` 와 `useJobManagement` orchestrator 모두 TSX consumer **0건** (`employer.tsx` 는 개별 hook 만 import). bulk 경로는 UX 관점에서 dead code → semantic 변경을 UX 회귀 위험 없이 land 가능, UI 디자인은 결정된 model 위에 후속.
+
+## Decision
+
+**Option C — 대상 status 별 분기:**
+
+- **bulk close / reopen / active** — `loadAndVerifyMutateAccess` (owner | workspace_member | admin). 단일 row PR #73 와 동등.
+- **bulk cancel (`status='cancelled'`)** — service-layer 에서 reject. status 전이 trigger (migration `20260514050000`) 가 DB-level 에서 한 번 더 차단. trigger land 후 Phase 2 에서 `loadAndVerifyDeleteAccess` (owner | admin) 로 재오픈.
+
+**정당화:**
+1. **PR #73 단일 row 변형과 UX 일관성** — editor 가 한 건씩 close 할 수 있으면서 bulk close 만 owner-only 로 막힐 이유 없음.
+2. **bulk-cancel 루프홀 차단** — service guard 가 cancel 을 우선 거절하므로 trigger 의존성 없이 안전 land. trigger land 후 defense-in-depth 유지.
+3. **UI 무종속** — TSX consumer 0건 → semantic PR 단독 land. UI 는 결정된 model 위에 디자인.
+4. **cross-workspace 는 RLS row-by-row 평가** — partial commit 은 의도된 동작. 기존 `successCount` 토스트 (`${successCount}개 변경됨`) 가 자연스럽게 표현.
+5. **helper 비대칭 보존** — mutate 경로는 `loadAndVerifyMutateAccess`, delete 경로는 `loadAndVerifyDeleteAccess` 로 단일 row 와 동일 분리. RLS 는 이중 방어, trust boundary 가 아님.
+
+## Consequences
+
+**긍정:**
+- bulk close/reopen/active 가 editor 에게 노출, 단일 row PR #73 와 parity.
+- soft-delete 루프홀 service-layer 에서 차단 (trigger 비의존 land 가능).
+- partial-commit 의 cross-workspace 시멘틱이 `successCount` 로 자연 표현.
+
+**부담/위험:**
+- 호출자 owner 가 아닌 경우 per-id `loadAndVerifyMutateAccess` 가 N RPC 까지 발생. 완화: `Promise.all` 병렬 + workspace_id 별 `is_workspace_member` 캐싱 (distinct workspace 1회).
+- bulk cancel 이 본 hook 으로는 일시 불가 (모든 role). 단일 row delete 는 기존대로 가능 → UI 영향 없음.
+
+**Blocking on:** Land 차원 없음. status 전이 trigger 는 별도 dispatch 로 이미 작성/검증 완료 (production apply 별건 승인).
+
+## Alternatives Considered
+
+**Option A — owner-only 유지 (현 상태).** 거부: 단일 row PR #73 와 UX 비일관, editor 가 bulk 차단됨, `jp_update_workspace_member` 의도와 어긋남.
+
+**Option B — 모든 status 멤버 호환 (cancel 포함).** 거부: trigger 가 land 안 되면 member→cancelled UPDATE 경로가 `jp_delete_workspace_owner` 의도를 우회. 본 PR 을 trigger 작업과 강결합. trigger land 후 Phase 2 로 재고려.
+
+## Follow-up Tasks (별도 PR)
+
+1. **Service refactor (PR-A)** — `bulkUpdateJobPostingStatus` 에 `status === 'cancelled'` reject guard 추가. repository `bulkUpdateStatus` 를 `.eq('owner_id', ...)` 에서 per-id `loadAndVerifyMutateAccess` (parallel) + `owner_id` 필터 제거 multi-row UPDATE 로 전환. workspace_id 그룹화로 멤버십 캐시 보존.
+2. **Unit tests** — owner | member | admin | outsider × close | reopen | active | cancelled = 16 케이스 + cross-workspace partial-commit + atomicity (USING fail row 1 + pass row 1 → `successCount=1`).
+3. **Bulk UI 통합 (PR-B)** — `app/(employer)/my-postings/index.tsx` 멀티셀렉트 + 액션바 (마감/재오픈/활성화). cancel 버튼은 Phase 2 까지 미포함.
+4. **Dogfooding** — WS-1 owner + invited editor 로 editor 의 bulk close 3건 통과 확인. cancel 버튼 부재/disabled 확인.
+5. **Phase 2 (post-trigger)** — trigger land 후 bulk cancel 을 `loadAndVerifyDeleteAccess` 로 재오픈, owner|admin cancel 테스트 추가, service-layer status-cancelled guard 제거 또는 defense-in-depth 유지 여부 재결정.
+
+## Cross-references
+
+- PR #73 (commit `4383e8ee9`) — 단일 row helper 분리
+- PR #74 (commit `2e4019db9`) — audit 로드맵 (PR3-E placeholder)
+- `uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts:139-203` — `loadAndVerifyMutateAccess` / `loadAndVerifyDeleteAccess`
+- `uniqn-mobile/supabase/migrations/20260514010000_workspace_m3_consolidate_jp_rls.sql` — 현재 `jp_*` RLS
+- `uniqn-mobile/supabase/migrations/20260514050000_enforce_jp_status_transition.sql` — status 전이 trigger (Phase 2 의 DB defense)

--- a/uniqn-mobile/src/components/home/EmployerDashboard.tsx
+++ b/uniqn-mobile/src/components/home/EmployerDashboard.tsx
@@ -4,6 +4,7 @@ import { WeeklyStaffWidget } from '@/components/home/widgets/WeeklyStaffWidget';
 import { PostingOverviewWidget } from '@/components/home/widgets/PostingOverviewWidget';
 import { CancellationWidget } from '@/components/home/widgets/CancellationWidget';
 import { RecentNoticesWidget } from '@/components/home/widgets/RecentNoticesWidget';
+import { SettlementSummaryWidget } from '@/components/home/widgets/SettlementSummaryWidget';
 
 interface EmployerDashboardProps {
   bottomPadding?: number;
@@ -14,6 +15,7 @@ export function EmployerDashboard({ bottomPadding = 0 }: EmployerDashboardProps)
     <ScrollView contentContainerStyle={{ paddingBottom: 16 + bottomPadding }}>
       <PostingOverviewWidget />
       <WeeklyStaffWidget />
+      <SettlementSummaryWidget />
       <CancellationWidget />
       <RecentNoticesWidget />
     </ScrollView>

--- a/uniqn-mobile/src/components/home/StaffDashboard.tsx
+++ b/uniqn-mobile/src/components/home/StaffDashboard.tsx
@@ -3,6 +3,7 @@ import { ScrollView } from 'react-native';
 import { NextWorkWidget } from '@/components/home/widgets/NextWorkWidget';
 import { ApplicationStatusWidget } from '@/components/home/widgets/ApplicationStatusWidget';
 import { MonthSummaryWidget } from '@/components/home/widgets/MonthSummaryWidget';
+import { MonthlyPayrollWidget } from '@/components/home/widgets/MonthlyPayrollWidget';
 import { RecentNoticesWidget } from '@/components/home/widgets/RecentNoticesWidget';
 
 interface StaffDashboardProps {
@@ -15,6 +16,7 @@ export function StaffDashboard({ bottomPadding = 0 }: StaffDashboardProps) {
       <NextWorkWidget />
       <ApplicationStatusWidget />
       <MonthSummaryWidget />
+      <MonthlyPayrollWidget />
       <RecentNoticesWidget />
     </ScrollView>
   );

--- a/uniqn-mobile/src/components/home/__tests__/EmployerDashboard.test.tsx
+++ b/uniqn-mobile/src/components/home/__tests__/EmployerDashboard.test.tsx
@@ -30,13 +30,21 @@ jest.mock('@/components/home/widgets/RecentNoticesWidget', () => ({
   },
 }));
 
+jest.mock('@/components/home/widgets/SettlementSummaryWidget', () => ({
+  SettlementSummaryWidget: () => {
+    const { View } = jest.requireActual('react-native') as typeof import('react-native');
+    return <View testID="settlement-summary-widget" />;
+  },
+}));
+
 describe('EmployerDashboard', () => {
-  it('4개 위젯이 모두 렌더된다', () => {
+  it('5개 위젯이 모두 렌더된다', () => {
     const { getByTestId } = render(<EmployerDashboard />);
     expect(getByTestId('weekly-staff-widget')).toBeTruthy();
     expect(getByTestId('posting-overview-widget')).toBeTruthy();
     expect(getByTestId('cancellation-widget')).toBeTruthy();
     expect(getByTestId('recent-notices-widget')).toBeTruthy();
+    expect(getByTestId('settlement-summary-widget')).toBeTruthy();
   });
 
   it('ScrollView로 래핑되어 있다', () => {

--- a/uniqn-mobile/src/components/home/__tests__/StaffDashboard.test.tsx
+++ b/uniqn-mobile/src/components/home/__tests__/StaffDashboard.test.tsx
@@ -30,13 +30,21 @@ jest.mock('@/components/home/widgets/RecentNoticesWidget', () => ({
   },
 }));
 
+jest.mock('@/components/home/widgets/MonthlyPayrollWidget', () => ({
+  MonthlyPayrollWidget: () => {
+    const { View } = jest.requireActual('react-native') as typeof import('react-native');
+    return <View testID="monthly-payroll-widget" />;
+  },
+}));
+
 describe('StaffDashboard', () => {
-  it('4개 위젯이 모두 렌더된다', () => {
+  it('5개 위젯이 모두 렌더된다', () => {
     const { getByTestId } = render(<StaffDashboard />);
     expect(getByTestId('next-work-widget')).toBeTruthy();
     expect(getByTestId('application-status-widget')).toBeTruthy();
     expect(getByTestId('month-summary-widget')).toBeTruthy();
     expect(getByTestId('recent-notices-widget')).toBeTruthy();
+    expect(getByTestId('monthly-payroll-widget')).toBeTruthy();
   });
 
   it('ScrollView로 래핑되어 있다', () => {

--- a/uniqn-mobile/src/components/home/widgets/MonthlyPayrollWidget.tsx
+++ b/uniqn-mobile/src/components/home/widgets/MonthlyPayrollWidget.tsx
@@ -1,0 +1,88 @@
+/**
+ * MonthlyPayrollWidget
+ * 스태프 월별 정산(급여) 위젯 (Phase 2A.후속 PR3-B 통합).
+ *
+ * useMonthlyPayroll(year, month) — useActiveWorkspace 의존. Staff 가 여러 workspace
+ * 에서 근무하면 active workspace 별로 분리. queryKey 에 workspaceId 포함되어
+ * workspace 스위치 시 자동 refetch (PR #71 ghost cache 회귀 방지).
+ *
+ * MonthSummaryWidget 은 schedule 기반 "확정/근무시간/예상 수령액" 요약, 본 위젯은
+ * work_log 기반 "정산 완료/미정산 금액" 분리 — 보완 관계.
+ */
+import React, { useMemo } from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { router } from 'expo-router';
+import { DashboardWidgetShell } from '@/components/home/DashboardWidgetShell';
+import { NumericText } from '@/components/ui';
+import { useMonthlyPayroll } from '@/hooks/useWorkLogs';
+// canonical currency 배럴 직접 참조 (impeccable v2 §19, "₩N" 포맷)
+import { formatCurrency } from '@/utils/formatters/currency';
+
+export function MonthlyPayrollWidget() {
+  // 현재 달 기준 — 매 렌더 동일 month 유지하도록 useMemo
+  const { year, month } = useMemo(() => {
+    const now = new Date();
+    return { year: now.getFullYear(), month: now.getMonth() + 1 };
+  }, []);
+
+  const { payroll, isLoading, error, refetch } = useMonthlyPayroll(year, month);
+
+  const totalAmount = payroll?.totalAmount ?? 0;
+  const pendingAmount = payroll?.pendingAmount ?? 0;
+  const completedAmount = payroll?.completedAmount ?? 0;
+  const workLogCount = payroll?.workLogs?.length ?? 0;
+
+  const hasData = payroll !== undefined && payroll !== null && workLogCount > 0;
+  const accessibilityLabel = hasData
+    ? `이번 달 급여, 합계 ${totalAmount}원, 미정산 ${pendingAmount}원, 정산 완료 ${completedAmount}원, 근무 ${workLogCount}건`
+    : '이번 달 급여';
+
+  return (
+    <DashboardWidgetShell
+      variant="section"
+      title={`${month}월 정산`}
+      isLoading={isLoading}
+      error={error instanceof Error ? error : null}
+      onRetry={refetch}
+      emptyState={!hasData ? { message: `${month}월 근무 기록이 없습니다` } : undefined}
+      action={
+        <Pressable
+          onPress={() => router.push('/(app)/(tabs)/schedule')}
+          accessibilityRole="button"
+          accessibilityLabel="스케줄에서 상세 보기"
+          hitSlop={8}
+        >
+          <Text className="text-primary-500 text-[10px] font-sans-bold">상세 →</Text>
+        </Pressable>
+      }
+    >
+      {hasData ? (
+        <View accessibilityLabel={accessibilityLabel}>
+          <View className="flex-row justify-between items-end">
+            <View>
+              <NumericText
+                className="text-3xl font-sans-bold text-primary-500"
+                style={{ letterSpacing: -0.6 }}
+              >
+                {formatCurrency(totalAmount)}
+              </NumericText>
+              <Text className="text-[10px] uppercase tracking-wider text-content-muted mt-1">
+                {month}월 합계
+              </Text>
+            </View>
+            <View className="items-end">
+              <NumericText className="text-base font-sans-bold text-content-primary dark:text-content-primary">
+                {formatCurrency(pendingAmount)}
+              </NumericText>
+              <NumericText className="text-xs text-content-secondary dark:text-content-secondary">
+                미정산 · 완료 {formatCurrency(completedAmount)} · {workLogCount}건
+              </NumericText>
+            </View>
+          </View>
+        </View>
+      ) : undefined}
+    </DashboardWidgetShell>
+  );
+}
+
+export default MonthlyPayrollWidget;

--- a/uniqn-mobile/src/components/home/widgets/SettlementSummaryWidget.tsx
+++ b/uniqn-mobile/src/components/home/widgets/SettlementSummaryWidget.tsx
@@ -1,0 +1,85 @@
+/**
+ * SettlementSummaryWidget
+ * 고용주 정산 요약 위젯 (Phase 2A.후속 PR3-C 통합).
+ *
+ * useSettlementDashboard wrapper 사용 — useMySettlementSummary 가 useActiveWorkspace
+ * 의존이라 active workspace 스위치 시 query key 자동 invalidation (PR #71 ghost cache
+ * 회귀 방지). 다중 workspace employer/admin 이 workspace 별로 정산을 분리해 본다.
+ *
+ * Black & Gold 토큰 + dark: 페어, accessibilityLabel + 44px touch target.
+ */
+import React from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { router } from 'expo-router';
+import { DashboardWidgetShell } from '@/components/home/DashboardWidgetShell';
+import { NumericText } from '@/components/ui';
+import { useSettlementDashboard } from '@/hooks/useSettlement';
+// `@/utils/formatters` flat 파일은 레거시 "N원" 포맷이라 canonical currency 서브패스 직접 참조.
+import { formatCurrency } from '@/utils/formatters/currency';
+
+export function SettlementSummaryWidget() {
+  const {
+    summary,
+    isLoading,
+    error,
+    refresh,
+    totalJobPostings,
+    totalWorkLogs,
+    totalPendingAmount,
+    totalCompletedAmount,
+  } = useSettlementDashboard();
+
+  const hasData = summary !== undefined && summary !== null && totalWorkLogs > 0;
+  const accessibilityLabel = hasData
+    ? `정산 요약, 미정산 ${totalPendingAmount}원, 정산 완료 ${totalCompletedAmount}원, 공고 ${totalJobPostings}건, 근무 ${totalWorkLogs}건`
+    : '정산 요약';
+
+  return (
+    <DashboardWidgetShell
+      variant="section"
+      title="정산 요약"
+      isLoading={isLoading}
+      error={error instanceof Error ? error : null}
+      onRetry={refresh}
+      emptyState={!hasData ? { message: '정산 대상 근무 기록이 없습니다' } : undefined}
+      action={
+        <Pressable
+          onPress={() => router.push('/(app)/(tabs)/employer')}
+          accessibilityRole="button"
+          accessibilityLabel="공고별 정산 보기"
+          hitSlop={8}
+        >
+          <Text className="text-primary-500 text-[10px] font-sans-bold">상세 →</Text>
+        </Pressable>
+      }
+    >
+      {hasData ? (
+        <View accessibilityLabel={accessibilityLabel}>
+          <View className="flex-row justify-between items-end">
+            <View>
+              <NumericText
+                className="text-3xl font-sans-bold text-primary-500"
+                style={{ letterSpacing: -0.6 }}
+              >
+                {formatCurrency(totalPendingAmount)}
+              </NumericText>
+              <Text className="text-[10px] uppercase tracking-wider text-content-muted mt-1">
+                미정산 잔액
+              </Text>
+            </View>
+            <View className="items-end">
+              <NumericText className="text-base font-sans-bold text-content-primary dark:text-content-primary">
+                {formatCurrency(totalCompletedAmount)}
+              </NumericText>
+              <NumericText className="text-xs text-content-secondary dark:text-content-secondary">
+                정산 완료 · 공고 {totalJobPostings}건 · 근무 {totalWorkLogs}건
+              </NumericText>
+            </View>
+          </View>
+        </View>
+      ) : undefined}
+    </DashboardWidgetShell>
+  );
+}
+
+export default SettlementSummaryWidget;

--- a/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
@@ -179,9 +179,9 @@ async function loadAndVerifyMutateAccess(
  * 소유자와 공고 소유자가 일치하는 일반 케이스 모두 통과. member 는 거절(soft-delete
  * 도 거부).
  *
- * 알려진 갭(out-of-scope): 본 클라이언트가 UPDATE status=cancelled (soft-delete) 를
- * 쓰므로 RLS 는 jp_update_workspace_member 를 평가 → API 직접 호출 시 member 가 우회
- * 가능. DB-level enforcement 는 별도 status 전이 trigger/함수로 강화 필요.
+ * DB-level 보강 (2026-05-10, migration 20260514050000): trg_enforce_jp_status_transition
+ * BEFORE UPDATE trigger 가 active|closed → cancelled 전이를 workspace owner|admin 만
+ * 통과시키도록 차단한다. 본 클라이언트 가드는 즉시 UX 차단 (double defense) 으로 유지.
  */
 async function loadAndVerifyDeleteAccess(
   jobPostingId: string,

--- a/uniqn-mobile/supabase/migrations/20260514050000_enforce_jp_status_transition.sql
+++ b/uniqn-mobile/supabase/migrations/20260514050000_enforce_jp_status_transition.sql
@@ -1,0 +1,101 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Phase 2A.후속 — job_postings status 전이 trigger (RLS gap 보강)
+--
+-- Why
+--   기존 RLS jp_update_workspace_member 는 (workspace member|admin) 에게 일반
+--   UPDATE 권한을 부여한다. 하지만 client 측 deletePosting 은 soft-delete 형태로
+--   UPDATE status='cancelled' 을 사용하므로, member (editor) 가 PostgREST API 를
+--   직접 호출하면 jp_delete_workspace_owner (owner|admin) 가 아닌
+--   jp_update_workspace_member (member|admin) 가 평가되어 권한 우회가 가능하다.
+--   client 측 loadAndVerifyDeleteAccess (JobPostingRepository.ts:186) 는 즉시
+--   UX 차단만 제공할 뿐 API 직접 호출 갭은 차단하지 못한다.
+--
+-- What
+--   active|closed → cancelled 전이를 BEFORE UPDATE trigger 에서 가로채어
+--   (1) workspace 소유자 또는 (2) admin 만 통과시킨다. 그 외 transition
+--   (active↔closed, draft→cancelled 등) 은 기존 RLS 정책에 위임한다.
+--
+--   service-side (no JWT — cron, SECURITY DEFINER RPC, 시드/마이그레이션) 는
+--   bypass 한다 (auth.uid() IS NULL 분기). 기존 fn_fixed_posting_expired
+--   (active → closed) 은 cancelled 가 아니므로 영향 없음.
+--
+-- Verification (production DB, dry-run with rollback, 2026-05-10)
+--   10 시나리오 통과:
+--   S1  member active→cancelled                      → BLOCKED 42501  ✅
+--   S2  workspace-owner active→cancelled             → ALLOWED        ✅
+--   S3  admin (own workspace) active→cancelled       → ALLOWED        ✅
+--   S4  member active→closed (regression)            → ALLOWED        ✅
+--   S5  member closed→cancelled                      → BLOCKED 42501  ✅
+--   S6  member draft→cancelled (not guarded)         → ALLOWED        ✅
+--   S7a member bulk→cancelled                        → BLOCKED 42501  ✅
+--   S7b bulk rollback integrity (cancelled count=0)  → 0 rows         ✅
+--   S8  workspace-owner cancelled→active (reverse)   → ALLOWED        ✅
+--   S10 service-side (no JWT) active→cancelled       → ALLOWED        ✅
+--
+-- Out of scope (별도 PR)
+--   • RLS jp_update_workspace_member 의 (SELECT is_admin()) 서브쿼리 평가가
+--     PostgREST UPDATE 경로에서 admin (non-workspace-owner) 를 차단하는 quirk.
+--     이 trigger 와 무관하며, 기존 admin-not-workspace-member 사용 사례가 적어
+--     운영 영향 미미. /cso 후속 감사 권장.
+--   • bulkUpdateStatus owner-only 전환 결정 (프롬프트 3): 보수적 가정으로
+--     active|closed→cancelled bulk 도 본 trigger 가 row-by-row 차단.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.enforce_jp_status_transition()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO 'public', 'pg_temp'
+AS $func$
+DECLARE
+  v_caller_uid uuid;
+  v_is_workspace_owner boolean;
+  v_is_admin boolean;
+BEGIN
+  -- 보호 대상: active|closed → cancelled (soft-delete 경로)
+  IF NEW.status = 'cancelled' AND OLD.status IN ('active', 'closed') THEN
+    v_caller_uid := (SELECT auth.uid());
+
+    -- service-side bypass: 시드/마이그레이션/cron/SECURITY DEFINER RPC
+    IF v_caller_uid IS NULL THEN
+      RETURN NEW;
+    END IF;
+
+    SELECT EXISTS (
+      SELECT 1 FROM public.workspaces
+      WHERE id = NEW.workspace_id AND owner_id = v_caller_uid
+    ) INTO v_is_workspace_owner;
+
+    -- 메모리 룰: app role 식별은 auth.jwt() -> 'app_metadata' ->> 'role' 사용
+    -- ('role' top-level 은 PostgREST 의 db role 이라 절대 사용 금지)
+    v_is_admin := coalesce(
+      (auth.jwt() -> 'app_metadata' ->> 'role') = 'admin',
+      false
+    );
+
+    IF NOT (v_is_workspace_owner OR v_is_admin) THEN
+      RAISE EXCEPTION
+        'permission denied: only workspace owner or admin can cancel job posting (id=%)',
+        NEW.id
+        USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$func$;
+
+COMMENT ON FUNCTION public.enforce_jp_status_transition() IS
+  'BEFORE UPDATE trigger 로 active|closed → cancelled 전이를 workspace owner|admin 만 통과시킨다. RLS jp_update_workspace_member 의 soft-delete 우회 갭을 DB-level 에서 차단. service-side (no JWT) bypass.';
+
+DROP TRIGGER IF EXISTS trg_enforce_jp_status_transition ON public.job_postings;
+
+CREATE TRIGGER trg_enforce_jp_status_transition
+  BEFORE UPDATE OF status ON public.job_postings
+  FOR EACH ROW
+  WHEN (NEW.status IS DISTINCT FROM OLD.status)
+  EXECUTE FUNCTION public.enforce_jp_status_transition();
+
+-- 실행 권한: SECURITY DEFINER 라 호출 권한만 필요
+REVOKE ALL ON FUNCTION public.enforce_jp_status_transition() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.enforce_jp_status_transition() TO authenticated, service_role;


### PR DESCRIPTION
## Summary

- **jp status 전이 trigger** — `active|closed → cancelled` 전이를 BEFORE UPDATE trigger 로 가로채어 workspace owner 또는 admin 만 통과. PR #73 가 명시한 known gap (client UPDATE status='cancelled' 가 jp_update_workspace_member 에서 member 통과되는 우회) 을 DB-level 에서 차단. service-side bypass 포함.
- **정산 요약 / 월별 정산 widget** — PR #77 (useSettlementDashboard) / PR #79 (useMonthlyPayroll) 가 시그니처만 분리하고 deferred 한 hook 을 employer/staff 홈 dashboard 에 실제 노출. workspace 스위치 시 자동 refetch (ghost cache 가드).
- **bulkUpdateStatus 권한 모델 ADR** — Option C 채택. close/reopen/active 는 멤버 호환, cancel 은 owner|admin (trigger 가 DB defense). 현재 useBulkUpdateStatus TSX consumer 0건 → semantic PR 단독 land 가능.

## Verification

- **Quality**: typecheck PASS / lint 0 errors (10 pre-existing warnings) / format PASS
- **Tests**: 273 suites · 4042 tests pass
- **Production migration**: 2026-05-10 production DB BEGIN/ROLLBACK dry-run 10/10 시나리오 통과 → 2026-05-11 apply_migration 적용 + trigger/function 존재 검증

## Test plan

- [ ] review-employer 로그인 → 홈에 "정산 요약" widget 표시 (미정산/완료 금액 + 공고/근무 건수)
- [ ] review-admin 동일 시나리오
- [ ] review-staff 로그인 → 홈에 "이번달 정산" widget 표시 (work_log 기반 미정산/완료)
- [ ] WorkspaceContextBar 에서 workspace 스위치 시 두 widget 자동 갱신 (이전 workspace 잔상 없음)
- [ ] 모든 화면 콘솔 0 errors
- [ ] (보안) member (editor) 자격으로 PostgREST UPDATE status='cancelled' 직접 호출 → 42501 RAISE 차단 확인

## Follow-ups

- Service refactor — bulkUpdateJobPostingStatus 에 cancel reject 가드 + per-id loadAndVerifyMutateAccess 전환 (ADR 결정 기반)
- /cso 후속 — jp_update_workspace_member (SELECT is_admin()) PostgREST UPDATE quirk 감사

🤖 Generated with [Claude Code](https://claude.com/claude-code)