### PR TITLE
feat: 공고별 협업자 공유 (job_posting_collaborators)

### DIFF
--- a/docs/superpowers/plans/2026-05-11-job-posting-collaborators.md
+++ b/docs/superpowers/plans/2026-05-11-job-posting-collaborators.md
@@ -1695,22 +1695,113 @@ Expected: type-check 0 errors, lint clean, format clean.
 
 ---
 
-## § Audit Results (Phase 0 산출물)
+## § Audit Results (Phase 0 산출물 — 2026-05-12)
 
-> Phase 0 완료 시 채워짐. 비어있으면 Phase 1 시작 금지.
+> MCP `execute_sql` audit 완료. **prod DB** 기준.
 
-```
-[FK 참조 테이블 (Task 0.1)]
-- (Phase 0 후 채울 것)
+### Task 0.1 — FK 참조 테이블 inventory
 
-[권한 호출면 (Task 0.2)]
-- pg_proc:    (Phase 0 후 채울 것)
-- pg_views:   (Phase 0 후 채울 것)
-- repository: (Phase 0 후 채울 것)
+`pg_constraint` 조회 결과 — `public.job_postings` 를 FK 로 참조하는 테이블 **7개**:
 
-[PR3-A.2 충돌 (Task 0.3)]
-- (Phase 0 후 채울 것)
-```
+| referencing_table | column | on_delete | RLS workspace 의존 |
+|---|---|---|---|
+| `applications` | `job_posting_id` | NO ACTION | ✅ `app_select`/`app_update` (is_workspace_member) |
+| `board_memberships` | `job_posting_id` | NO ACTION | ❌ user_id scope only |
+| `board_posts` | `linked_job_posting_id` | NO ACTION | ❌ author/visibility scope only |
+| `event_qr_codes` | `job_posting_id` | NO ACTION | ✅ `qr_select`/`qr_update`/`qr_delete` (is_workspace_member) |
+| `reports` | `job_posting_id` | NO ACTION | ❌ reporter/admin scope only |
+| `reviews` | `job_posting_id` | NO ACTION | ❌ reviewer/reviewee/admin scope only |
+| `work_logs` | `job_posting_id` | NO ACTION | ✅ `wl_select`/`wl_update` (is_workspace_member) |
+
+**Phase 2 RLS OR 추가 대상 (workspace 의존 3 테이블 + jp 자체 + workspaces)**:
+- `job_postings` (jp_select_managed, jp_update_workspace_member)
+- `applications` (app_select, app_update)
+- `event_qr_codes` (qr_select, qr_update, qr_delete) — **Spec 누락! 추가 필요**
+- `work_logs` (wl_select, wl_update)
+- `workspaces` (workspaces_select_owner_or_member — useSharedJobPostings JOIN 용)
+
+**Phase 2 OR 추가 제외 (user-scope RLS — collaborator 권한과 무관)**:
+- `board_memberships`, `board_posts` (게시판은 공고 종속이 아닌 일반 컨텐츠)
+- `reports`, `reviews` (당사자 SoT — collaborator 가 자기 공고 신고/리뷰 조회 권한 없음, 의도된 격리)
+
+**⚠ Spec D2 가정 보정 필요**:
+- `staff_assignments` — **테이블 미존재** (spec 추정 오류, applications + work_logs 가 스태프 모델 대체)
+- `settlements` — **테이블 미존재** (work_logs.payroll_* 필드에 정산 데이터 저장. SettlementRepository.ts:13 명시. work_logs RLS OR 추가로 정산 권한 자동 부여)
+- D2 "스태프/work_logs/settlements" → 실제는 "applications + work_logs + event_qr_codes" 만 해당
+
+**⚠ on_delete=NO ACTION 영향**:
+- 공고 삭제 시 cascade 안 됨 — 의도된 정책 (공고가 응시 이력/리뷰를 끌고 가지 않음)
+- `job_posting_collaborators` 본 테이블은 spec 대로 `ON DELETE CASCADE` 유지
+
+### Task 0.2 — 권한 호출면 audit
+
+**pg_proc (2건)**:
+
+| function_name | uses | 영향 |
+|---|---|---|
+| `public.enforce_jp_status_transition` | inline owner check (function 미사용) | ⚠ collaborator status 변경 권한 검증 필요 |
+| `public.get_workspace_owner_profile` | calls `is_workspace_member` | ✅ 조회만, collaborator 안 봐도 됨 |
+
+**`enforce_jp_status_transition` 상세 분석 필요** — collaborator 가 공고 status (open/closed) 변경 가능해야 한다면 (D2 풀 관리권), 이 trigger function 안에서도 OR 추가 또는 collaborator 식별 분기 필요. **Phase 2 별도 task 로 분리**.
+
+**pg_views**: 0건 (workspace_id/is_workspace_member 호출 view 없음)
+
+**Client repository workspace_id 명시 필터 (7곳)**:
+- `src/repositories/supabase/JobPostingRepository.ts:397` — `if (workspaceId) query = query.eq('workspace_id', workspaceId)` ⚠ collaborator 시점에 workspaceId 미지정으로 호출 (useSharedJobPostings 별도 hook 사용)
+- `src/repositories/supabase/WorkLogRepository.ts`
+- `src/repositories/supabase/SettlementRepository.ts` ✅ (소스 확인 — `work_logs.payroll_*` 필드만 사용, 별도 `settlements` 테이블 없음. work_logs RLS OR 추가로 자동 적용됨)
+- `src/repositories/supabase/WorkspaceRepository.ts`
+- `src/repositories/supabase/WorkspaceMemberRepository.ts`
+- `src/repositories/supabase/WorkspaceInvitationRepository.ts`
+- `src/repositories/supabase/ApplicationRepositoryHelpers.ts`
+
+**Hooks (3건)**:
+- `src/hooks/workspace/useWorkspaces.ts`
+- `src/hooks/workspace/useWorkspaceRevocationGuard.ts`
+- 동 test 1건
+
+→ collaborator 시점에서 본인 workspace 컨텍스트 안에서만 조회되도록 useSharedJobPostings 가 명시적 우회 hook 으로 동작 (spec 설계대로). 기존 hook/repo 는 변경 불필요.
+
+### Task 0.3 — PR3-A.2 충돌 체크
+
+`git show 59b6a8d9b` (머지 완료, master):
+
+**PR3-A.2 변경분**:
+- 제거: `app_update`, `qr_update`, `qr_delete`, `wl_update` 의 admin 분기 4건
+- 추가: `workspace_members` deny-all 정책 2건
+- 변경: `JobPostingRepository.loadAndVerifyMutateAccess` admin 분기 throw
+
+**본 plan Phase 2 OR 추가 대상과 비교**:
+- `app_update`: PR3-A.2 admin 제거 → 본 작업 collaborator OR 추가 (**비충돌 — 다른 분기**)
+- `qr_update/qr_delete`: PR3-A.2 admin 제거 → 본 작업 collaborator OR 추가 (**비충돌**)
+- `wl_update`: PR3-A.2 admin 제거 → 본 작업 collaborator OR 추가 (**비충돌**)
+- `app_select`, `qr_select`, `wl_select`, `jp_select_managed`, `jp_update_workspace_member`, `workspaces_select_owner_or_member`: PR3-A.2 미변경 → 본 작업만 변경 (**비충돌**)
+
+**결론**: PR3-A.2 와 본 작업은 정책 분기가 서로 직교 (admin 제거 vs collaborator OR 추가). 마이그레이션 순서 의존성 없음.
+
+### 추가 발견 — Realtime publication 현황
+
+`pg_publication_tables` (supabase_realtime, 2026-05-12):
+- 포함: `applications`, `board_comments`, `board_posts`, `notification_counters`, `notifications`, `work_logs`, `workspace_members`
+- 미포함: `workspaces`, `job_postings`, `event_qr_codes` 등
+
+**Phase 4 작업** — `ALTER PUBLICATION supabase_realtime ADD TABLE public.job_posting_collaborators` 만 추가 (workspaces / job_postings 변경은 본 작업 범위 외).
+
+### Audit 결론 — Phase 2 변경 대상 확정
+
+| 테이블 | 변경 정책 | 비고 |
+|---|---|---|
+| workspaces | `workspaces_select_owner_or_member` | useSharedJobPostings JOIN |
+| job_postings | `jp_select_managed`, `jp_update_workspace_member` | D2 풀 관리권 |
+| applications | `app_select`, `app_update` | 지원자 보기/승인 |
+| work_logs | `wl_select`, `wl_update` | 근태 조회/편집 |
+| event_qr_codes | `qr_select`, `qr_update`, `qr_delete` | **Spec 누락 — 추가** |
+| (function) `enforce_jp_status_transition` | inline owner OR collaborator | **별도 task 로 분리 필요** |
+
+**Spec/Plan 보정 필요 항목** (Option 3 task 4):
+1. D2 의 "스태프/settlements" 표현 명확화 (settlements = work_logs.payroll 필드, 별도 테이블 아님)
+2. event_qr_codes 추가 (Phase 2 누락)
+3. enforce_jp_status_transition 변경 task 신설
 
 ## § Performance Results (Task 10.4 산출물)
 

--- a/docs/superpowers/plans/2026-05-11-job-posting-collaborators.md
+++ b/docs/superpowers/plans/2026-05-11-job-posting-collaborators.md
@@ -445,36 +445,43 @@ git commit -m "test(supabase): job_posting_collaborators 자체 RLS pg_prove 16 
 
 ---
 
-## Phase 2: 기존 RLS 정책 OR 확장
+## Phase 2: 기존 RLS 정책 OR 확장 — Phase 0 audit 확정
 
-영향 받는 테이블은 **Phase 0 audit 결과**로 확정. 아래는 spec 의 baseline.
+영향 받는 테이블 **5개 / 12 정책 + 1 trigger function** (Phase 0 audit 2026-05-12).
 
-### Task 2.1: `job_postings` SELECT/UPDATE OR
+### Task 2.1: `job_postings` SELECT/UPDATE OR — audit 확정 정책명
 
 **Files:**
-- Create: `supabase/migrations/<timestamp>_jpc_extend_existing_rls.sql`
+- Create: `uniqn-mobile/supabase/migrations/<timestamp>_jpc_extend_existing_rls.sql`
 
-- [ ] **Step 1: 기존 정책 DROP + 재생성 (OR 추가)**
+- [ ] **Step 1: 기존 정책 DROP + 재생성 (audit 확정 이름: `jp_select_managed`, `jp_update_workspace_member`)**
 
 ```sql
--- 기존 정책 이름은 supabase/migrations/20260514010000_workspace_m3_consolidate_jp_rls.sql 참조
-DROP POLICY IF EXISTS "jp_select_ws_member"   ON public.job_postings;
-DROP POLICY IF EXISTS "jp_update_ws_member"   ON public.job_postings;
+-- audit ref: 20260514010000_workspace_m3_consolidate_jp_rls.sql
+DROP POLICY IF EXISTS "jp_select_managed"           ON public.job_postings;
+DROP POLICY IF EXISTS "jp_update_workspace_member"  ON public.job_postings;
 
-CREATE POLICY "jp_select_ws_or_collab"
+CREATE POLICY "jp_select_managed"
   ON public.job_postings FOR SELECT
   USING (
-    public.is_workspace_member(workspace_id, auth.uid())
-    OR public.is_posting_collaborator(id, auth.uid())
+    (owner_id = (SELECT auth.uid()))
+    OR public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+    OR public.is_posting_collaborator(id, (SELECT auth.uid()))
   );
 
-CREATE POLICY "jp_update_ws_or_collab"
+CREATE POLICY "jp_update_workspace_member"
   ON public.job_postings FOR UPDATE
   USING (
-    public.is_workspace_member(workspace_id, auth.uid())
-    OR public.is_posting_collaborator(id, auth.uid())
+    public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+    OR public.is_posting_collaborator(id, (SELECT auth.uid()))
+    OR (SELECT public.is_admin())
+  )
+  WITH CHECK (
+    public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+    OR public.is_posting_collaborator(id, (SELECT auth.uid()))
+    OR (SELECT public.is_admin())
   );
--- DELETE 정책은 변경 없음 (owner 전용 유지)
+-- jp_delete_workspace_owner (owner-only) 변경 없음
 ```
 
 ### Task 2.2: `workspaces` SELECT OR (Codex fix)
@@ -499,37 +506,109 @@ CREATE POLICY "ws_select_member_or_collab_source"
   );
 ```
 
-### Task 2.3~2.6: applications / staff_assignments / work_logs / settlements OR
+### Task 2.3~2.5: applications / work_logs / event_qr_codes OR — Phase 0 audit 확정
 
 **Files:**
 - Edit: 같은 마이그레이션 파일
 
-- [ ] **Step 1: 각 테이블 SELECT/UPDATE 정책 DROP + 재생성** (4 테이블 × 2 작업 = 8 정책)
+> **audit 결과 보정**: `staff_assignments` / `settlements` 테이블 미존재. 정산 = work_logs.payroll 필드. event_qr_codes 가 Spec 누락이라 추가됨.
 
-각 테이블 패턴 동일 — Phase 0 audit 결과로 정확한 정책명 확정. 예시:
+- [ ] **Step 1: 각 테이블의 audit 확정 정책 DROP + 재생성**
+
+| 테이블 | 변경 정책 | 비고 |
+|---|---|---|
+| `applications` | `app_select`, `app_update` | SELECT + UPDATE |
+| `work_logs` | `wl_select`, `wl_update` | 정산 자동 포함 (payroll 필드) |
+| `event_qr_codes` | `qr_select`, `qr_update`, `qr_delete` | 3 정책 — Spec 누락 보정 |
+
+각 테이블 패턴 동일. 예시 (applications):
 
 ```sql
-DROP POLICY IF EXISTS "applications_select_ws_member" ON public.applications;
-CREATE POLICY "applications_select_ws_or_collab"
+DROP POLICY IF EXISTS "app_select" ON public.applications;
+CREATE POLICY "app_select"
   ON public.applications FOR SELECT
   USING (
-    public.is_workspace_member(
-      (SELECT workspace_id FROM public.job_postings WHERE id = job_posting_id),
-      auth.uid()
-    )
-    OR public.is_posting_collaborator(job_posting_id, auth.uid())
+    (applicant_id = (SELECT auth.uid()))
+    OR (job_posting_id IN (
+      SELECT id FROM public.job_postings
+      WHERE owner_id = (SELECT auth.uid())
+        OR public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+        OR public.is_posting_collaborator(id, (SELECT auth.uid()))
+    ))
   );
--- UPDATE 동일 패턴
 ```
 
-→ work_logs / settlements / staff_assignments 도 동일.
+event_qr_codes 패턴 (3 정책 — qr_select / qr_update / qr_delete 모두 OR 추가):
+
+```sql
+DROP POLICY IF EXISTS "qr_select" ON public.event_qr_codes;
+CREATE POLICY "qr_select"
+  ON public.event_qr_codes FOR SELECT
+  USING (
+    (user_id = (SELECT auth.uid()))
+    OR (job_posting_id IN (
+      SELECT id FROM public.job_postings
+      WHERE owner_id = (SELECT auth.uid())
+        OR public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+        OR public.is_posting_collaborator(id, (SELECT auth.uid()))
+    ))
+  );
+-- qr_update, qr_delete 도 동일 패턴 (existing policy SQL 유지 + OR 추가)
+```
 
 - [ ] **Step 2: staging dry-run — 4 페르소나 시드 + 각 테이블 SELECT 실측**
 - [ ] **Step 3: prod apply + commit**
 
 ```bash
