### PR TITLE
test(jpc): C2 fix 후속 — jpc INSERT/DELETE invoker 패턴 복원

### DIFF
--- a/uniqn-mobile/supabase/fixtures/jpc_helpers.sql
+++ b/uniqn-mobile/supabase/fixtures/jpc_helpers.sql
@@ -10,12 +10,16 @@
 --             보고 "No plan found in TAP output" 으로 fail. supabase/fixtures/
 --             분리. npm run test:db:helpers 가 docker cp 으로 등록.
 --
--- 이 파일에는 SECURITY DEFINER 함수 12개가 포함되어 RLS 를 완전히 우회합니다:
---   - jpc_test_force_delete_workspace / _jp / _jpc / force_insert_jpc
+-- 이 파일에는 SECURITY DEFINER 함수들이 포함되어 RLS 를 완전히 우회합니다:
+--   - jpc_test_force_delete_workspace (workspaces.DELETE 정책 부재 = deny-all 우회)
+--   - jpc_test_force_delete_jp (FK ON DELETE NO ACTION 시 app/wl/qr cascade utility)
+--   - jpc_check_can_delete_jp (jp DELETE owner case — FK cascade utility 로 정책 동등 평가)
 --   - jpc_test_create_user / delete_user / transfer_ws_owner
 --   - jpc_test_seed / count_jpc / audit_source / count_notif_* / get_ws_owner
 --
 -- 이 헬퍼들은 RLS 정책 검증의 부수효과 확인용 (cascade/trigger/audit) 입니다.