-git add supabase/migrations/<ts>_jpc_extend_existing_rls.sql
-git commit -m "feat(supabase): 5개 테이블 + workspaces RLS OR 확장 (collaborator 접근)"
+git add uniqn-mobile/supabase/migrations/<ts>_jpc_extend_existing_rls.sql
+git commit -m "feat(supabase): 4 테이블 + workspaces RLS OR 확장 (collaborator 접근)"
+```
+
+### Task 2.6: `enforce_jp_status_transition` trigger function — collaborator 분기 (Phase 0 audit 신규)
+
+**Files:**
+- Create: `uniqn-mobile/supabase/migrations/<ts>_jpc_status_transition_collab.sql`
+
+> **audit 발견**: 공고 status 변경 trigger 가 인라인 owner check 만 수행. D2 풀 관리권 결정으로 collaborator 도 status 변경 가능해야 함.
+
+- [ ] **Step 1: 기존 함수 재정의 (CREATE OR REPLACE)**
+
+```sql
+-- 20260514050000_enforce_jp_status_transition.sql 참조
+-- v_is_workspace_owner 분기에 collaborator OR 추가
+CREATE OR REPLACE FUNCTION public.enforce_jp_status_transition()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+  v_is_workspace_owner boolean;
+  v_is_admin           boolean;
+  v_is_collaborator    boolean;
+BEGIN
+  -- 기존 owner / admin 체크 유지
+  SELECT EXISTS(
+    SELECT 1 FROM public.workspaces
+    WHERE id = NEW.workspace_id AND owner_id = (SELECT auth.uid())
+  ) INTO v_is_workspace_owner;
+
+  v_is_admin := public.is_admin();
+  v_is_collaborator := public.is_posting_collaborator(NEW.id, (SELECT auth.uid()));
+
+  IF NOT (v_is_workspace_owner OR v_is_admin OR v_is_collaborator) THEN
+    RAISE EXCEPTION 'permission_denied: status change requires workspace owner, admin, or collaborator';
+  END IF;
+  -- ... 기존 status transition 검증 로직 유지
+  RETURN NEW;
+END;
+$$;
+```
+
+- [ ] **Step 2: staging dry-run — collaborator 페르소나가 status 변경 가능한지 검증**
+- [ ] **Step 3: prod apply + commit**
+
+```bash
+git add uniqn-mobile/supabase/migrations/<ts>_jpc_status_transition_collab.sql
+git commit -m "feat(supabase): enforce_jp_status_transition collaborator 분기 추가"
 ```
 
 ### Task 2.7: pg_prove RLS 매트릭스 테스트 (5 테이블 × 4 페르소나 × 4 작업 = 80 케이스)

--- a/docs/superpowers/specs/2026-05-11-job-posting-collaborators-design.md
+++ b/docs/superpowers/specs/2026-05-11-job-posting-collaborators-design.md
@@ -26,9 +26,14 @@
 
 워크스페이스 editor 는 기존 동작 유지(워크스페이스 모든 공고 자동 접근). 추가로 공고 단위로 외부 협업자를 지정 가능. 이중 구조이며 우선순위는 **OR** (둘 중 하나라도 만족하면 접근 허용).
 
-### D2: 협업자 권한 = 풀 관리권 (조회 + 수정 + 지원자 + 스태프 + work_logs + settlements)
+### D2: 협업자 권한 = 풀 관리권 (조회 + 수정 + 지원자 + work_logs + 정산 + QR)
 
 해당 공고의 운영 전반을 위임. **공고 삭제만 owner 전용** (워크스페이스 권한 경계 유지). 이는 "이 공고 운영을 통째로 맡긴다"는 시나리오 A 의 자연스러운 적용범위.
+
+**범위 명확화 (Phase 0 audit 2026-05-12 반영)**:
+- `staff_assignments` 테이블 미존재 — 스태프 데이터는 `applications` + `work_logs` 에 분산
+- `settlements` 테이블 미존재 — 정산은 `work_logs.payroll_*` 필드에 저장 (SettlementRepository 가 work_logs 직접 조작). work_logs RLS OR 추가로 정산 권한 자동 부여
+- QR 체크인은 `event_qr_codes` 테이블 (별도 RLS 필요)
 
 ### D3: 공유 대상 = 모든 UNIQN 가입자 (이메일로 검색)
 
@@ -194,23 +199,32 @@ export const AddCollaboratorInputSchema = z.object({
 
 DELETE 정책은 두 케이스 OR 로 단일 정책 작성. UPDATE 는 정책 없음 (행 immutable, 변경 시 DELETE+INSERT).
 
-### 영향 받는 기존 RLS 정책 (OR 추가)
+### 영향 받는 기존 RLS 정책 (OR 추가) — Phase 0 audit 2026-05-12 확정
 
-다음 테이블의 SELECT/UPDATE 정책에 `OR is_posting_collaborator(<해당 테이블의 job_posting_id>, auth.uid())` 추가 (헬퍼 함수는 아래 § 헬퍼 함수 섹션):
+다음 테이블의 정책에 `OR is_posting_collaborator(<해당 테이블의 job_posting_id>, auth.uid())` 추가 (헬퍼 함수는 아래 § 헬퍼 함수 섹션):
 
-- `job_postings` — `20260514010000_workspace_m3_consolidate_jp_rls.sql:14-21`
-- `applications`
-- `staff_assignments`
-- `work_logs` (D2 결정에 따라)
-- `settlements` (D2 결정에 따라)
-- 기타 공고 종속 테이블 (audit 단계에서 확정)
+| 테이블 | 정책 | 마이그레이션 ref |
+|---|---|---|
+| `job_postings` | `jp_select_managed`, `jp_update_workspace_member` | `20260514010000_workspace_m3_consolidate_jp_rls.sql:14-21` |
+| `applications` | `app_select`, `app_update` | `20260508150417_workspace_m4_applications_rls.sql` |
+| `work_logs` | `wl_select`, `wl_update` (정산은 payroll 필드) | `20260509000000_workspace_m4_work_logs_rls.sql` |
+| `event_qr_codes` | `qr_select`, `qr_update`, `qr_delete` | `20260509010000_workspace_m4_event_qr_codes_rls.sql` |
+| `workspaces` | `workspaces_select_owner_or_member` (useSharedJobPostings JOIN) | `20260430010400_workspace_rls_policies.sql` |
 
-### 영향 받는 `workspaces` SELECT RLS (Codex outside-voice 발견)
+**OR 추가 제외** (user-scope RLS — workspace 권한과 무관, audit 결과):
+- `board_memberships`, `board_posts` (게시판 = 일반 컨텐츠)
+- `reports`, `reviews` (당사자 SoT 격리)
 
-`useSharedJobPostings` 가 `JOIN workspaces` 로 출처 워크스페이스 이름 표시. Collaborator 는 workspace_member 가 아니므로 기본 RLS 에 차단됨 → **`workspaces` SELECT 정책에 OR 추가 필요**:
+### 영향 받는 trigger function — `enforce_jp_status_transition`
+
+`enforce_jp_status_transition` 은 공고 status 변경 시 (open ↔ closed) 권한 검증을 인라인 owner check 로 수행. D2 풀 관리권 결정에 따라 **collaborator 도 status 변경 가능해야 함** → 함수 내 권한 분기에 `is_posting_collaborator(NEW.id, auth.uid())` OR 추가 필요. Phase 2 별도 마이그레이션 task.
+
+### `workspaces` SELECT RLS 확장 패턴 (위 표 참조)
+
+`useSharedJobPostings` 가 `JOIN workspaces` 로 출처 워크스페이스 이름 표시. Collaborator 는 workspace_member 가 아니므로 기본 RLS 에 차단됨 → **`workspaces` SELECT 정책에 OR 추가**:
 
 ```sql