+-- 2026-05-13: C2 fix (PR #91) 후 jpc INSERT/DELETE cycle 해소 → invoker 패턴 복원.
+--             jpc_test_force_delete_jpc / jpc_test_force_insert_jpc 제거.
 -- migrations/ 폴더로 옮기거나 prod DB 에 직접 등록하면 ANY authenticated user 가
 -- workspace/jp/jpc 의 RLS 를 우회 가능 — catastrophic security incident.
 --
@@ -319,36 +323,10 @@ BEGIN
 END;
 $$;
 
--- C4/C5 의 jpc DELETE 도 정책 USING (jpc_delete_owner_or_self) 의
--- EXISTS (job_postings JOIN workspaces) → workspaces SELECT JPC JOIN 분기 →
--- job_posting_collaborators SELECT RLS 재진입 → recursion.
--- SECURITY DEFINER 우회로 DELETE 수행 + audit trigger (auth.uid() 는 invoker
--- 의 jwt 를 그대로 읽음) 동작 검증.
-CREATE OR REPLACE FUNCTION jpc_test_force_delete_jpc(p_jp_id uuid, p_user_id uuid)
-RETURNS void
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = public, pg_temp
-AS $$
-BEGIN
-  DELETE FROM public.job_posting_collaborators
-   WHERE job_posting_id = p_jp_id AND user_id = p_user_id;
-END;
-$$;
-
--- C9 jpc INSERT 도 jpc_insert_ws_owner WITH CHECK 안 workspaces JOIN → 같은 recursion.
--- SECURITY DEFINER 우회로 INSERT 수행 + trigger (notify_on_collaborator_added) 동작 검증.
-CREATE OR REPLACE FUNCTION jpc_test_force_insert_jpc(p_jp uuid, p_user uuid, p_added_by uuid)
-RETURNS void
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = public, pg_temp
-AS $$
-BEGIN
-  INSERT INTO public.job_posting_collaborators (job_posting_id, user_id, added_by)
-  VALUES (p_jp, p_user, p_added_by);
-END;
-$$;
+-- 2026-05-13: jpc_test_force_delete_jpc / jpc_test_force_insert_jpc 제거.
+-- C2 fix (PR #91, 20260515100000) 로 workspaces SELECT JPC JOIN cycle 해소 →
+-- jpc DELETE (jpc_delete_owner_or_self) / INSERT (jpc_insert_ws_owner) 가
+-- invoker 권한으로 직접 호출 가능. jpc_cascade.test.sql C4/C5/C9/C10 참조.
 
 -- C6 검증용 (workspaces.SELECT RLS 우회로 owner_id 확인)
 CREATE OR REPLACE FUNCTION jpc_test_get_ws_owner(p_ws_id uuid)

--- a/uniqn-mobile/supabase/tests/jpc_cascade.test.sql
+++ b/uniqn-mobile/supabase/tests/jpc_cascade.test.sql
@@ -83,12 +83,11 @@ BEGIN
 END $$;
 
 SELECT jpc_test_set_user((current_setting('jpc.c4_collab'))::uuid);
--- 직접 DELETE 는 jpc_delete_owner_or_self USING 의 workspaces JOIN → RLS recursion
--- (job_posting_collaborators). SECURITY DEFINER 우회 + auth.uid() 는 invoker context 유지.
-SELECT jpc_test_force_delete_jpc(
-  (current_setting('jpc.c4_jp'))::uuid,
-  (current_setting('jpc.c4_collab'))::uuid
-);
+-- C2 fix 후 (PR #91, 20260515100000) cycle 해소 — invoker 직접 DELETE 검증 가능.
+-- jpc_delete_owner_or_self USING 의 workspaces JOIN 이 cycle-free 가 됨.
+DELETE FROM public.job_posting_collaborators
+ WHERE job_posting_id = (current_setting('jpc.c4_jp'))::uuid
+   AND user_id        = (current_setting('jpc.c4_collab'))::uuid;
 
 SELECT is(
   jpc_test_audit_source(
@@ -111,10 +110,10 @@ BEGIN
 END $$;
 
 SELECT jpc_test_set_user((current_setting('jpc.c5_owner'))::uuid);
-SELECT jpc_test_force_delete_jpc(
-  (current_setting('jpc.c5_jp'))::uuid,
-  (current_setting('jpc.c5_collab'))::uuid
-);
+-- C2 fix 후 cycle 해소 — invoker 직접 DELETE.
+DELETE FROM public.job_posting_collaborators
+ WHERE job_posting_id = (current_setting('jpc.c5_jp'))::uuid
+   AND user_id        = (current_setting('jpc.c5_collab'))::uuid;
 
 SELECT is(
   jpc_test_audit_actor(
@@ -218,8 +217,10 @@ BEGIN
 END $$;
 
 SELECT jpc_test_set_user((current_setting('jpc.c9_owner'))::uuid);
--- jpc_insert_ws_owner WITH CHECK 안 workspaces JOIN → RLS recursion. SECURITY DEFINER 우회.
-SELECT jpc_test_force_insert_jpc(
+-- C2 fix 후 cycle 해소 — invoker 직접 INSERT.
+-- jpc_insert_ws_owner WITH CHECK 안 workspaces JOIN 이 cycle-free 가 됨.
+INSERT INTO public.job_posting_collaborators (job_posting_id, user_id, added_by)
+VALUES (
   (current_setting('jpc.c9_jp'))::uuid,
   (current_setting('jpc.c9_new_user'))::uuid,
   (current_setting('jpc.c9_owner'))::uuid
@@ -237,10 +238,10 @@ SELECT is(
 -- C10: owner 가 C9 collab 제거 → notifications removed 1행
 -- ============================================================================
 SELECT jpc_test_set_user((current_setting('jpc.c9_owner'))::uuid);
-SELECT jpc_test_force_delete_jpc(
-  (current_setting('jpc.c9_jp'))::uuid,
-  (current_setting('jpc.c9_new_user'))::uuid
-);
+-- C2 fix 후 cycle 해소 — invoker 직접 DELETE.
+DELETE FROM public.job_posting_collaborators
+ WHERE job_posting_id = (current_setting('jpc.c9_jp'))::uuid
+   AND user_id        = (current_setting('jpc.c9_new_user'))::uuid;
 
 SELECT is(
   jpc_test_count_notif_for_user(

--- a/uniqn-mobile/supabase/tests/jpc_job_postings_rls.test.sql
+++ b/uniqn-mobile/supabase/tests/jpc_job_postings_rls.test.sql
@@ -122,31 +122,31 @@ WITH u AS (UPDATE public.job_postings SET title='u-outsider' WHERE id=(current_s
 SELECT is((SELECT count(*)::int FROM u), 0, 'job_postings UPDATE: outsider denied');
 
 -- ============================================================================
--- DELETE (4 케이스) — jpc_check_can_delete_jp SECURITY DEFINER 함수로 정책 동등 평가.
--- 직접 DELETE 는 jp_delete_workspace_owner USING 의 SELECT FROM workspaces →
--- workspaces JPC JOIN 분기 → job_postings SELECT RLS recursion (42P17) 으로 검증 불가.
+-- DELETE (4 케이스) — C2 fix 후 cycle 해소 (PR #91, 20260515100000) 로 invoker
+-- 직접 DELETE 검증 가능 (editor/collab/outsider 3 case = RLS 차단으로 0 rows).
 -- 정책: job_postings_delete_owner_or_admin OR jp_delete_workspace_owner
 --      = (jp.owner = self) OR (ws.owner = self) OR is_admin
 -- seed: jp.owner = ws.owner = v_owner → owner 만 ALLOW
+--
+-- owner case 는 jpc_test_seed 의 applications/work_logs/event_qr_codes
+-- (FK ON DELETE NO ACTION) 로 인해 invoker 직접 DELETE 시 23503 발생.
+-- jpc_check_can_delete_jp 로 정책 동등 평가 유지 (cascade utility).
 -- ============================================================================
-SELECT is(
-  public.jpc_check_can_delete_jp((current_setting('jpc.editor_id'))::uuid, (current_setting('jpc.jp_id'))::uuid),
-  false, 'job_postings DELETE: ws_editor denied (ws.owner 아님)'
-);
+SELECT jpc_test_set_user((current_setting('jpc.editor_id'))::uuid);
+WITH d AS (DELETE FROM public.job_postings WHERE id=(current_setting('jpc.jp_id'))::uuid RETURNING 1)
+SELECT is((SELECT count(*)::int FROM d), 0, 'job_postings DELETE: ws_editor denied (ws.owner 아님)');
 
-SELECT is(
-  public.jpc_check_can_delete_jp((current_setting('jpc.collab_id'))::uuid, (current_setting('jpc.jp_id'))::uuid),
-  false, 'job_postings DELETE: collaborator denied (D2: 풀 관리권만)'
-);
+SELECT jpc_test_set_user((current_setting('jpc.collab_id'))::uuid);
+WITH d AS (DELETE FROM public.job_postings WHERE id=(current_setting('jpc.jp_id'))::uuid RETURNING 1)
+SELECT is((SELECT count(*)::int FROM d), 0, 'job_postings DELETE: collaborator denied (D2: 풀 관리권만)');
 
-SELECT is(
-  public.jpc_check_can_delete_jp((current_setting('jpc.outsider_id'))::uuid, (current_setting('jpc.jp_id'))::uuid),
-  false, 'job_postings DELETE: outsider denied'
-);
+SELECT jpc_test_set_user((current_setting('jpc.outsider_id'))::uuid);
+WITH d AS (DELETE FROM public.job_postings WHERE id=(current_setting('jpc.jp_id'))::uuid RETURNING 1)
+SELECT is((SELECT count(*)::int FROM d), 0, 'job_postings DELETE: outsider denied');
 
 SELECT is(
   public.jpc_check_can_delete_jp((current_setting('jpc.owner_id'))::uuid, (current_setting('jpc.jp_id'))::uuid),
-  true, 'job_postings DELETE: owner (jp.owner + ws.owner)'
+  true, 'job_postings DELETE: owner (jp.owner + ws.owner; FK cascade utility 로 SECDEF 유지)'
 );
 
 SELECT * FROM finish();


### PR DESCRIPTION
## 요약

PR #91 (C2 fix) 로 `workspaces_select_owner_or_member` JPC JOIN cycle 이 해소되어, PR #90 에서 RLS recursion 회피용으로 도입했던 SECURITY DEFINER 우회 helper 중 jpc 단일 INSERT/DELETE 케이스를 invoker 패턴으로 복원.

## 배경

PR #90 (JPC 매트릭스) 머지 당시 직접 `INSERT/DELETE FROM job_posting_collaborators` 가 PostgreSQL `42P17 infinite recursion` 으로 실패. workspaces SELECT 의 JPC JOIN 분기가 root cause. PR #90 작업자는 SECURITY DEFINER 함수로 우회. PR #91 가 cycle 자체를 해소하여 우회 helper 가 불필요해짐.

## 복원 (5 사용처)

| 파일 | 케이스 | 이전 (SECDEF) | 본 PR (invoker) |
|---|---|---|---|
| `jpc_cascade.test.sql` | C4 (collab self-leave) | `jpc_test_force_delete_jpc` | `DELETE FROM jpc WHERE ...` |
| `jpc_cascade.test.sql` | C5 (owner removes collab) | `jpc_test_force_delete_jpc` | `DELETE FROM jpc WHERE ...` |
| `jpc_cascade.test.sql` | C9 (owner adds collab) | `jpc_test_force_insert_jpc` | `INSERT INTO jpc VALUES ...` |
| `jpc_cascade.test.sql` | C10 (owner removes C9 collab) | `jpc_test_force_delete_jpc` | `DELETE FROM jpc WHERE ...` |
| `jpc_job_postings_rls.test.sql` | DELETE editor/collab/outsider 3 case | `jpc_check_can_delete_jp` (boolean) | `WITH d AS (DELETE ...) SELECT is(count, 0, ...)` |

## 제거 (jpc_helpers.sql)

- `jpc_test_force_delete_jpc` (4 사용처 모두 invoker 로 교체)
- `jpc_test_force_insert_jpc` (1 사용처 invoker 로 교체)

## 유지 (FK 또는 RLS-uninvolved 사유)

| Helper | 유지 사유 |
|---|---|
| `jpc_test_force_delete_jp` | jp 시드의 applications/work_logs/event_qr_codes 가 FK ON DELETE NO ACTION → invoker DELETE 시 23503. cascade verification utility |
| `jpc_check_can_delete_jp` | DELETE owner case 동일 FK 이슈. 정책 동등 평가로 boolean 반환 유지 |
| `jpc_test_force_delete_workspace` | workspaces.DELETE 정책 부재 = deny-all (C2 무관) |
| `jpc_test_seed/create_user/delete_user/transfer_ws_owner` | auth.users INSERT + RLS-uninvolved setup |
| `jpc_test_count_*/audit_*/get_ws_owner` | audit/notifications RLS 좁아 invoker 검증 불가 |

## 검증

- **PR #91 §4.2 prod 검증 (사전 완료)**: minimal jp 시드 → owner 페르소나 DELETE 성공, workspaces SELECT 1행 반환 → cycle 부재 입증
- **본 PR**: DB Tests CI (pg_prove) 매트릭스 통과 — `jpc_cascade plan(10)` + `jpc_job_postings_rls 16/16`
- 실패 시 시그널: cycle 해소가 부분적이거나 C2 fix 자체 회귀

## Scope guard

- 변경 금지: src/, app/, migrations/ (본 PR 은 test infra cleanup only)
- 허용: supabase/fixtures/, supabase/tests/

## Test plan

- [ ] DB Tests (pg_prove) workflow 통과
- [ ] CI: type-check / lint / format / Tests / Bundle Size 등 통과
- [ ] 매트릭스 16/16 (jpc_job_postings_rls) + plan(10) (jpc_cascade) 모두 PASS

## 참조

- PR #91 plan: `docs/superpowers/plans/2026-05-12-c2-rls-jp-delete-recursion-fix.md`
- 메모리: pitfall_rls_jpc_recursion_widespread (cycle root cause), feedback_subagent_dispatch_guards (시드 helper scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)