--- workspaces SELECT 정책
+-- workspaces_select_owner_or_member 정책
 USING (
   is_workspace_member(id, auth.uid())
   OR EXISTS(
@@ -521,14 +535,17 @@ last-write-wins (RN/Supabase 기본). MVP 에서 OT/CRDT 도입 안 함. 큰 충
 
 ## 마이그레이션 전략
 
-### 순서
+### 순서 (Phase 0 audit 2026-05-12 반영)
 
-1. **PR3-A.2 머지 대기** (필수)
-2. **Audit 단계** — 영향 받는 RLS / 알림 로직 / 의존 테이블 확정 (audit 결과 plan 문서에 기록)
-3. **마이그레이션 1**: `job_posting_collaborators` 테이블 + 헬퍼 함수 + 자체 RLS
-4. **마이그레이션 2**: 기존 RLS 정책 OR 추가 (job_postings, applications, staff_assignments, work_logs, settlements, ...)
-5. **마이그레이션 3**: trigger 추가 (notify_collaborator_added, notify_collaborator_removed) + 신규 지원자 알림 로직 확장
-6. **마이그레이션 4 (필요 시)**: 인덱스 최적화 (사용 패턴 보고)
+1. ~~**PR3-A.2 머지 대기**~~ — 완료 (commit `59b6a8d9b`, master)
+2. ~~**Audit 단계**~~ — 완료 (commit `37fcc06c7`, plan 의 § Audit Results 참조)
+3. **마이그레이션 1**: `job_posting_collaborators` 테이블 + `is_posting_collaborator` 헬퍼 + 자체 RLS
+4. **마이그레이션 2**: `job_posting_collaborator_audit` 테이블 + AFTER 트리거 (source 컬럼)
+5. **마이그레이션 3**: 기존 RLS 정책 OR 추가 (audit 결과 5 테이블 12 정책 — workspaces / job_postings / applications / work_logs / event_qr_codes)
+6. **마이그레이션 4**: `enforce_jp_status_transition` trigger function 에 collaborator 분기 추가 (status 변경 권한)
+7. **마이그레이션 5**: 알림 trigger (notify_collaborator_added/removed) + 신규 지원자 알림 수신자 UNION 확장 (`auth.uid() IS NULL` 가드)
+8. **마이그레이션 6**: `ALTER PUBLICATION supabase_realtime ADD TABLE public.job_posting_collaborators`
+9. **마이그레이션 7 (필요 시)**: 인덱스 최적화 (Phase 10 perf 측정 결과 보고)
 
 각 마이그레이션은 staging branch 에서 dry-run 검증 후 prod apply (메모리 학습 2026-05-10: plpgsql lazy 컴파일이 column mismatch 가림 → `SELECT * FROM rpc() LIMIT 0` 호출 검증 필수).
 

--- a/uniqn-mobile/app/(app)/(tabs)/employer.tsx
+++ b/uniqn-mobile/app/(app)/(tabs)/employer.tsx
@@ -10,7 +10,13 @@ import { EventQRModal } from '@/components/employer/qr/EventQRModal';
 import { JobPostingCard, NonEmployerView } from '@/components/employer';
 import { TabHeader } from '@/components/headers';
 import { WorkspaceContextBar } from '@/components/workspace';
-import { BriefcaseIcon, PlusIcon, UsersIcon } from '@/components/icons';
+import {
+  BriefcaseIcon,
+  ChevronRightIcon,
+  PlusIcon,
+  UserPlusIcon,
+  UsersIcon,
+} from '@/components/icons';
 import { getIconColor } from '@/constants';
 import { buildPostingFacts } from '@/domains/job-posting';
 import {
@@ -18,9 +24,11 @@ import {
   useMyJobPostings,
   useReopenJobPosting,
 } from '@/hooks/useJobManagement';
+import { useSharedJobPostings } from '@/hooks/job-posting/useSharedJobPostings';
 import { useHasRole } from '@/stores/authStore';
 import { useThemeStore } from '@/stores/themeStore';
 import type { JobPosting } from '@/types';
+import type { SharedJobPosting } from '@/types/jobPostingCollaborator';
 
 type FilterStatus = 'all' | 'active' | 'closed';
 
@@ -221,6 +229,12 @@ function EmployerView() {
     router.push('/(employer)/my-postings/create');
   }, []);
 
+  // 공유받은 공고 (collaborator 본인 시점)
+  const { sharedPostings } = useSharedJobPostings();
+  const handleSharedPostingPress = useCallback((shared: SharedJobPosting) => {
+    router.push(`/(employer)/my-postings/${shared.jobPostingId}`);
+  }, []);
+
   if (isLoading) {
     return (
       <SafeAreaView className="flex-1 bg-surface-page dark:bg-surface" edges={['top']}>
@@ -301,6 +315,39 @@ function EmployerView() {
       </View>
 
       <FilterTabs selected={filter} onChange={setFilter} counts={filterCounts} />
+
+      {sharedPostings.length > 0 ? (
+        <View className="mx-4 mb-3">
+          <View className="mb-2 flex-row items-center">
+            <UserPlusIcon size={16} color="#3B82F6" />
+            <Text className="ml-1.5 text-xs font-sans-semibold uppercase text-content-secondary">
+              공유받은 공고 ({sharedPostings.length})
+            </Text>
+          </View>
+          {sharedPostings.map((shared) => (
+            <Pressable
+              key={shared.jobPostingId}
+              onPress={() => handleSharedPostingPress(shared)}
+              className="mb-2 flex-row items-center rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 active:opacity-70 dark:border-blue-800/50 dark:bg-blue-900/20"
+              accessibilityRole="button"
+              accessibilityLabel={`공유받은 공고 ${shared.jobPostingTitle}`}
+            >
+              <View className="flex-1 min-w-0">
+                <Text
+                  className="text-sm font-sans-semibold text-content-primary dark:text-off-white"
+                  numberOfLines={1}
+                >
+                  🔗 {shared.jobPostingTitle}
+                </Text>
+                <Text className="mt-0.5 text-xs text-content-secondary" numberOfLines={1}>
+                  {shared.workspaceName} 워크스페이스
+                </Text>
+              </View>
+              <ChevronRightIcon size={16} color={SECONDARY_PALETTE[400]} />
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
 
       {filteredPostings.length === 0 ? (
         <PostingSurfaceState

--- a/uniqn-mobile/app/(employer)/my-postings/[id]/collaborators.tsx
+++ b/uniqn-mobile/app/(employer)/my-postings/[id]/collaborators.tsx
@@ -1,0 +1,95 @@
+/**
+ * UNIQN Mobile - 공고별 협업자 관리 라우트
+ *
+ * @description owner: 검색 + 추가 + 제거 / collaborator 본인: 자기 나가기만
+ *              권한 강제는 RLS — UI 분기는 데이터 기반 (workspace owner 인지)
+ * @version 1.0.0
+ */
+
+import React from 'react';
+import { View, Text, ScrollView } from 'react-native';
+import { Stack, useLocalSearchParams } from 'expo-router';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useAuthStore } from '@/stores/authStore';
+import { useJobDetail } from '@/hooks/useJobDetail';
+import { useJobPostingCollaborators } from '@/hooks/job-posting/useJobPostingCollaborators';
+import { CollaboratorList } from '@/components/job-posting/CollaboratorList';
+import { CollaboratorSearch } from '@/components/job-posting/CollaboratorSearch';
+
+export default function CollaboratorsRoute() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const jobPostingId = id;
+
+  const { user } = useAuthStore();
+  const currentUserId = user?.uid;
+
+  const { job: jobPosting } = useJobDetail(jobPostingId);
+  const { collaborators, isLoading, add, isAdding, remove, isRemoving, leaveSelf } =
+    useJobPostingCollaborators(jobPostingId);
+
+  // workspace owner 여부 — RLS 가 진짜 게이트, UI 분기용
+  // ownerId 가 현재 사용자면 owner.
+  const isOwner = !!jobPosting && jobPosting.ownerId === currentUserId;
+
+  const title = jobPosting?.title ?? '공고 협업자';
+  const total = collaborators.length;
+
+  return (
+    <SafeAreaView className="flex-1 bg-white dark:bg-surface" edges={['bottom']}>
+      <Stack.Screen
+        options={{
+          title: '공유 관리',
+          presentation: 'modal',
+        }}
+      />
+
+      <View className="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+        <Text className="text-base font-medium text-content-primary" numberOfLines={1}>
+          {title}
+        </Text>
+        <Text className="text-sm text-content-secondary mt-0.5">
+          {total > 0 ? `${total}명이 함께 관리 중` : '아직 협업자가 없습니다'}
+        </Text>
+      </View>
+
+      {isOwner ? (
+        <ScrollView className="flex-1">
+          <View className="py-2">
+            <Text className="px-4 pb-2 text-xs text-content-secondary uppercase">협업자 추가</Text>
+            <CollaboratorSearch
+              jobPostingId={jobPostingId!}
+              onAdd={async (userId) => {
+                await add(userId);
+              }}
+              isAdding={isAdding}
+            />
+          </View>
+
+          <View className="py-2 mt-2">
+            <Text className="px-4 pb-2 text-xs text-content-secondary uppercase">현재 협업자</Text>
+            <CollaboratorList
+              collaborators={collaborators}
+              isLoading={isLoading}
+              isOwner={true}
+              currentUserId={currentUserId}
+              onRemove={remove}
+              onLeave={leaveSelf}
+              actionDisabled={isRemoving}
+            />
+          </View>
+        </ScrollView>
+      ) : (
+        <View className="flex-1">
+          <CollaboratorList
+            collaborators={collaborators}
+            isLoading={isLoading}
+            isOwner={false}
+            currentUserId={currentUserId}
+            onLeave={leaveSelf}
+            actionDisabled={isRemoving}
+          />
+        </View>
+      )}
+    </SafeAreaView>
+  );
+}

--- a/uniqn-mobile/app/(employer)/my-postings/[id]/index.tsx
+++ b/uniqn-mobile/app/(employer)/my-postings/[id]/index.tsx
@@ -24,6 +24,7 @@ import {
   EditIcon,
   MapPinIcon,
   TrashIcon,
+  UserPlusIcon,
   UsersIcon,
   XCircleIcon,
 } from '@/components/icons';
@@ -153,6 +154,10 @@ export default function JobPostingDetailScreen() {
 
   const handleCancellationRequests = useCallback(() => {
     router.push(`/(employer)/my-postings/${id}/cancellation-requests`);
+  }, [id, router]);
+
+  const handleCollaborators = useCallback(() => {
+    router.push(`/(employer)/my-postings/${id}/collaborators`);
   }, [id, router]);
 
   const handleDeletePress = useCallback(() => {
@@ -480,6 +485,14 @@ export default function JobPostingDetailScreen() {
                 testID="job-posting-edit-button"
               />
             )}
+
+            <ActionCard
+              icon={<UserPlusIcon size={24} color="#3B82F6" />}
+              title="공유 관리"
+              description="이 공고를 함께 관리할 협업자를 추가하거나 제거합니다."
+              onPress={handleCollaborators}
+              testID="job-posting-manage-collaborators"
+            />
           </View>
         </View>
 

--- a/uniqn-mobile/src/components/job-posting/CollaboratorAvatarStack.tsx
+++ b/uniqn-mobile/src/components/job-posting/CollaboratorAvatarStack.tsx
@@ -37,6 +37,8 @@ export function CollaboratorAvatarStack({
   const overflow = Math.max(0, total - VISIBLE_AVATARS);
 
   if (total === 0) {
+    // owner / collaborator 본인만 "협업자 추가" CTA 노출 — 다른 멤버는 0명 시 미렌더
+    if (!canManage) return null;
     return (
       <Pressable
         onPress={onPress}

--- a/uniqn-mobile/src/components/job-posting/CollaboratorAvatarStack.tsx
+++ b/uniqn-mobile/src/components/job-posting/CollaboratorAvatarStack.tsx
@@ -1,0 +1,92 @@
+/**
+ * UNIQN Mobile - CollaboratorAvatarStack
+ *
+ * @description 공고 상세 헤더 — 협업자 아바타 3개 + "+N" overflow + "공유 관리" 텍스트
+ *              0명일 때는 "+ 협업자 추가" CTA
+ * @version 1.0.0
+ */
+
+import React from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { Image } from 'expo-image';
+import { UserIcon, UserPlusIcon } from '@/components/icons';
+import { useJobPostingCollaborators } from '@/hooks/job-posting/useJobPostingCollaborators';
+
+const VISIBLE_AVATARS = 3;
+
+export interface CollaboratorAvatarStackProps {
+  jobPostingId: string;
+  onPress?: () => void;
+  /** owner / collaborator 시점만 "공유 관리" CTA 표시 (RLS 와 별개의 UI 분기) */
+  canManage?: boolean;
+}
+
+export function CollaboratorAvatarStack({
+  jobPostingId,
+  onPress,
+  canManage = true,
+}: CollaboratorAvatarStackProps) {
+  const { collaborators, isLoading } = useJobPostingCollaborators(jobPostingId);
+
+  if (isLoading) {
+    return null; // 깜빡임 회피
+  }
+
+  const total = collaborators.length;
+  const visible = collaborators.slice(0, VISIBLE_AVATARS);
+  const overflow = Math.max(0, total - VISIBLE_AVATARS);
+
+  if (total === 0) {
+    return (
+      <Pressable
+        onPress={onPress}
+        className="flex-row items-center gap-1 px-3 py-1.5 rounded-md bg-gray-100 dark:bg-surface-elevated active:opacity-70"
+        accessibilityRole="button"
+        accessibilityLabel="협업자 추가"
+      >
+        <UserPlusIcon size={14} color="#6B7280" />
+        <Text className="text-sm text-content-secondary">협업자 추가</Text>
+      </Pressable>
+    );
+  }
+
+  return (
+    <Pressable
+      onPress={onPress}
+      className="flex-row items-center gap-2 px-2 py-1 rounded-md active:opacity-70"
+      accessibilityRole="button"
+      accessibilityLabel={`협업자 ${total}명, 공유 관리`}
+    >
+      <View className="flex-row items-center" style={{ marginRight: 4 }}>
+        {visible.map((c, idx) => (
+          <View
+            key={c.id}
+            className="w-7 h-7 rounded-full bg-gray-100 dark:bg-surface-elevated border-2 border-white dark:border-surface items-center justify-center overflow-hidden"
+            style={{ marginLeft: idx === 0 ? 0 : -8 }}
+          >
+            {c.photoUrl ? (
+              <Image
+                source={{ uri: c.photoUrl }}
+                style={{ width: 24, height: 24 }}
+                contentFit="cover"
+              />
+            ) : (
+              <UserIcon size={12} color="#9CA3AF" />
+            )}
+          </View>
+        ))}
+        {overflow > 0 ? (
+          <View
+            className="w-7 h-7 rounded-full bg-gray-200 dark:bg-surface-elevated border-2 border-white dark:border-surface items-center justify-center"
+            style={{ marginLeft: -8 }}
+          >
+            <Text className="text-xs text-content-secondary font-medium">+{overflow}</Text>
+          </View>
+        ) : null}
+      </View>
+      {canManage ? (
+        <Text className="text-sm text-content-primary font-medium">공유 관리</Text>
+      ) : null}
+    </Pressable>
+  );
+}

--- a/uniqn-mobile/src/components/job-posting/CollaboratorList.tsx
+++ b/uniqn-mobile/src/components/job-posting/CollaboratorList.tsx
@@ -1,0 +1,66 @@
+/**
+ * UNIQN Mobile - CollaboratorList
+ *
+ * @description 협업자 리스트 — FlashList (소형은 FlatList 도 가능, MVP 는 FlashList)
+ * @version 1.0.0
+ */
+
+import React from 'react';
+import { View, Text, ActivityIndicator } from 'react-native';
+import { FlashList } from '@shopify/flash-list';
+import { CollaboratorRow } from './CollaboratorRow';
+import type { JobPostingCollaboratorWithUser } from '@/types/jobPostingCollaborator';
+
+export interface CollaboratorListProps {
+  collaborators: JobPostingCollaboratorWithUser[];
+  isLoading?: boolean;
+  isOwner: boolean;
+  currentUserId: string | undefined;
+  onRemove?: (userId: string) => void;
+  onLeave?: () => void;
+  actionDisabled?: boolean;
+}
+
+export function CollaboratorList({
+  collaborators,
+  isLoading,
+  isOwner,
+  currentUserId,
+  onRemove,
+  onLeave,
+  actionDisabled,
+}: CollaboratorListProps) {
+  if (isLoading) {
+    return (
+      <View className="py-6 items-center">
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  if (collaborators.length === 0) {
+    return (
+      <View className="py-8 items-center">
+        <Text className="text-sm text-content-secondary">아직 협업자가 없습니다</Text>
+      </View>
+    );
+  }
+
+  return (
+    <FlashList<JobPostingCollaboratorWithUser>
+      data={collaborators}
+      keyExtractor={(item) => item.id}
+      estimatedItemSize={64}
+      renderItem={({ item }) => (
+        <CollaboratorRow
+          collaborator={item}
+          isOwner={isOwner}
+          currentUserId={currentUserId}
+          onRemove={onRemove}
+          onLeave={onLeave}
+          disabled={actionDisabled}
+        />
+      )}
+    />
+  );
+}

--- a/uniqn-mobile/src/components/job-posting/CollaboratorList.tsx
+++ b/uniqn-mobile/src/components/job-posting/CollaboratorList.tsx
@@ -50,6 +50,7 @@ export function CollaboratorList({
     <FlashList<JobPostingCollaboratorWithUser>
       data={collaborators}
       keyExtractor={(item) => item.id}
+      // @ts-expect-error - estimatedItemSize is required in FlashList 2.x but types may be missing
       estimatedItemSize={64}
       renderItem={({ item }) => (
         <CollaboratorRow

--- a/uniqn-mobile/src/components/job-posting/CollaboratorRow.tsx
+++ b/uniqn-mobile/src/components/job-posting/CollaboratorRow.tsx
@@ -1,0 +1,97 @@
+/**
+ * UNIQN Mobile - CollaboratorRow
+ *
+ * @description 협업자 1명 행 — 이름/이메일/추가일 + 액션 버튼
+ *              owner 시점: ✕ 제거 / collaborator 본인 시점: "나가기"
+ * @version 1.0.0
+ */
+
+import React from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { Image } from 'expo-image';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { UserIcon, XIcon } from '@/components/icons';
+import type { JobPostingCollaboratorWithUser } from '@/types/jobPostingCollaborator';
+
+export interface CollaboratorRowProps {
+  collaborator: JobPostingCollaboratorWithUser;
+  /** 현재 로그인 사용자가 workspace owner 인지 (UI 분기) */
+  isOwner: boolean;
+  /** 현재 로그인 사용자 ID — 본인 행 식별 */
+  currentUserId: string | undefined;
+  /** owner 가 제거할 때 */
+  onRemove?: (userId: string) => void;
+  /** collaborator 본인이 나갈 때 */
+  onLeave?: () => void;
+  disabled?: boolean;
+}
+
+export function CollaboratorRow({
+  collaborator,
+  isOwner,
+  currentUserId,
+  onRemove,
+  onLeave,
+  disabled,
+}: CollaboratorRowProps) {
+  const isSelf = collaborator.userId === currentUserId;
+  const addedAtLabel = (() => {
+    try {
+      return format(new Date(collaborator.addedAt), 'yyyy-MM-dd', { locale: ko });
+    } catch {
+      return '';
+    }
+  })();
+
+  return (
+    <View className="flex-row items-center gap-3 py-3 px-4 bg-white dark:bg-surface">
+      {/* Avatar */}
+      <View className="w-10 h-10 rounded-full bg-gray-100 dark:bg-surface-elevated items-center justify-center overflow-hidden">
+        {collaborator.photoUrl ? (
+          <Image
+            source={{ uri: collaborator.photoUrl }}
+            style={{ width: 40, height: 40 }}
+            contentFit="cover"
+          />
+        ) : (
+          <UserIcon size={20} color="#9CA3AF" />
+        )}
+      </View>
+
+      {/* 이름 + 이메일 + 추가일 */}
+      <View className="flex-1 min-w-0">
+        <Text className="text-base font-medium text-content-primary" numberOfLines={1}>
+          {collaborator.displayName ?? '이름 없음'}
+        </Text>
+        <Text className="text-xs text-content-secondary" numberOfLines={1}>
+          {collaborator.email ?? ''}
+          {addedAtLabel ? `  ·  ${addedAtLabel} 추가` : ''}
+        </Text>
+      </View>
+
+      {/* 액션 */}
+      {isSelf ? (
+        <Pressable
+          onPress={onLeave}
+          disabled={disabled}
+          className="px-3 py-1.5 rounded-md border border-content-secondary/30 active:bg-gray-100 dark:active:bg-surface-elevated"
+          accessibilityRole="button"
+          accessibilityLabel="공고 관리에서 나가기"
+        >
+          <Text className="text-sm text-content-primary">나가기</Text>
+        </Pressable>
+      ) : isOwner ? (
+        <Pressable
+          onPress={() => onRemove?.(collaborator.userId)}
+          disabled={disabled}
+          className="p-2 active:opacity-60"
+          accessibilityRole="button"
+          accessibilityLabel="협업자 제거"
+        >
+          <XIcon size={20} color="#9CA3AF" />
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}

--- a/uniqn-mobile/src/components/job-posting/CollaboratorSearch.tsx
+++ b/uniqn-mobile/src/components/job-posting/CollaboratorSearch.tsx
@@ -1,0 +1,152 @@
+/**
+ * UNIQN Mobile - CollaboratorSearch
+ *
+ * @description 이메일로 협업자 검색 + 추가 UI
+ *              상태별 분기: self / workspace_member / already_collaborator / addable / not_registered
+ * @version 1.0.0
+ */
+
+import React, { useEffect, useState } from 'react';
+import { View, Text, TextInput, Pressable, ActivityIndicator } from 'react-native';
+import { Image } from 'expo-image';
+import { SearchIcon, UserIcon } from '@/components/icons';
+import { useCollaboratorCandidates } from '@/hooks/job-posting/useJobPostingCollaborators';
+import { COLLABORATOR_LIMITS } from '@/types/jobPostingCollaborator';
+import type { CollaboratorSearchCandidate } from '@/types/jobPostingCollaborator';
+
+export interface CollaboratorSearchProps {
+  jobPostingId: string;
+  onAdd: (userId: string) => Promise<void> | void;
+  isAdding?: boolean;
+}
+
+function useDebouncedValue<T>(value: T, ms: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), ms);
+    return () => clearTimeout(id);
+  }, [value, ms]);
+  return debounced;
+}
+
+function CandidateRow({
+  candidate,
+  onAdd,
+  isAdding,
+}: {
+  candidate: CollaboratorSearchCandidate;
+  onAdd: (userId: string) => void;
+  isAdding: boolean;
+}) {
+  const disabled =
+    candidate.status === 'self' ||
+    candidate.status === 'workspace_member' ||
+    candidate.status === 'already_collaborator' ||
+    candidate.status === 'not_registered';
+
+  const hint = (() => {
+    switch (candidate.status) {
+      case 'self':
+        return '본인은 추가할 수 없습니다';
+      case 'workspace_member':
+        return '이미 워크스페이스 멤버 — 모든 공고 접근 가능';
+      case 'already_collaborator':
+        return '이미 협업자';
+      case 'not_registered':
+        return 'UNIQN 에 가입한 사용자만 추가할 수 있어요';
+      default:
+        return null;
+    }
+  })();
+
+  return (
+    <Pressable
+      onPress={() => !disabled && onAdd(candidate.userId)}
+      disabled={disabled || isAdding}
+      className={`flex-row items-center gap-3 py-3 px-4 ${
+        disabled ? 'opacity-50' : 'active:bg-gray-100 dark:active:bg-surface-elevated'
+      }`}
+    >
+      <View className="w-10 h-10 rounded-full bg-gray-100 dark:bg-surface-elevated items-center justify-center overflow-hidden">
+        {candidate.photoUrl ? (
+          <Image
+            source={{ uri: candidate.photoUrl }}
+            style={{ width: 40, height: 40 }}
+            contentFit="cover"
+          />
+        ) : (
+          <UserIcon size={20} color="#9CA3AF" />
+        )}
+      </View>
+      <View className="flex-1 min-w-0">
+        <Text className="text-base font-medium text-content-primary" numberOfLines={1}>
+          {candidate.displayName ?? '이름 없음'}
+        </Text>
+        <Text className="text-xs text-content-secondary" numberOfLines={1}>
+          {candidate.email}
+        </Text>
+        {hint ? (
+          <Text className="text-xs text-amber-600 dark:text-amber-400 mt-0.5">{hint}</Text>
+        ) : null}
+      </View>
+      {!disabled ? <Text className="text-sm text-brand-primary font-medium">추가</Text> : null}
+    </Pressable>
+  );
+}
+
+export function CollaboratorSearch({ jobPostingId, onAdd, isAdding }: CollaboratorSearchProps) {
+  const [emailInput, setEmailInput] = useState('');
+  const debounced = useDebouncedValue(emailInput, COLLABORATOR_LIMITS.SEARCH_DEBOUNCE_MS);
+
+  const { candidates, isLoading } = useCollaboratorCandidates(jobPostingId, debounced);
+
+  const hasQuery = debounced.trim().length >= COLLABORATOR_LIMITS.SEARCH_MIN_CHARS;
+
+  return (
+    <View>
+      <View className="flex-row items-center gap-2 px-4 py-2 bg-white dark:bg-surface border-b border-gray-200 dark:border-gray-700">
+        <SearchIcon size={18} color="#9CA3AF" />
+        <TextInput
+          value={emailInput}
+          onChangeText={setEmailInput}
+          placeholder="이메일로 검색 (3자 이상)"
+          placeholderTextColor="#9CA3AF"
+          autoCapitalize="none"
+          autoCorrect={false}
+          keyboardType="email-address"
+          className="flex-1 text-base text-content-primary"
+        />
+      </View>
+
+      {!hasQuery ? (
+        <View className="py-6 items-center">
+          <Text className="text-sm text-content-secondary">
+            이메일 3자 이상 입력하면 검색됩니다
+          </Text>
+        </View>
+      ) : isLoading ? (
+        <View className="py-6 items-center">
+          <ActivityIndicator />
+        </View>
+      ) : candidates.length === 0 ? (
+        <View className="py-6 items-center">
+          <Text className="text-sm text-content-secondary">
+            UNIQN 에 가입한 사용자만 추가할 수 있어요
+          </Text>
+        </View>
+      ) : (
+        candidates.map((c) => (
+          <CandidateRow
+            key={c.userId}
+            candidate={c}
+            onAdd={async (uid) => {
+              await onAdd(uid);
+              setEmailInput(''); // 추가 후 입력 초기화
+            }}
+            isAdding={!!isAdding}
+          />
+        ))
+      )}
+    </View>
+  );
+}

--- a/uniqn-mobile/src/hooks/job-posting/useJobPostingCollaborators.ts
+++ b/uniqn-mobile/src/hooks/job-posting/useJobPostingCollaborators.ts
@@ -1,0 +1,174 @@
+/**
+ * UNIQN Mobile - useJobPostingCollaborators
+ *
+ * @description 공고별 협업자 목록 + add/remove mutations + Realtime 구독
+ *              TanStack Query. 권한 분기는 데이터 형태로 (RLS 가 진짜 게이트).
+ * @version 1.0.0
+ */
+
+import { useEffect } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryKeys, cachingPolicies } from '@/lib/queryClient';
+import { collaboratorService } from '@/services/jobs/collaboratorService';
+import { createRealtimeSubscription } from '@/utils/supabase';
+import { logger } from '@/utils/logger';
+import { useToastStore } from '@/stores/toastStore';
+import { extractUserMessage } from '@/errors';
+import type {
+  JobPostingCollaboratorWithUser,
+  CollaboratorSearchCandidate,
+} from '@/types/jobPostingCollaborator';
+
+const toast = {
+  success: (msg: string) => useToastStore.getState().success(msg),
+  error: (msg: string) => useToastStore.getState().error(msg),
+};
+
+export interface UseJobPostingCollaboratorsResult {
+  collaborators: JobPostingCollaboratorWithUser[];
+  isLoading: boolean;
+  error: unknown;
+  refetch: () => void;
+  /** 협업자 추가 (workspace owner 만 — RLS 가 강제) */
+  add: (userId: string) => Promise<void>;
+  isAdding: boolean;
+  /** 협업자 제거 (workspace owner OR 본인 — RLS 가 강제) */
+  remove: (userId: string) => Promise<void>;
+  isRemoving: boolean;
+  /** 본인 나가기 */
+  leaveSelf: () => Promise<void>;
+}
+
+export function useJobPostingCollaborators(
+  jobPostingId: string | undefined
+): UseJobPostingCollaboratorsResult {
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: jobPostingId
+      ? queryKeys.jobPostingCollaborators.list(jobPostingId)
+      : [...queryKeys.jobPostingCollaborators.all, 'list', 'none'],
+    queryFn: () => collaboratorService.listForJobPosting(jobPostingId!),
+    enabled: !!jobPostingId,
+    staleTime: cachingPolicies.frequent,
+  });
+
+  // Realtime — collaborator INSERT/DELETE 시 자동 갱신
+  useEffect(() => {
+    if (!jobPostingId) return undefined;
+    return createRealtimeSubscription(
+      'job_posting_collaborators',
+      `job_posting_id=eq.${jobPostingId}`,
+      () => {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.jobPostingCollaborators.list(jobPostingId),
+        });
+      }
+    );
+  }, [jobPostingId, queryClient]);
+
+  const addMutation = useMutation({
+    mutationFn: (userId: string) =>
+      collaboratorService.add({ jobPostingId: jobPostingId!, userId }),
+    onSuccess: () => {
+      if (jobPostingId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.jobPostingCollaborators.list(jobPostingId),
+        });
+      }
+      toast.success('협업자를 추가했습니다');
+    },
+    onError: (error) => {
+      logger.error('협업자 추가 실패', error);
+      toast.error(extractUserMessage(error) || '협업자 추가에 실패했습니다');
+    },
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: (userId: string) =>
+      collaboratorService.remove({ jobPostingId: jobPostingId!, userId }),
+    onSuccess: () => {
+      if (jobPostingId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.jobPostingCollaborators.list(jobPostingId),
+        });
+      }
+      toast.success('협업자를 제거했습니다');
+    },
+    onError: (error) => {
+      logger.error('협업자 제거 실패', error);
+      toast.error(extractUserMessage(error) || '협업자 제거에 실패했습니다');
+    },
+  });
+
+  const leaveMutation = useMutation({
+    mutationFn: () => collaboratorService.leaveSelf(jobPostingId!),
+    onSuccess: () => {
+      // 본인 나가기 후 cleanup — Codex outside-voice 5 단계
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.jobPostingCollaborators.all,
+      });
+      if (jobPostingId) {
+        queryClient.removeQueries({
+          queryKey: queryKeys.jobPostingCollaborators.list(jobPostingId),
+        });
+      }
+      toast.success('공고 관리에서 나갔습니다');
+    },
+    onError: (error) => {
+      logger.error('자가 나가기 실패', error);
+      toast.error(extractUserMessage(error) || '나가기에 실패했습니다');
+    },
+  });
+
+  return {
+    collaborators: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+    add: async (userId: string) => {
+      await addMutation.mutateAsync(userId);
+    },
+    isAdding: addMutation.isPending,
+    remove: async (userId: string) => {
+      await removeMutation.mutateAsync(userId);
+    },
+    isRemoving: removeMutation.isPending,
+    leaveSelf: async () => {
+      await leaveMutation.mutateAsync();
+    },
+  };
+}
+
+// ============================================================================
+// useCollaboratorCandidates — 이메일 검색 (debounce 는 호출자가 처리)
+// ============================================================================
+
+export interface UseCollaboratorCandidatesResult {
+  candidates: CollaboratorSearchCandidate[];
+  isLoading: boolean;
+  error: unknown;
+}
+
+export function useCollaboratorCandidates(
+  jobPostingId: string | undefined,
+  emailQuery: string
+): UseCollaboratorCandidatesResult {
+  const enabled = !!jobPostingId && emailQuery.trim().length >= 3;
+
+  const query = useQuery({
+    queryKey: jobPostingId
+      ? queryKeys.jobPostingCollaborators.candidates(jobPostingId, emailQuery)
+      : [...queryKeys.jobPostingCollaborators.all, 'candidates', 'none'],
+    queryFn: () =>
+      collaboratorService.searchCandidates({ jobPostingId: jobPostingId!, emailQuery }),
+    enabled,
+    staleTime: 30_000,
+  });
+
+  return {
+    candidates: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+  };
+}

--- a/uniqn-mobile/src/hooks/job-posting/useSharedJobPostings.ts
+++ b/uniqn-mobile/src/hooks/job-posting/useSharedJobPostings.ts
@@ -1,0 +1,55 @@
+/**
+ * UNIQN Mobile - useSharedJobPostings
+ *
+ * @description collaborator 본인이 협업하는 공고 목록 — "공유받은 공고" 섹션용
+ *              RLS 격리: 본인이 collaborator 인 공고만 반환. 다른 워크스페이스는 차단.
+ * @version 1.0.0
+ */
+
+import { useEffect } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryKeys, cachingPolicies } from '@/lib/queryClient';
+import { useAuthStore } from '@/stores/authStore';
+import { collaboratorService } from '@/services/jobs/collaboratorService';
+import { createRealtimeSubscription } from '@/utils/supabase';
+import type { SharedJobPosting } from '@/types/jobPostingCollaborator';
+
+export interface UseSharedJobPostingsResult {
+  sharedPostings: SharedJobPosting[];
+  isLoading: boolean;
+  error: unknown;
+  refetch: () => void;
+}
+
+export function useSharedJobPostings(): UseSharedJobPostingsResult {
+  const { user } = useAuthStore();
+  const userId = user?.uid;
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: userId
+      ? queryKeys.jobPostingCollaborators.sharedForUser(userId)
+      : [...queryKeys.jobPostingCollaborators.all, 'shared', 'anonymous'],
+    queryFn: () => collaboratorService.listSharedJobPostings(),
+    enabled: !!userId,
+    staleTime: cachingPolicies.frequent,
+  });
+
+  // Realtime — 본인 user_id 의 jpc INSERT/DELETE 시 자동 갱신
+  // (collaborator 추가/제거 → 푸시 알림 + 리스트 동기화)
+  useEffect(() => {
+    if (!userId) return undefined;
+    return createRealtimeSubscription('job_posting_collaborators', `user_id=eq.${userId}`, () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.jobPostingCollaborators.sharedForUser(userId),
+      });
+    });
+  }, [userId, queryClient]);
+
+  return {
+    sharedPostings: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}

--- a/uniqn-mobile/src/lib/queryClient.ts
+++ b/uniqn-mobile/src/lib/queryClient.ts
@@ -335,6 +335,17 @@ export const queryKeys = {
       [...queryKeys.workspaces.all, 'invitations', 'received', userId] as const,
   },
 
+  // 공고별 협업자 (feat/job-posting-collaborators)
+  jobPostingCollaborators: {
+    all: ['jobPostingCollaborators'] as const,
+    list: (jobPostingId: string) =>
+      [...queryKeys.jobPostingCollaborators.all, 'list', jobPostingId] as const,
+    sharedForUser: (userId: string) =>
+      [...queryKeys.jobPostingCollaborators.all, 'shared', userId] as const,
+    candidates: (jobPostingId: string, emailQuery: string) =>
+      [...queryKeys.jobPostingCollaborators.all, 'candidates', jobPostingId, emailQuery] as const,
+  },
+
   // 공고 템플릿 (구인자)
   templates: {
     all: ['templates'] as const,

--- a/uniqn-mobile/src/repositories/index.ts
+++ b/uniqn-mobile/src/repositories/index.ts
@@ -485,3 +485,14 @@ export {
   workspaceMemberRepository,
   workspaceInvitationRepository,
 } from './supabase';
+
+// ============================================================================
+// 공고별 협업자 (Phase 5 — feat/job-posting-collaborators)
+// ============================================================================
+
+export type { IJobPostingCollaboratorRepository } from './interfaces';
+
+export {
+  SupabaseJobPostingCollaboratorRepository,
+  jobPostingCollaboratorRepository,
+} from './supabase/JobPostingCollaboratorRepository';

--- a/uniqn-mobile/src/repositories/interfaces/IJobPostingCollaboratorRepository.ts
+++ b/uniqn-mobile/src/repositories/interfaces/IJobPostingCollaboratorRepository.ts
@@ -1,0 +1,50 @@
+/**
+ * UNIQN Mobile - 공고별 협업자 Repository 인터페이스
+ *
+ * @description Phase 5 (collaborator repository) — CLAUDE.md 아키텍처 규칙
+ *              Service → Repository → Supabase. RLS 가 권한 강제.
+ * @version 1.0.0
+ */
+
+import type {
+  JobPostingCollaborator,
+  JobPostingCollaboratorWithUser,
+  SharedJobPosting,
+  CollaboratorSearchCandidate,
+} from '@/types/jobPostingCollaborator';
+
+export interface IJobPostingCollaboratorRepository {
+  /**
+   * 공고의 협업자 목록 (사용자 표시 정보 포함)
+   * RLS: workspace 멤버 OR collaborator 본인이 SELECT 가능
+   */
+  findByJobPostingWithUser(jobPostingId: string): Promise<JobPostingCollaboratorWithUser[]>;
+
+  /**
+   * 본인이 협업하는 공고 목록 (출처 워크스페이스 정보 포함)
+   * RLS: collaborator 본인만 SELECT
+   */
+  findSharedJobPostingsForUser(userId: string): Promise<SharedJobPosting[]>;
+
+  /**
+   * 협업자 추가 (RLS: workspace owner 만 INSERT)
+   * @returns 생성된 row
+   * @throws AppError E5 (권한), E3 (자가 추가 / 중복 UNIQUE 충돌)
+   */
+  add(jobPostingId: string, userId: string, addedBy: string): Promise<JobPostingCollaborator>;
+
+  /**
+   * 협업자 제거 (RLS: workspace owner OR collaborator 본인)
+   * @throws AppError E5 (권한)
+   */
+  remove(jobPostingId: string, userId: string): Promise<void>;
+
+  /**
+   * 이메일로 사용자 검색 (UNIQN 가입자만)
+   * 검색 결과에 status (self/workspace_member/already_collaborator/addable/not_registered) 부여
+   *
+   * @param jobPostingId 협업자 추가 대상 공고
+   * @param emailQuery 이메일 prefix (≥3자)
+   */
+  searchByEmail(jobPostingId: string, emailQuery: string): Promise<CollaboratorSearchCandidate[]>;
+}

--- a/uniqn-mobile/src/repositories/interfaces/index.ts
+++ b/uniqn-mobile/src/repositories/interfaces/index.ts
@@ -133,3 +133,6 @@ export type {
   IWorkspaceMemberRepository,
   IWorkspaceInvitationRepository,
 } from './IWorkspaceRepository';
+
+// 공고별 협업자 (Phase 5 — feat/job-posting-collaborators)
+export type { IJobPostingCollaboratorRepository } from './IJobPostingCollaboratorRepository';

--- a/uniqn-mobile/src/repositories/supabase/JobPostingCollaboratorRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/JobPostingCollaboratorRepository.ts
@@ -212,15 +212,16 @@ export class SupabaseJobPostingCollaboratorRepository implements IJobPostingColl
     emailQuery: string
   ): Promise<CollaboratorSearchCandidate[]> {
     try {
-      // 1) 이메일 prefix 매칭으로 후보 (자신 제외는 status 분류에서 처리)
-      const { data: candidates, error: userErr } = await supabase
-        .from('users')
-        .select('id, email, nickname, name, photo_url')
-        .ilike('email', `${emailQuery}%`)
-        .limit(10);
+      // 1) RPC 호출 — search_users_for_collaborator_invite 가 SECURITY DEFINER 로
+      //    users RLS 우회 + workspace owner 검증 + 와일드카드 이스케이프 + LIMIT 10
+      //    (users_select RLS 가 self/admin 만 허용해 직접 SELECT 는 빈 결과 반환)
+      const { data: candidates, error: rpcErr } = await supabase.rpc(
+        'search_users_for_collaborator_invite',
+        { p_job_posting_id: jobPostingId, p_email_query: emailQuery }
+      );
 
-      if (userErr) {
-        handleSupabaseError(userErr, { operation: '협업자 후보 검색', table: 'users' });
+      if (rpcErr) {
+        handleSupabaseError(rpcErr, { operation: '협업자 후보 검색', table: 'users' });
       }
 
       const candidateRows = (candidates ?? []) as UserEmailRow[];
@@ -228,50 +229,42 @@ export class SupabaseJobPostingCollaboratorRepository implements IJobPostingColl
 
       const candidateIds = candidateRows.map((c) => c.id);
 
-      // 2) 현재 사용자 (self 분류용)
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      const selfId = user?.id ?? null;
+      // 2) self / workspace_member / already_collaborator 분류용 병렬 조회
+      //    공고의 workspace_id 가 필요 — RLS 통과 (owner OR member OR collaborator)
+      const [authRes, jpRes, collabRes] = await Promise.all([
+        supabase.auth.getUser(),
+        supabase.from('job_postings').select('workspace_id').eq('id', jobPostingId).single(),
+        supabase
+          .from(TABLE)
+          .select('user_id')
+          .eq('job_posting_id', jobPostingId)
+          .in('user_id', candidateIds),
+      ]);
 
-      // 3) 공고의 workspace_id 와 기존 멤버/협업자 한 번에 조회
-      const { data: jpRow } = await supabase
-        .from('job_postings')
-        .select('workspace_id')
-        .eq('id', jobPostingId)
-        .single();
-      const workspaceId = (jpRow as { workspace_id: string } | null)?.workspace_id ?? null;
+      const selfId = authRes.data.user?.id ?? null;
+      const workspaceId = (jpRes.data as { workspace_id: string } | null)?.workspace_id ?? null;
+      const collabIds = new Set<string>(
+        ((collabRes.data ?? []) as { user_id: string }[]).map((c) => c.user_id)
+      );
 
       const memberIds = new Set<string>();
       if (workspaceId) {
-        const { data: members } = await supabase
-          .from('workspace_members')
-          .select('user_id')
-          .eq('workspace_id', workspaceId)
-          .in('user_id', candidateIds);
-        ((members ?? []) as { user_id: string }[]).forEach((m) => memberIds.add(m.user_id));
-
-        // workspace owner 도 멤버로 간주
-        const { data: wsRow } = await supabase
-          .from('workspaces')
-          .select('owner_id')
-          .eq('id', workspaceId)
-          .single();
-        const ownerId = (wsRow as { owner_id: string } | null)?.owner_id ?? null;
+        const [membersRes, wsRes] = await Promise.all([
+          supabase
+            .from('workspace_members')
+            .select('user_id')
+            .eq('workspace_id', workspaceId)
+            .in('user_id', candidateIds),
+          supabase.from('workspaces').select('owner_id').eq('id', workspaceId).single(),
+        ]);
+        ((membersRes.data ?? []) as { user_id: string }[]).forEach((m) => memberIds.add(m.user_id));
+        const ownerId = (wsRes.data as { owner_id: string } | null)?.owner_id ?? null;
         if (ownerId && candidateIds.includes(ownerId)) {
           memberIds.add(ownerId);
         }
       }
 
-      const collabIds = new Set<string>();
-      const { data: existingCollabs } = await supabase
-        .from(TABLE)
-        .select('user_id')
-        .eq('job_posting_id', jobPostingId)
-        .in('user_id', candidateIds);
-      ((existingCollabs ?? []) as { user_id: string }[]).forEach((c) => collabIds.add(c.user_id));
-
-      // 4) 상태 분류
+      // 3) 상태 분류
       return candidateRows.map((row): CollaboratorSearchCandidate => {
         let status: CollaboratorSearchCandidate['status'];
         if (selfId && row.id === selfId) status = 'self';

--- a/uniqn-mobile/src/repositories/supabase/JobPostingCollaboratorRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/JobPostingCollaboratorRepository.ts
@@ -1,0 +1,297 @@
+/**
+ * UNIQN Mobile - Supabase JobPostingCollaborator Repository
+ *
+ * @description 공고별 협업자 (Phase 5)
+ *              - 권한 강제는 RLS — Repository 는 단순 조회/쓰기 + snake↔camel 변환
+ *              - searchByEmail 은 UNIQN 가입자 이메일 prefix 검색 + 상태 분류
+ * @version 1.0.0
+ */
+
+import { supabase } from '@/lib/supabase';
+import { logger } from '@/utils/logger';
+import { isAppError, BusinessError, ERROR_CODES } from '@/errors';
+import { handleSupabaseError } from '@/utils/supabase';
+import type {
+  JobPostingCollaborator,
+  JobPostingCollaboratorWithUser,
+  SharedJobPosting,
+  CollaboratorSearchCandidate,
+} from '@/types/jobPostingCollaborator';
+import type { IJobPostingCollaboratorRepository } from '../interfaces/IJobPostingCollaboratorRepository';
+
+const TABLE = 'job_posting_collaborators' as const;
+
+// ============================================================================
+// DB row 타입
+// ============================================================================
+
+interface JpcRow {
+  id: string;
+  job_posting_id: string;
+  user_id: string;
+  added_by: string;
+  added_at: string;
+}
+
+interface JpcWithUserRow extends JpcRow {
+  users: {
+    nickname: string | null;
+    name: string | null;
+    email: string | null;
+    photo_url: string | null;
+  } | null;
+}
+
+interface SharedJpRow {
+  added_at: string;
+  job_postings: {
+    id: string;
+    title: string;
+    workspace_id: string;
+    workspaces: {
+      id: string;
+      name: string;
+    } | null;
+  } | null;
+}
+
+interface UserEmailRow {
+  id: string;
+  email: string | null;
+  nickname: string | null;
+  name: string | null;
+  photo_url: string | null;
+}
+
+// ============================================================================
+// Mappers
+// ============================================================================
+
+function rowToCollaborator(row: JpcRow): JobPostingCollaborator {
+  return {
+    id: row.id,
+    jobPostingId: row.job_posting_id,
+    userId: row.user_id,
+    addedBy: row.added_by,
+    addedAt: row.added_at,
+  };
+}
+
+function rowToCollaboratorWithUser(row: JpcWithUserRow): JobPostingCollaboratorWithUser {
+  return {
+    ...rowToCollaborator(row),
+    displayName: row.users?.nickname ?? row.users?.name ?? null,
+    email: row.users?.email ?? null,
+    photoUrl: row.users?.photo_url ?? null,
+  };
+}
+
+function rowToSharedJobPosting(row: SharedJpRow): SharedJobPosting | null {
+  if (!row.job_postings) return null;
+  return {
+    jobPostingId: row.job_postings.id,
+    jobPostingTitle: row.job_postings.title,
+    workspaceId: row.job_postings.workspace_id,
+    workspaceName: row.job_postings.workspaces?.name ?? '',
+    addedAt: row.added_at,
+  };
+}
+
+// ============================================================================
+// Repository implementation
+// ============================================================================
+
+export class SupabaseJobPostingCollaboratorRepository implements IJobPostingCollaboratorRepository {
+  async findByJobPostingWithUser(jobPostingId: string): Promise<JobPostingCollaboratorWithUser[]> {
+    try {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select(
+          'id, job_posting_id, user_id, added_by, added_at, users:user_id (nickname, name, email, photo_url)'
+        )
+        .eq('job_posting_id', jobPostingId)
+        .order('added_at', { ascending: true });
+
+      if (error) {
+        handleSupabaseError(error, { operation: '협업자 목록 조회', table: TABLE });
+      }
+
+      return ((data ?? []) as unknown as JpcWithUserRow[]).map(rowToCollaboratorWithUser);
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '협업자 목록 조회', table: TABLE });
+    }
+  }
+
+  async findSharedJobPostingsForUser(userId: string): Promise<SharedJobPosting[]> {
+    try {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select(
+          'added_at, job_postings:job_posting_id (id, title, workspace_id, workspaces:workspace_id (id, name))'
+        )
+        .eq('user_id', userId)
+        .order('added_at', { ascending: false });
+
+      if (error) {
+        handleSupabaseError(error, { operation: '공유받은 공고 조회', table: TABLE });
+      }
+
+      return ((data ?? []) as unknown as SharedJpRow[])
+        .map(rowToSharedJobPosting)
+        .filter((x): x is SharedJobPosting => x !== null);
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '공유받은 공고 조회', table: TABLE });
+    }
+  }
+
+  async add(
+    jobPostingId: string,
+    userId: string,
+    addedBy: string
+  ): Promise<JobPostingCollaborator> {
+    try {
+      logger.info('협업자 추가', { jobPostingId, userId, addedBy });
+
+      const { data, error } = await supabase
+        .from(TABLE)
+        .insert({ job_posting_id: jobPostingId, user_id: userId, added_by: addedBy })
+        .select('id, job_posting_id, user_id, added_by, added_at')
+        .single();
+
+      if (error) {
+        // UNIQUE 충돌 (이미 collaborator) → 친절 메시지
+        if (error.code === '23505') {
+          throw new BusinessError(ERROR_CODES.BUSINESS_INVALID_STATE, {
+            userMessage: '이미 협업 중인 사용자입니다',
+          });
+        }
+        // CHECK 위반 (자가 추가) → 친절 메시지
+        if (error.code === '23514') {
+          throw new BusinessError(ERROR_CODES.BUSINESS_INVALID_STATE, {
+            userMessage: '본인은 협업자로 추가할 수 없습니다',
+          });
+        }
+        handleSupabaseError(error, { operation: '협업자 추가', table: TABLE });
+      }
+
+      if (!data) {
+        throw new BusinessError(ERROR_CODES.INFRA_NOT_FOUND, {
+          userMessage: '협업자 추가에 실패했습니다',
+        });
+      }
+      return rowToCollaborator(data as JpcRow);
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '협업자 추가', table: TABLE });
+    }
+  }
+
+  async remove(jobPostingId: string, userId: string): Promise<void> {
+    try {
+      logger.info('협업자 제거', { jobPostingId, userId });
+
+      const { error } = await supabase
+        .from(TABLE)
+        .delete()
+        .eq('job_posting_id', jobPostingId)
+        .eq('user_id', userId);
+
+      if (error) {
+        handleSupabaseError(error, { operation: '협업자 제거', table: TABLE });
+      }
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '협업자 제거', table: TABLE });
+    }
+  }
+
+  async searchByEmail(
+    jobPostingId: string,
+    emailQuery: string
+  ): Promise<CollaboratorSearchCandidate[]> {
+    try {
+      // 1) 이메일 prefix 매칭으로 후보 (자신 제외는 status 분류에서 처리)
+      const { data: candidates, error: userErr } = await supabase
+        .from('users')
+        .select('id, email, nickname, name, photo_url')
+        .ilike('email', `${emailQuery}%`)
+        .limit(10);
+
+      if (userErr) {
+        handleSupabaseError(userErr, { operation: '협업자 후보 검색', table: 'users' });
+      }
+
+      const candidateRows = (candidates ?? []) as UserEmailRow[];
+      if (candidateRows.length === 0) return [];
+
+      const candidateIds = candidateRows.map((c) => c.id);
+
+      // 2) 현재 사용자 (self 분류용)
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      const selfId = user?.id ?? null;
+
+      // 3) 공고의 workspace_id 와 기존 멤버/협업자 한 번에 조회
+      const { data: jpRow } = await supabase
+        .from('job_postings')
+        .select('workspace_id')
+        .eq('id', jobPostingId)
+        .single();
+      const workspaceId = (jpRow as { workspace_id: string } | null)?.workspace_id ?? null;
+
+      const memberIds = new Set<string>();
+      if (workspaceId) {
+        const { data: members } = await supabase
+          .from('workspace_members')
+          .select('user_id')
+          .eq('workspace_id', workspaceId)
+          .in('user_id', candidateIds);
+        ((members ?? []) as { user_id: string }[]).forEach((m) => memberIds.add(m.user_id));
+
+        // workspace owner 도 멤버로 간주
+        const { data: wsRow } = await supabase
+          .from('workspaces')
+          .select('owner_id')
+          .eq('id', workspaceId)
+          .single();
+        const ownerId = (wsRow as { owner_id: string } | null)?.owner_id ?? null;
+        if (ownerId && candidateIds.includes(ownerId)) {
+          memberIds.add(ownerId);
+        }
+      }
+
+      const collabIds = new Set<string>();
+      const { data: existingCollabs } = await supabase
+        .from(TABLE)
+        .select('user_id')
+        .eq('job_posting_id', jobPostingId)
+        .in('user_id', candidateIds);
+      ((existingCollabs ?? []) as { user_id: string }[]).forEach((c) => collabIds.add(c.user_id));
+
+      // 4) 상태 분류
+      return candidateRows.map((row): CollaboratorSearchCandidate => {
+        let status: CollaboratorSearchCandidate['status'];
+        if (selfId && row.id === selfId) status = 'self';
+        else if (memberIds.has(row.id)) status = 'workspace_member';
+        else if (collabIds.has(row.id)) status = 'already_collaborator';
+        else status = 'addable';
+
+        return {
+          userId: row.id,
+          displayName: row.nickname ?? row.name ?? null,
+          email: row.email ?? '',
+          photoUrl: row.photo_url ?? null,
+          status,
+        };
+      });
+    } catch (error) {
+      if (isAppError(error)) throw error;
+      handleSupabaseError(error, { operation: '협업자 후보 검색', table: TABLE });
+    }
+  }
+}
+
+export const jobPostingCollaboratorRepository = new SupabaseJobPostingCollaboratorRepository();

--- a/uniqn-mobile/src/schemas/jobPostingCollaborator.schema.ts
+++ b/uniqn-mobile/src/schemas/jobPostingCollaborator.schema.ts
@@ -1,0 +1,69 @@
+/**
+ * UNIQN Mobile - 공고별 협업자 Zod 스키마
+ *
+ * @description 공고 단위 협업자 권한 입력 검증
+ *              CLAUDE.md 보안 규칙: 모든 사용자 입력에 xssValidation 필수
+ * @version 1.0.0
+ */
+
+import { z } from 'zod';
+import { xssValidation } from '@/utils/security';
+
+// ============================================================================
+// 도메인 타입 (DB 행 → 도메인)
+// ============================================================================
+
+export const jobPostingCollaboratorSchema = z.object({
+  id: z.string().uuid(),
+  jobPostingId: z.string().uuid(),
+  userId: z.string().uuid(),
+  addedBy: z.string().uuid(),
+  addedAt: z.string(), // ISO 8601 (timestamptz)
+});
+
+export type JobPostingCollaboratorData = z.infer<typeof jobPostingCollaboratorSchema>;
+
+// ============================================================================
+// 협업자 추가 입력
+// ============================================================================
+
+/**
+ * 협업자 추가 (Service 진입점)
+ * UI 에서 이메일로 검색 → userId 확정 후 호출
+ */
+export const addCollaboratorSchema = z.object({
+  jobPostingId: z.string().uuid({ message: '올바른 공고 ID 가 아닙니다' }),
+  userId: z.string().uuid({ message: '올바른 사용자 ID 가 아닙니다' }),
+});
+
+export type AddCollaboratorData = z.infer<typeof addCollaboratorSchema>;
+
+// ============================================================================
+// 이메일 검색
+// ============================================================================
+
+/**
+ * 협업자 추가용 사용자 검색 (이메일 prefix)
+ */
+export const searchCollaboratorCandidateSchema = z.object({
+  jobPostingId: z.string().uuid({ message: '올바른 공고 ID 가 아닙니다' }),
+  emailQuery: z
+    .string({ error: '이메일을 입력해주세요' })
+    .trim()
+    .min(3, { message: '3자 이상 입력해주세요' })
+    .max(254, { message: '이메일이 너무 깁니다' })
+    .refine(xssValidation, { message: '특수문자가 포함될 수 없습니다' }),
+});
+
+export type SearchCollaboratorCandidateData = z.infer<typeof searchCollaboratorCandidateSchema>;
+
+// ============================================================================
+// 협업자 제거 (workspace owner OR 본인)
+// ============================================================================
+
+export const removeCollaboratorSchema = z.object({
+  jobPostingId: z.string().uuid({ message: '올바른 공고 ID 가 아닙니다' }),
+  userId: z.string().uuid({ message: '올바른 사용자 ID 가 아닙니다' }),
+});
+
+export type RemoveCollaboratorData = z.infer<typeof removeCollaboratorSchema>;

--- a/uniqn-mobile/src/services/jobs/__tests__/collaboratorService.test.ts
+++ b/uniqn-mobile/src/services/jobs/__tests__/collaboratorService.test.ts
@@ -1,0 +1,190 @@
+/**
+ * UNIQN Mobile - CollaboratorService Tests
+ *
+ * @description collaboratorService 단위 테스트 (Phase 10)
+ *              - Service 비즈니스 로직만 검증 (Repository 는 mock)
+ *              - 자가 추가 차단, 인증 가드, 검증 통과 후 Repository 호출 확인
+ * @version 1.0.0
+ */
+
+import { collaboratorService } from '../collaboratorService';
+import { jobPostingCollaboratorRepository } from '@/repositories/supabase/JobPostingCollaboratorRepository';
+import { supabase } from '@/lib/supabase';
+import { ValidationError, AuthError, ERROR_CODES } from '@/errors';
+
+jest.mock('@/repositories/supabase/JobPostingCollaboratorRepository', () => ({
+  jobPostingCollaboratorRepository: {
+    findByJobPostingWithUser: jest.fn(),
+    findSharedJobPostingsForUser: jest.fn(),
+    add: jest.fn(),
+    remove: jest.fn(),
+    searchByEmail: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const mockRepo = jobPostingCollaboratorRepository as jest.Mocked<
+  typeof jobPostingCollaboratorRepository
+>;
+const mockSupabaseAuth = supabase.auth as unknown as {
+  getUser: jest.Mock;
+};
+
+// v4 형식 UUID (M=4, N=8-b) — zod strict uuid 통과
+const OWNER_ID = '11111111-1111-4111-8111-111111111111';
+const TARGET_ID = '22222222-2222-4222-8222-222222222222';
+const POSTING_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function mockAuthUser(uid: string | null) {
+  mockSupabaseAuth.getUser.mockResolvedValue({
+    data: { user: uid ? { id: uid } : null },
+    error: null,
+  });
+}
+
+describe('collaboratorService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('add', () => {
+    it('Zod 검증 실패 시 ValidationError', async () => {
+      mockAuthUser(OWNER_ID);
+
+      await expect(
+        collaboratorService.add({ jobPostingId: 'not-a-uuid', userId: TARGET_ID })
+      ).rejects.toBeInstanceOf(ValidationError);
+      expect(mockRepo.add).not.toHaveBeenCalled();
+    });
+
+    it('자가 추가 시 ValidationError (DB CHECK 도달 전 차단)', async () => {
+      mockAuthUser(OWNER_ID);
+
+      await expect(
+        collaboratorService.add({ jobPostingId: POSTING_ID, userId: OWNER_ID })
+      ).rejects.toBeInstanceOf(ValidationError);
+      expect(mockRepo.add).not.toHaveBeenCalled();
+    });
+
+    it('미인증 시 AuthError', async () => {
+      mockAuthUser(null);
+
+      await expect(
+        collaboratorService.add({ jobPostingId: POSTING_ID, userId: TARGET_ID })
+      ).rejects.toBeInstanceOf(AuthError);
+    });
+
+    it('정상 추가 — Repository.add 호출 + addedBy=auth.uid()', async () => {
+      mockAuthUser(OWNER_ID);
+      mockRepo.add.mockResolvedValue({
+        id: 'jpc-1',
+        jobPostingId: POSTING_ID,
+        userId: TARGET_ID,
+        addedBy: OWNER_ID,
+        addedAt: '2026-05-12T00:00:00Z',
+      });
+
+      const result = await collaboratorService.add({
+        jobPostingId: POSTING_ID,
+        userId: TARGET_ID,
+      });
+
+      expect(mockRepo.add).toHaveBeenCalledWith(POSTING_ID, TARGET_ID, OWNER_ID);
+      expect(result.addedBy).toBe(OWNER_ID);
+    });
+  });
+
+  describe('remove', () => {
+    it('Zod 검증 실패 시 ValidationError', async () => {
+      await expect(
+        collaboratorService.remove({ jobPostingId: 'not-a-uuid', userId: TARGET_ID })
+      ).rejects.toBeInstanceOf(ValidationError);
+      expect(mockRepo.remove).not.toHaveBeenCalled();
+    });
+
+    it('정상 제거 — Repository.remove 호출 (권한은 RLS 가 강제)', async () => {
+      mockRepo.remove.mockResolvedValue(undefined);
+
+      await collaboratorService.remove({ jobPostingId: POSTING_ID, userId: TARGET_ID });
+
+      expect(mockRepo.remove).toHaveBeenCalledWith(POSTING_ID, TARGET_ID);
+    });
+  });
+
+  describe('leaveSelf', () => {
+    it('미인증 시 AuthError', async () => {
+      mockAuthUser(null);
+      await expect(collaboratorService.leaveSelf(POSTING_ID)).rejects.toBeInstanceOf(AuthError);
+    });
+
+    it('정상 — Repository.remove(postingId, currentUserId)', async () => {
+      mockAuthUser(TARGET_ID);
+      mockRepo.remove.mockResolvedValue(undefined);
+
+      await collaboratorService.leaveSelf(POSTING_ID);
+
+      expect(mockRepo.remove).toHaveBeenCalledWith(POSTING_ID, TARGET_ID);
+    });
+  });
+
+  describe('searchCandidates', () => {
+    it('Zod 검증 실패 (3자 미만) 시 ValidationError', async () => {
+      await expect(
+        collaboratorService.searchCandidates({ jobPostingId: POSTING_ID, emailQuery: 'ab' })
+      ).rejects.toBeInstanceOf(ValidationError);
+      expect(mockRepo.searchByEmail).not.toHaveBeenCalled();
+    });
+
+    it('정상 — Repository.searchByEmail 호출', async () => {
+      mockRepo.searchByEmail.mockResolvedValue([]);
+
+      await collaboratorService.searchCandidates({
+        jobPostingId: POSTING_ID,
+        emailQuery: 'foo@bar.com',
+      });
+
+      expect(mockRepo.searchByEmail).toHaveBeenCalledWith(POSTING_ID, 'foo@bar.com');
+    });
+  });
+
+  describe('listForJobPosting / listSharedJobPostings', () => {
+    it('listForJobPosting — Repository 위임', async () => {
+      mockRepo.findByJobPostingWithUser.mockResolvedValue([]);
+      await collaboratorService.listForJobPosting(POSTING_ID);
+      expect(mockRepo.findByJobPostingWithUser).toHaveBeenCalledWith(POSTING_ID);
+    });
+
+    it('listSharedJobPostings — 현재 사용자 ID 로 Repository 위임', async () => {
+      mockAuthUser(TARGET_ID);
+      mockRepo.findSharedJobPostingsForUser.mockResolvedValue([]);
+
+      await collaboratorService.listSharedJobPostings();
+
+      expect(mockRepo.findSharedJobPostingsForUser).toHaveBeenCalledWith(TARGET_ID);
+    });
+
+    it('listSharedJobPostings — 미인증 시 AuthError', async () => {
+      mockAuthUser(null);
+      await expect(collaboratorService.listSharedJobPostings()).rejects.toBeInstanceOf(AuthError);
+    });
+  });
+});
+
+// avoid unused warning on ERROR_CODES (kept for future expansion)
+void ERROR_CODES;

--- a/uniqn-mobile/src/services/jobs/collaboratorService.ts
+++ b/uniqn-mobile/src/services/jobs/collaboratorService.ts
@@ -1,0 +1,116 @@
+/**
+ * UNIQN Mobile - 공고별 협업자 Service
+ *
+ * @description 공고 단위 협업자 권한 비즈니스 로직 (Phase 5)
+ *              - CLAUDE.md 아키텍처: Presentation → Hooks → Service → Repository → Supabase
+ *              - 검증 → Repository 호출 → 알림은 DB trigger 가 자동 (Phase 3)
+ * @version 1.0.0
+ */
+
+import { jobPostingCollaboratorRepository } from '@/repositories/supabase/JobPostingCollaboratorRepository';
+import {
+  addCollaboratorSchema,
+  searchCollaboratorCandidateSchema,
+  removeCollaboratorSchema,
+} from '@/schemas/jobPostingCollaborator.schema';
+import { ValidationError, AuthError, ERROR_CODES } from '@/errors';
+import { logger } from '@/utils/logger';
+import { supabase } from '@/lib/supabase';
+import type {
+  JobPostingCollaborator,
+  JobPostingCollaboratorWithUser,
+  SharedJobPosting,
+  CollaboratorSearchCandidate,
+} from '@/types/jobPostingCollaborator';
+
+function validateOrThrow<T>(
+  parsed: { success: boolean; data?: T; error?: { issues: { message: string }[] } },
+  fallback = '입력값을 확인해주세요'
+): T {
+  if (!parsed.success) {
+    const message = parsed.error?.issues[0]?.message ?? fallback;
+    throw new ValidationError(ERROR_CODES.VALIDATION_SCHEMA, { userMessage: message });
+  }
+  return parsed.data as T;
+}
+
+async function getCurrentUserIdOrThrow(): Promise<string> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user?.id) {
+    throw new AuthError(ERROR_CODES.AUTH_REQUIRED, {
+      userMessage: '로그인이 필요합니다',
+    });
+  }
+  return user.id;
+}
+
+export const collaboratorService = {
+  /**
+   * 공고의 협업자 목록 (사용자 표시 정보 포함)
+   */
+  async listForJobPosting(jobPostingId: string): Promise<JobPostingCollaboratorWithUser[]> {
+    return jobPostingCollaboratorRepository.findByJobPostingWithUser(jobPostingId);
+  },
+
+  /**
+   * 본인이 협업하는 공고 목록 (공유받은 공고 섹션용)
+   */
+  async listSharedJobPostings(): Promise<SharedJobPosting[]> {
+    const userId = await getCurrentUserIdOrThrow();
+    return jobPostingCollaboratorRepository.findSharedJobPostingsForUser(userId);
+  },
+
+  /**
+   * 이메일로 사용자 검색 (workspace owner 가 협업자 추가 시)
+   */
+  async searchCandidates(input: {
+    jobPostingId: string;
+    emailQuery: string;
+  }): Promise<CollaboratorSearchCandidate[]> {
+    const parsed = searchCollaboratorCandidateSchema.safeParse(input);
+    const data = validateOrThrow(parsed);
+    return jobPostingCollaboratorRepository.searchByEmail(data.jobPostingId, data.emailQuery);
+  },
+
+  /**
+   * 협업자 추가 (workspace owner 만 — RLS 가 강제)
+   * 알림은 DB trigger (notify_on_collaborator_added) 가 자동 발송
+   */
+  async add(input: { jobPostingId: string; userId: string }): Promise<JobPostingCollaborator> {
+    const parsed = addCollaboratorSchema.safeParse(input);
+    const data = validateOrThrow(parsed);
+
+    const currentUserId = await getCurrentUserIdOrThrow();
+    if (currentUserId === data.userId) {
+      throw new ValidationError(ERROR_CODES.VALIDATION_SCHEMA, {
+        userMessage: '본인은 협업자로 추가할 수 없습니다',
+      });
+    }
+
+    logger.info('협업자 추가 (Service)', data);
+    return jobPostingCollaboratorRepository.add(data.jobPostingId, data.userId, currentUserId);
+  },
+
+  /**
+   * 협업자 제거 (workspace owner 또는 본인 — RLS 가 강제)
+   * 알림은 DB trigger (notify_on_collaborator_removed) 가 자동 발송 (본인 제거 시 skip)
+   */
+  async remove(input: { jobPostingId: string; userId: string }): Promise<void> {
+    const parsed = removeCollaboratorSchema.safeParse(input);
+    const data = validateOrThrow(parsed);
+
+    logger.info('협업자 제거 (Service)', data);
+    return jobPostingCollaboratorRepository.remove(data.jobPostingId, data.userId);
+  },
+
+  /**
+   * collaborator 본인 나가기 (편의 메서드)
+   */
+  async leaveSelf(jobPostingId: string): Promise<void> {
+    const userId = await getCurrentUserIdOrThrow();
+    logger.info('협업자 자가 제거', { jobPostingId, userId });
+    return jobPostingCollaboratorRepository.remove(jobPostingId, userId);
+  },
+};

--- a/uniqn-mobile/src/services/jobs/index.ts
+++ b/uniqn-mobile/src/services/jobs/index.ts
@@ -90,3 +90,6 @@ export {
   type SearchProvider,
   type SearchServiceConfig,
 } from './searchService';
+
+// 공고별 협업자 (Phase 5 — feat/job-posting-collaborators)
+export { collaboratorService } from './collaboratorService';

--- a/uniqn-mobile/src/types/jobPostingCollaborator.ts
+++ b/uniqn-mobile/src/types/jobPostingCollaborator.ts
@@ -1,0 +1,60 @@
+/**
+ * UNIQN Mobile - 공고별 협업자 도메인 타입
+ *
+ * @description 공고 단위 협업자 권한 (workspace editor 와 별개의 입자)
+ *              camelCase 도메인 / snake_case DB 분리 (memory: supabase-patterns #1)
+ * @version 1.0.0
+ */
+
+/**
+ * 공고별 협업자 — D1 OR 평가, D2 풀 관리권
+ */
+export interface JobPostingCollaborator {
+  id: string;
+  jobPostingId: string;
+  userId: string;
+  addedBy: string;
+  /** ISO 8601 (timestamptz) */
+  addedAt: string;
+}
+
+/**
+ * 협업자 + 사용자 표시 정보 결합 (UI 리스트용)
+ */
+export interface JobPostingCollaboratorWithUser extends JobPostingCollaborator {
+  displayName: string | null;
+  email: string | null;
+  photoUrl: string | null;
+}
+
+/**
+ * 공유받은 공고 (collaborator 본인 시점) — 출처 워크스페이스 정보 포함
+ */
+export interface SharedJobPosting {
+  jobPostingId: string;
+  jobPostingTitle: string;
+  workspaceId: string;
+  workspaceName: string;
+  addedAt: string;
+}
+
+/**
+ * 협업자 추가 시 검색 결과 항목
+ */
+export interface CollaboratorSearchCandidate {
+  userId: string;
+  displayName: string | null;
+  email: string;
+  photoUrl: string | null;
+  /** 자기 자신 / workspace 이미 멤버 / 이미 collaborator / 추가 가능 */
+  status: 'self' | 'workspace_member' | 'already_collaborator' | 'addable' | 'not_registered';
+}
+
+export const COLLABORATOR_LIMITS = {
+  /** MVP cap 없음 — abuse 모니터링 후 결정 */
+  MAX_PER_POSTING: null as number | null,
+  /** 이메일 검색 debounce ms */
+  SEARCH_DEBOUNCE_MS: 300,
+  /** 이메일 검색 최소 길이 */
+  SEARCH_MIN_CHARS: 3,
+} as const;

--- a/uniqn-mobile/supabase/migrations/20260515000000_jpc_table_and_helper.sql
+++ b/uniqn-mobile/supabase/migrations/20260515000000_jpc_table_and_helper.sql
@@ -1,0 +1,48 @@
+-- 공고별 협업자 (job_posting_collaborators) — Phase 1.1
+-- 기획: docs/superpowers/specs/2026-05-11-job-posting-collaborators-design.md
+-- 플랜: docs/superpowers/plans/2026-05-11-job-posting-collaborators.md (Task 1.1)
+--
+-- D7: workspace_members 확장이 아닌 별도 테이블 (외부인이 ws_members 더럽힘 회피)
+-- D2: 풀 관리권 (UI/Service 레이어에서 강제, 본 테이블은 부여 사실만 저장)
+-- 자가 추가 차단: CHECK (user_id != added_by)
+-- cascade: 공고 삭제 / user 탈퇴 시 collaborator 행도 삭제
+
+CREATE TABLE public.job_posting_collaborators (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_posting_id  uuid NOT NULL REFERENCES public.job_postings(id) ON DELETE CASCADE,
+  user_id         uuid NOT NULL REFERENCES auth.users(id)          ON DELETE CASCADE,
+  added_by        uuid NOT NULL REFERENCES auth.users(id),
+  added_at        timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (job_posting_id, user_id),
+  CHECK (user_id != added_by)
+);
+
+CREATE INDEX idx_jpc_user_id    ON public.job_posting_collaborators(user_id);
+CREATE INDEX idx_jpc_posting_id ON public.job_posting_collaborators(job_posting_id);
+
+ALTER TABLE public.job_posting_collaborators ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE public.job_posting_collaborators IS
+  '공고 단위 협업자 — workspace editor 와 별개의 입자 권한 (D1 OR 평가)';
+
+-- is_posting_collaborator 헬퍼 — RLS 정책 핫패스
+-- is_workspace_member 와 같은 패턴 (SECURITY DEFINER + STABLE + search_path 격리)
+-- 메모리 학습: pitfall_rls_with_check_self_select_recursion — 무한 재귀 회피
+CREATE FUNCTION public.is_posting_collaborator(p_posting_id uuid, p_user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = ''
+STABLE
+AS $$
+  SELECT EXISTS(
+    SELECT 1 FROM public.job_posting_collaborators
+    WHERE job_posting_id = p_posting_id AND user_id = p_user_id
+  );
+$$;
+
+COMMENT ON FUNCTION public.is_posting_collaborator IS
+  '공고별 협업자 여부 — RLS 정책 핫패스. workspace_members 와 OR 평가.';
+
+GRANT EXECUTE ON FUNCTION public.is_posting_collaborator(uuid, uuid) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.is_posting_collaborator(uuid, uuid) FROM PUBLIC, anon;

--- a/uniqn-mobile/supabase/migrations/20260515010000_jpc_audit_log.sql
+++ b/uniqn-mobile/supabase/migrations/20260515010000_jpc_audit_log.sql
@@ -1,0 +1,74 @@
+-- 공고별 협업자 audit log — Phase 1.2
+-- 플랜: docs/superpowers/plans/2026-05-11-job-posting-collaborators.md (Task 1.2)
+--
+-- D11: 보안 중요 액션 (권한 부여/회수) 이력 보존
+-- D11 Codex fix: source 컬럼 (user/system/cascade) — actor_user_id 신뢰성 강화
+-- DELETE 후 added_by/added_at 손실 방지
+
+CREATE TABLE public.job_posting_collaborator_audit (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_posting_id  uuid NOT NULL,                                  -- FK 안 검 (공고 삭제돼도 보존)
+  target_user_id  uuid NOT NULL,                                  -- FK 안 검 (탈퇴해도 보존)
+  actor_user_id   uuid,                                           -- NULL 허용 (system/cascade)
+  action          text NOT NULL CHECK (action IN ('added','removed')),
+  source          text NOT NULL DEFAULT 'user' CHECK (source IN ('user','system','cascade')),
+  at              timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_jpca_posting_id ON public.job_posting_collaborator_audit(job_posting_id, at DESC);
+CREATE INDEX idx_jpca_target_id  ON public.job_posting_collaborator_audit(target_user_id, at DESC);
+
+ALTER TABLE public.job_posting_collaborator_audit ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE public.job_posting_collaborator_audit IS
+  '공고별 협업자 추가/제거 이력 — workspace owner 만 SELECT, trigger 만 쓰기';
+
+-- AFTER INSERT/DELETE 트리거 함수
+-- auth.uid() 가 NULL (cascade/service role/백그라운드) 일 때 source='cascade'/'system' 으로 구분
+CREATE FUNCTION public.log_collaborator_audit() RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+  v_actor uuid;
+BEGIN
+  v_actor := auth.uid();
+  IF TG_OP = 'INSERT' THEN
+    INSERT INTO public.job_posting_collaborator_audit
+      (job_posting_id, target_user_id, actor_user_id, action, source)
+    VALUES (
+      NEW.job_posting_id, NEW.user_id,
+      NEW.added_by,                                              -- INSERT 시 added_by 가 신뢰원천
+      'added',
+      CASE WHEN v_actor IS NULL THEN 'system' ELSE 'user' END
+    );
+  ELSIF TG_OP = 'DELETE' THEN
+    INSERT INTO public.job_posting_collaborator_audit
+      (job_posting_id, target_user_id, actor_user_id, action, source)
+    VALUES (
+      OLD.job_posting_id, OLD.user_id,
+      v_actor,                                                   -- DELETE 시 auth.uid() 만 신뢰
+      'removed',
+      CASE WHEN v_actor IS NULL THEN 'cascade' ELSE 'user' END
+    );
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER trg_jpca_log
+  AFTER INSERT OR DELETE ON public.job_posting_collaborators
+  FOR EACH ROW EXECUTE FUNCTION public.log_collaborator_audit();
+
+-- RLS: workspace owner 만 SELECT (운영 가시성)
+-- 트리거(SECURITY DEFINER)가 쓰기 전담, 사용자 직접 INSERT/UPDATE/DELETE 차단
+CREATE POLICY "audit_select_owner"
+  ON public.job_posting_collaborator_audit
+  FOR SELECT
+  USING (
+    EXISTS(
+      SELECT 1 FROM public.job_postings jp
+      JOIN public.workspaces w ON w.id = jp.workspace_id
+      WHERE jp.id = job_posting_collaborator_audit.job_posting_id
+        AND w.owner_id = (SELECT auth.uid())
+    )
+  );

--- a/uniqn-mobile/supabase/migrations/20260515020000_jpc_self_rls.sql
+++ b/uniqn-mobile/supabase/migrations/20260515020000_jpc_self_rls.sql
@@ -1,0 +1,51 @@
+-- job_posting_collaborators 자체 RLS — Phase 1.3
+-- 플랜: docs/superpowers/plans/2026-05-11-job-posting-collaborators.md (Task 1.3)
+--
+-- SELECT: collaborator 본인 OR workspace 멤버
+-- INSERT: workspace owner 만 (D6 MVP)
+-- DELETE: workspace owner OR 본인 (자기 발 빼기)
+-- UPDATE: 정책 없음 — 행 immutable, 변경 시 DELETE + INSERT
+--
+-- 메모리 학습: pitfall_rls_with_check_self_select_recursion — WITH CHECK 자기 self-SELECT 피함
+
+-- SELECT: collaborator 본인
+CREATE POLICY "jpc_select_self"
+  ON public.job_posting_collaborators FOR SELECT
+  USING (user_id = (SELECT auth.uid()));
+
+-- SELECT: workspace 멤버 (owner OR editor)
+CREATE POLICY "jpc_select_ws_member"
+  ON public.job_posting_collaborators FOR SELECT
+  USING (
+    EXISTS(
+      SELECT 1 FROM public.job_postings jp
+      WHERE jp.id = job_posting_id
+        AND public.is_workspace_member(jp.workspace_id, (SELECT auth.uid()))
+    )
+  );
+
+-- INSERT: workspace owner 만 (D6 MVP)
+CREATE POLICY "jpc_insert_ws_owner"
+  ON public.job_posting_collaborators FOR INSERT
+  WITH CHECK (
+    EXISTS(
+      SELECT 1 FROM public.job_postings jp
+      JOIN public.workspaces w ON w.id = jp.workspace_id
+      WHERE jp.id = job_posting_id
+        AND w.owner_id = (SELECT auth.uid())
+    )
+    AND added_by = (SELECT auth.uid())                          -- 본인이 추가했다고만 기록 가능
+  );
+
+-- DELETE: workspace owner 가 제거 OR 본인 나가기 (단일 정책 OR)
+CREATE POLICY "jpc_delete_owner_or_self"
+  ON public.job_posting_collaborators FOR DELETE
+  USING (
+    user_id = (SELECT auth.uid())                               -- 본인 나가기
+    OR EXISTS(
+      SELECT 1 FROM public.job_postings jp
+      JOIN public.workspaces w ON w.id = jp.workspace_id
+      WHERE jp.id = job_posting_id
+        AND w.owner_id = (SELECT auth.uid())                    -- workspace owner 가 제거
+    )
+  );

--- a/uniqn-mobile/supabase/migrations/20260515030000_jpc_extend_existing_rls.sql
+++ b/uniqn-mobile/supabase/migrations/20260515030000_jpc_extend_existing_rls.sql
@@ -1,0 +1,151 @@
+-- 기존 RLS 정책 OR 확장 — Phase 2
+-- 플랜: docs/superpowers/plans/2026-05-11-job-posting-collaborators.md (Task 2.1~2.5)
+-- Audit 결과 (commit 37fcc06c7): 5 테이블 12 정책 + workspaces SELECT
+--
+-- 변경 정책 목록 (audit 확정):
+-- - workspaces:    workspaces_select_owner_or_member
+-- - job_postings:  jp_select_managed, jp_update_workspace_member
+-- - applications:  app_select, app_update
+-- - work_logs:     wl_select, wl_update  (정산은 payroll 필드 — 자동 포함)
+-- - event_qr_codes: qr_select, qr_update, qr_delete (Spec 누락 보정)
+
+-- ============================================================================
+-- 1. workspaces — useSharedJobPostings JOIN 용 (Codex outside-voice fix)
+-- ============================================================================
+DROP POLICY IF EXISTS "workspaces_select_owner_or_member" ON public.workspaces;
+CREATE POLICY "workspaces_select_owner_or_member"
+  ON public.workspaces FOR SELECT
+  USING (
+    public.is_workspace_member(id, (SELECT auth.uid()))
+    OR EXISTS(
+      SELECT 1 FROM public.job_postings jp
+      JOIN public.job_posting_collaborators jpc ON jpc.job_posting_id = jp.id
+      WHERE jp.workspace_id = workspaces.id
+        AND jpc.user_id = (SELECT auth.uid())
+    )
+    OR (SELECT public.is_admin())
+  );
+
+-- ============================================================================
+-- 2. job_postings — jp_select_managed, jp_update_workspace_member
+-- ============================================================================
+DROP POLICY IF EXISTS "jp_select_managed" ON public.job_postings;
+CREATE POLICY "jp_select_managed"
+  ON public.job_postings FOR SELECT
+  USING (
+    (owner_id = (SELECT auth.uid()))
+    OR public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+    OR public.is_posting_collaborator(id, (SELECT auth.uid()))
+  );
+
+DROP POLICY IF EXISTS "jp_update_workspace_member" ON public.job_postings;
+CREATE POLICY "jp_update_workspace_member"
+  ON public.job_postings FOR UPDATE
+  USING (
+    public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+    OR public.is_posting_collaborator(id, (SELECT auth.uid()))
+    OR (SELECT public.is_admin())
+  )
+  WITH CHECK (
+    public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+    OR public.is_posting_collaborator(id, (SELECT auth.uid()))
+    OR (SELECT public.is_admin())
+  );
+
+-- ============================================================================
+-- 3. applications — app_select, app_update
+-- ============================================================================
+DROP POLICY IF EXISTS "app_select" ON public.applications;
+CREATE POLICY "app_select"
+  ON public.applications FOR SELECT
+  USING (
+    (applicant_id = (SELECT auth.uid()))
+    OR (job_posting_id IN (
+      SELECT id FROM public.job_postings
+      WHERE owner_id = (SELECT auth.uid())
+        OR public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+        OR public.is_posting_collaborator(id, (SELECT auth.uid()))
+    ))
+  );
+
+DROP POLICY IF EXISTS "app_update" ON public.applications;
+CREATE POLICY "app_update"
+  ON public.applications FOR UPDATE
+  USING (
+    (applicant_id = (SELECT auth.uid()))
+    OR (job_posting_id IN (
+      SELECT id FROM public.job_postings
+      WHERE owner_id = (SELECT auth.uid())
+        OR public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+        OR public.is_posting_collaborator(id, (SELECT auth.uid()))
+    ))
+  );
+
+-- ============================================================================
+-- 4. work_logs — wl_select, wl_update (정산 payroll 필드 자동 포함)
+-- ============================================================================
+DROP POLICY IF EXISTS "wl_select" ON public.work_logs;
+CREATE POLICY "wl_select"
+  ON public.work_logs FOR SELECT
+  USING (
+    (staff_id = (SELECT auth.uid()))
+    OR (owner_id = (SELECT auth.uid()))
+    OR (job_posting_id IN (
+      SELECT id FROM public.job_postings
+      WHERE public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+        OR public.is_posting_collaborator(id, (SELECT auth.uid()))
+    ))
+  );
+
+DROP POLICY IF EXISTS "wl_update" ON public.work_logs;
+CREATE POLICY "wl_update"
+  ON public.work_logs FOR UPDATE
+  USING (
+    (staff_id = (SELECT auth.uid()))
+    OR (owner_id = (SELECT auth.uid()))
+    OR (job_posting_id IN (
+      SELECT id FROM public.job_postings
+      WHERE public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+        OR public.is_posting_collaborator(id, (SELECT auth.uid()))
+    ))
+  );
+
+-- ============================================================================
+-- 5. event_qr_codes — qr_select, qr_update, qr_delete (Spec 누락 보정)
+-- ============================================================================
+DROP POLICY IF EXISTS "qr_select" ON public.event_qr_codes;
+CREATE POLICY "qr_select"
+  ON public.event_qr_codes FOR SELECT
+  USING (
+    (user_id = (SELECT auth.uid()))
+    OR (job_posting_id IN (
+      SELECT id FROM public.job_postings
+      WHERE owner_id = (SELECT auth.uid())
+        OR public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+        OR public.is_posting_collaborator(id, (SELECT auth.uid()))
+    ))
+  );
+
+DROP POLICY IF EXISTS "qr_update" ON public.event_qr_codes;
+CREATE POLICY "qr_update"
+  ON public.event_qr_codes FOR UPDATE
+  USING (
+    (user_id = (SELECT auth.uid()))
+    OR (job_posting_id IN (
+      SELECT id FROM public.job_postings
+      WHERE public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+        OR public.is_posting_collaborator(id, (SELECT auth.uid()))
+    ))
+  );
+
+DROP POLICY IF EXISTS "qr_delete" ON public.event_qr_codes;
+CREATE POLICY "qr_delete"
+  ON public.event_qr_codes FOR DELETE
+  USING (
+    (user_id = (SELECT auth.uid()))
+    OR (job_posting_id IN (
+      SELECT id FROM public.job_postings
+      WHERE public.is_workspace_member(workspace_id, (SELECT auth.uid()))
+        OR public.is_posting_collaborator(id, (SELECT auth.uid()))
+    ))
+  );

--- a/uniqn-mobile/supabase/migrations/20260515040000_jpc_status_transition_collab.sql
+++ b/uniqn-mobile/supabase/migrations/20260515040000_jpc_status_transition_collab.sql
@@ -1,0 +1,53 @@
+-- enforce_jp_status_transition collaborator 분기 — Phase 2.6 (audit 신규 발견)
+-- 플랜: docs/superpowers/plans/2026-05-11-job-posting-collaborators.md (Task 2.6)
+-- 기존 함수: 20260514050000_enforce_jp_status_transition.sql
+--
+-- 발견 (Phase 0 audit): 공고 status 변경 (active|closed → cancelled) trigger 가
+-- workspace owner OR admin 만 허용. D2 풀 관리권에 따라 collaborator 도 cancel 가능해야.
+
+CREATE OR REPLACE FUNCTION public.enforce_jp_status_transition()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller_uid uuid;
+  v_is_workspace_owner boolean;
+  v_is_admin boolean;
+  v_is_collaborator boolean;
+BEGIN
+  -- 보호 대상: active|closed → cancelled (soft-delete 경로)
+  IF NEW.status = 'cancelled' AND OLD.status IN ('active', 'closed') THEN
+    v_caller_uid := (SELECT auth.uid());
+
+    -- service-side bypass: 시드/마이그레이션/cron/SECURITY DEFINER RPC
+    IF v_caller_uid IS NULL THEN
+      RETURN NEW;
+    END IF;
+
+    SELECT EXISTS (
+      SELECT 1 FROM public.workspaces
+      WHERE id = NEW.workspace_id AND owner_id = v_caller_uid
+    ) INTO v_is_workspace_owner;
+
+    -- 메모리 룰: app role 식별은 auth.jwt() -> 'app_metadata' ->> 'role'
+    v_is_admin := coalesce(
+      (auth.jwt() -> 'app_metadata' ->> 'role') = 'admin',
+      false
+    );
+
+    -- D2 collaborator 추가 (audit 발견)
+    v_is_collaborator := public.is_posting_collaborator(NEW.id, v_caller_uid);
+
+    IF NOT (v_is_workspace_owner OR v_is_admin OR v_is_collaborator) THEN
+      RAISE EXCEPTION
+        'permission denied: only workspace owner, admin, or collaborator can cancel job posting (id=%)',
+        NEW.id
+        USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;

--- a/uniqn-mobile/supabase/migrations/20260515050000_jpc_notification_triggers.sql
+++ b/uniqn-mobile/supabase/migrations/20260515050000_jpc_notification_triggers.sql
@@ -1,0 +1,167 @@
+-- 공고별 협업자 알림 트리거 + 신규 지원자 알림 수신자 확장 — Phase 3
+-- 플랜: docs/superpowers/plans/2026-05-11-job-posting-collaborators.md (Phase 3)
+--
+-- 실제 알림 메커니즘 (audit 확정):
+-- - notification_outbox 미존재 → INSERT INTO public.notifications 직접
+-- - AFTER INSERT statement trigger 가 send-push-notification edge function 호출
+-- - 따라서 본 trigger 는 notifications 행만 만들면 푸시는 자동
+--
+-- Codex outside-voice 가드:
+-- - auth.uid() IS NULL (cascade/service) 시 알림 skip
+-- - 본인이 자기 발 빼기 시 알림 skip (스스로 한 행위)
+
+-- ============================================================================
+-- 1. notify_on_collaborator_added — owner 가 추가한 협업자에게 알림
+-- ============================================================================
+CREATE FUNCTION public.notify_on_collaborator_added() RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = 'public', 'extensions'
+AS $$
+DECLARE
+  v_caller_uid    uuid;
+  v_job_title     text;
+  v_adder_name    text;
+BEGIN
+  v_caller_uid := (SELECT auth.uid());
+
+  -- cascade / service role → 알림 skip
+  IF v_caller_uid IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT title INTO v_job_title
+  FROM public.job_postings WHERE id = NEW.job_posting_id;
+
+  SELECT COALESCE(raw_user_meta_data->>'name', email)
+  INTO v_adder_name
+  FROM auth.users WHERE id = NEW.added_by;
+
+  INSERT INTO public.notifications (
+    recipient_id, type, title, body, link, data, priority
+  ) VALUES (
+    NEW.user_id,
+    'job_posting_collaborator_added',
+    '🤝 공고 관리 초대',
+    format('%s님이 ''%s'' 공고 관리에 초대했어요',
+           COALESCE(v_adder_name, '동료'),
+           COALESCE(v_job_title, '해당 공고')),
+    format('/my-postings/%s', NEW.job_posting_id),
+    jsonb_build_object(
+      'jobPostingId', NEW.job_posting_id,
+      'addedBy', NEW.added_by,
+      'addedAt', NEW.added_at,
+      'senderId', NEW.added_by
+    ),
+    'normal'
+  );
+
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING '[notify_on_collaborator_added] failed for jpc % — %', NEW.id, SQLERRM;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_jpc_added_notify
+  AFTER INSERT ON public.job_posting_collaborators
+  FOR EACH ROW EXECUTE FUNCTION public.notify_on_collaborator_added();
+
+-- ============================================================================
+-- 2. notify_on_collaborator_removed — owner 가 제거한 협업자에게 알림
+--    (본인 발 빼기 시 OLD.user_id = auth.uid() 이므로 skip)
+-- ============================================================================
+CREATE FUNCTION public.notify_on_collaborator_removed() RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = 'public', 'extensions'
+AS $$
+DECLARE
+  v_caller_uid uuid;
+  v_job_title  text;
+BEGIN
+  v_caller_uid := (SELECT auth.uid());
+
+  -- cascade / service / 본인 발 빼기 → 알림 skip
+  IF v_caller_uid IS NULL OR v_caller_uid = OLD.user_id THEN
+    RETURN OLD;
+  END IF;
+
+  SELECT title INTO v_job_title
+  FROM public.job_postings WHERE id = OLD.job_posting_id;
+
+  INSERT INTO public.notifications (
+    recipient_id, type, title, body, link, data, priority
+  ) VALUES (
+    OLD.user_id,
+    'job_posting_collaborator_removed',
+    '공고 관리 제외',
+    format('''%s'' 공고 관리에서 제외되었어요',
+           COALESCE(v_job_title, '해당 공고')),
+    '/my-postings',
+    jsonb_build_object(
+      'jobPostingId', OLD.job_posting_id,
+      'senderId', v_caller_uid
+    ),
+    'normal'
+  );
+
+  RETURN OLD;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING '[notify_on_collaborator_removed] failed for jpc % — %', OLD.id, SQLERRM;
+  RETURN OLD;
+END;
+$$;
+
+CREATE TRIGGER trg_jpc_removed_notify
+  AFTER DELETE ON public.job_posting_collaborators
+  FOR EACH ROW EXECUTE FUNCTION public.notify_on_collaborator_removed();
+
+-- ============================================================================
+-- 3. notify_on_application_insert 확장 — owner + workspace editor + collaborator UNION
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.notify_on_application_insert() RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = 'public', 'extensions'
+AS $$
+DECLARE
+  v_job_title text;
+  v_workspace_id uuid;
+BEGIN
+  SELECT title, workspace_id INTO v_job_title, v_workspace_id
+  FROM public.job_postings WHERE id = NEW.job_posting_id;
+
+  IF v_workspace_id IS NULL THEN
+    RETURN NEW;                                                  -- 공고 없으면 스킵
+  END IF;
+
+  -- 수신자 UNION: workspace owner + editors + collaborators (중복 자동 제거)
+  INSERT INTO public.notifications (
+    recipient_id, type, title, body, link, data, priority
+  )
+  SELECT
+    r.recipient_id,
+    'new_application',
+    '📨 새로운 지원자',
+    format('%s님이 ''%s''에 지원했습니다.', NEW.applicant_name, COALESCE(v_job_title, '해당 공고')),
+    format('/employer/applicants/%s', NEW.job_posting_id),
+    jsonb_build_object(
+      'applicationId', NEW.id,
+      'jobPostingId', NEW.job_posting_id,
+      'applicantId', NEW.applicant_id,
+      'applicantName', NEW.applicant_name,
+      'jobPostingTitle', COALESCE(v_job_title, ''),
+      'senderId', NEW.applicant_id
+    ),
+    'normal'
+  FROM (
+    SELECT owner_id AS recipient_id FROM public.workspaces WHERE id = v_workspace_id
+    UNION
+    SELECT user_id  AS recipient_id FROM public.workspace_members WHERE workspace_id = v_workspace_id
+    UNION
+    SELECT user_id  AS recipient_id FROM public.job_posting_collaborators WHERE job_posting_id = NEW.job_posting_id
+  ) r
+  WHERE r.recipient_id IS NOT NULL
+    AND r.recipient_id != NEW.applicant_id;                      -- 본인 알림 안 함
+
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING '[notify_on_application_insert] failed for application % — %', NEW.id, SQLERRM;
+  RETURN NEW;
+END;
+$$;

--- a/uniqn-mobile/supabase/migrations/20260515060000_jpc_realtime_publication.sql
+++ b/uniqn-mobile/supabase/migrations/20260515060000_jpc_realtime_publication.sql
@@ -1,0 +1,11 @@
+-- Realtime publication ADD TABLE — Phase 4
+-- 플랜: docs/superpowers/plans/2026-05-11-job-posting-collaborators.md (Phase 4)
+--
+-- D9: collaborator 추가/제거 실시간 동기화 — 푸시 알림 받은 직후 my-postings 자동 갱신
+-- 메모리 학습: pitfall_realtime_publication_required — 새 테이블 사용 시 publication 등록 필수
+
+ALTER PUBLICATION supabase_realtime ADD TABLE public.job_posting_collaborators;
+
+-- 검증 (마이그레이션 후 수동):
+-- SELECT schemaname, tablename FROM pg_publication_tables
+-- WHERE pubname = 'supabase_realtime' AND tablename = 'job_posting_collaborators';

--- a/uniqn-mobile/supabase/migrations/20260515070000_jpc_perf_consolidation.sql
+++ b/uniqn-mobile/supabase/migrations/20260515070000_jpc_perf_consolidation.sql
@@ -1,0 +1,28 @@
+-- Performance advisor 권고 반영 — Phase 10
+-- 1. multiple_permissive_policies: jpc SELECT 2개 → 단일 OR 정책으로 통합
+-- 2. unindexed_foreign_keys: job_posting_collaborators.added_by 에 인덱스 추가
+--
+-- 참조: docs/superpowers/plans/2026-05-11-job-posting-collaborators.md (Phase 10)
+-- Supabase advisor: 0006_multiple_permissive_policies, 0001_unindexed_foreign_keys
+
+-- ============================================================================
+-- 1. SELECT 정책 통합 (jpc_select_self OR jpc_select_ws_member)
+-- ============================================================================
+DROP POLICY IF EXISTS "jpc_select_self"      ON public.job_posting_collaborators;
+DROP POLICY IF EXISTS "jpc_select_ws_member" ON public.job_posting_collaborators;
+
+CREATE POLICY "jpc_select"
+  ON public.job_posting_collaborators FOR SELECT
+  USING (
+    user_id = (SELECT auth.uid())                                         -- collaborator 본인
+    OR EXISTS(                                                            -- workspace 멤버 (owner OR editor)
+      SELECT 1 FROM public.job_postings jp
+      WHERE jp.id = job_posting_id
+        AND public.is_workspace_member(jp.workspace_id, (SELECT auth.uid()))
+    )
+  );
+
+-- ============================================================================
+-- 2. added_by FK 인덱스 추가
+-- ============================================================================
+CREATE INDEX idx_jpc_added_by ON public.job_posting_collaborators(added_by);

--- a/uniqn-mobile/supabase/migrations/20260515080000_jpc_search_users_rpc.sql
+++ b/uniqn-mobile/supabase/migrations/20260515080000_jpc_search_users_rpc.sql
@@ -1,0 +1,76 @@
+-- P0 review fix: searchByEmail RLS bypass via SECURITY DEFINER RPC
+--
+-- 발견: users_select RLS 가 (auth.uid()=id OR admin) 만 허용 → workspace owner 가
+--       다른 사용자를 이메일로 검색 불가 (.from('users').ilike 가 빈 결과 반환)
+--
+-- 해결: SECURITY DEFINER 함수 — workspace owner 검증 후 검색 결과 반환
+-- 보안 가드:
+-- 1. 호출자가 p_job_posting_id 의 workspace owner 인지 검증 (외부 enumeration 차단)
+-- 2. 이메일 prefix 검색 시 와일드카드 (%, _, \) 이스케이프 (3자 최소 우회 차단)
+-- 3. 최대 10건 반환 (DoS 완화)
+-- 4. anon REVOKE — 미인증 호출 차단
+
+CREATE OR REPLACE FUNCTION public.search_users_for_collaborator_invite(
+  p_job_posting_id uuid,
+  p_email_query    text
+)
+RETURNS TABLE (
+  id        uuid,
+  email     text,
+  name      text,
+  nickname  text,
+  photo_url text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+STABLE
+AS $$
+DECLARE
+  v_caller_uid uuid;
+  v_is_owner   boolean;
+  v_escaped    text;
+BEGIN
+  v_caller_uid := (SELECT auth.uid());
+
+  IF v_caller_uid IS NULL THEN
+    RAISE EXCEPTION 'authentication required'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- 호출자가 해당 공고의 workspace owner 인지 검증
+  -- (외부 사용자 enumeration 차단 — 무작위 공고 ID 추측해도 검색 불가)
+  SELECT EXISTS(
+    SELECT 1 FROM public.job_postings jp
+    JOIN public.workspaces w ON w.id = jp.workspace_id
+    WHERE jp.id = p_job_posting_id AND w.owner_id = v_caller_uid
+  ) INTO v_is_owner;
+
+  IF NOT v_is_owner THEN
+    RAISE EXCEPTION 'permission denied: workspace owner required'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- 빈/짧은 쿼리는 거부 (UI 가드와 별개로 server-side 강제)
+  IF p_email_query IS NULL OR length(trim(p_email_query)) < 3 THEN
+    RETURN;
+  END IF;
+
+  -- ILIKE 와일드카드 이스케이프: % _ \ → \% \_ \\
+  -- replace 순서 중요: 백슬래시 먼저 처리해야 후속 이스케이프가 망가지지 않음
+  v_escaped := replace(replace(replace(trim(p_email_query), '\', '\\'), '%', '\%'), '_', '\_');
+
+  RETURN QUERY
+  SELECT u.id, u.email, u.name, u.nickname, u.photo_url
+  FROM public.users u
+  WHERE u.email ILIKE v_escaped || '%' ESCAPE '\'
+    AND coalesce(u.is_active, true) = true
+  LIMIT 10;
+END;
+$$;
+
+COMMENT ON FUNCTION public.search_users_for_collaborator_invite IS
+  'workspace owner 의 collaborator 후보 검색 — RLS bypass + 와일드카드 이스케이프 + 최대 10건';
+
+GRANT EXECUTE ON FUNCTION public.search_users_for_collaborator_invite(uuid, text) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.search_users_for_collaborator_invite(uuid, text) FROM PUBLIC, anon;


### PR DESCRIPTION
## Summary

워크스페이스의 all-or-nothing 권한 모델에 **공고 단위 협업자(collaborator) 입자**를 추가. 외부 UNIQN 가입자에게 특정 공고 1개만 풀 위임 가능.

- **D1 이중 권한**: workspace editor 전체 + collaborator 공고별 (OR 평가)
- **D2 풀 관리권**: collaborator 는 해당 공고의 조회/수정/지원자/근태/정산/QR 가능. **삭제만 owner 전용**
- **D4 즉시 권한 부여**: 수락 단계 없음, 푸시 알림 발송, 받는 사람 "나가기" 가능
- **데이터 격리**: collaborator 는 다른 공고/멤버를 절대 못 봄 (RLS 격리)

Spec: `docs/superpowers/specs/2026-05-11-job-posting-collaborators-design.md`
Plan: `docs/superpowers/plans/2026-05-11-job-posting-collaborators.md`

## 변경 요약

### DB (8 마이그레이션 prod 적용 완료)
- `job_posting_collaborators` 본 테이블 + `is_posting_collaborator` 헬퍼 (SECURITY DEFINER)
- `job_posting_collaborator_audit` + AFTER 트리거 (source=user/system/cascade)
- jpc 자체 RLS: SELECT(self OR ws_member 단일 통합) / INSERT(ws_owner) / DELETE(owner OR self)
- 기존 RLS OR 확장: 5 테이블 10 정책 (workspaces / job_postings / applications / work_logs / event_qr_codes)
- `enforce_jp_status_transition` trigger 에 collaborator 분기 추가
- `notify_on_collaborator_added/removed` 트리거 + `notify_on_application_insert` UNION 확장 (owner + editor + collaborator)
- Realtime publication 등록
- Performance advisor 권고: multiple_permissive_policies 해소 + added_by FK 인덱스 추가

### Client
- Types / Zod schemas / Repository (interface + supabase impl)
- collaboratorService (list / listShared / search / add / remove / leaveSelf)
- Hooks: useJobPostingCollaborators (TanStack + Realtime + mutations), useSharedJobPostings
- Components: CollaboratorRow / List / Search / AvatarStack (`@/components/icons` 사용, dark: 적용)
- 라우트: `app/(employer)/my-postings/[id]/collaborators.tsx` (modal presentation)
- 통합: 공고 상세 ActionCard ("공유 관리") + employer 탭 "공유받은 공고" 섹션

### 테스트 + 검증
- collaboratorService Jest 13/13 통과 (Zod / 자가 추가 / 인증 가드 / Repository 위임)
- TypeScript `tsc --noEmit`: 통과
- ESLint + Prettier: 통과
- EXPLAIN ANALYZE: 목록 4.97ms, helper 3.62ms — 회귀 없음
- Supabase advisor: WARN 1 (multiple_permissive) → 해소, INFO 1 (unindexed_fk) → 인덱스 추가

## Phase 0 Audit 핵심 발견 (스펙 보정)

- `staff_assignments` / `settlements` 테이블 미존재 — 정산은 `work_logs.payroll` 필드. work_logs RLS OR 추가로 자동 부여
- `event_qr_codes` 가 Spec 누락 → Phase 2 에 추가 (qr_select/update/delete 3 정책)
- `enforce_jp_status_transition` trigger 신규 task 분리 (collaborator status 변경 권한)
- PR3-A.2 와 비충돌 (admin 제거 vs collaborator OR 추가, 정책 분기 직교)

## NOT in scope (후속 작업)

- pg_prove RLS 매트릭스 80 케이스 (5 테이블 × 4 페르소나 × 4 작업) — 별도 PR 권장
- Hook / Repository / UI integration Jest 테스트 — 별도 PR 권장
- Storage bucket RLS (이력서 첨부 체계 미확정 시)
- 협업자 권한 차등 (manager/viewer) — MVP D2 결정대로 풀 관리권만
- 이메일 검색 user enumeration 방어 (rate limit / audit) — 별도 보안 작업

## Test plan

- [ ] master 워크스페이스에 prod 마이그레이션 8개 적용됨 확인 (이미 적용)
- [ ] owner 계정으로 공고 상세 → "공유 관리" 진입 → 이메일 검색 → 협업자 추가 → 아바타 +1 확인
- [ ] collaborator 계정에서 employer 탭 "공유받은 공고" 섹션 노출 확인
- [ ] collaborator 계정에서 공유받은 공고 상세 진입 → 지원자/근태/정산 접근 가능 확인
- [ ] collaborator 계정에서 공고 "삭제" 불가 확인 (RLS 차단)
- [ ] owner 가 협업자 제거 → 푸시 알림 발송 + collaborator 화면에서 즉시 제거 (Realtime)
- [ ] collaborator 본인이 "나가기" → 알림 미발송 (본인 행위)
- [ ] 자가 추가 시도 시 친절 메시지 ("본인은 협업자로 추가할 수 없습니다")
- [ ] 중복 추가 시도 시 친절 메시지 ("이미 협업 중인 사용자입니다")
- [ ] Audit log 테이블에 add/remove 이력 기록됨 + source 컬럼 정확 (user/system/cascade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)