### PR TITLE
test(jpc): event_qr_codes DELETE 4 케이스 복원 — plan(16) (3b)

### DIFF
--- a/uniqn-mobile/supabase/fixtures/jpc_helpers.sql
+++ b/uniqn-mobile/supabase/fixtures/jpc_helpers.sql
@@ -226,7 +226,7 @@ CREATE OR REPLACE FUNCTION jpc_seed_extra_qr(p_jp_id uuid, p_user_id uuid)
 RETURNS uuid
 LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = public, pg_temp
+SET search_path = public, extensions, pg_temp
 AS $$
 DECLARE
   v_qr uuid := gen_random_uuid();

--- a/uniqn-mobile/supabase/fixtures/jpc_helpers.sql
+++ b/uniqn-mobile/supabase/fixtures/jpc_helpers.sql
@@ -216,6 +216,35 @@ END;
 $$;
 
 -- ============================================================================
+-- 추가 event_qr_code 시드 (SECURITY DEFINER — RLS 우회)
+-- DELETE 4 케이스 매트릭스 (jpc_event_qr_codes_rls) 가 같은 row 1건에 대해
+-- SAVEPOINT/ROLLBACK TO 로 격리하던 패턴이 pg_prove 환경에서 silent drop 됨.
+-- 4 페르소나 별 개별 qr_id 시드 → SAVEPOINT 불필요 → plan(16) 복원.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION jpc_seed_extra_qr(p_jp_id uuid, p_user_id uuid)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_qr uuid := gen_random_uuid();
+  v_work_date date := current_date + 14;
+BEGIN
+  INSERT INTO public.event_qr_codes (
+    id, job_posting_id, user_id, type, code, work_date, is_active, expires_at, created_at
+  )
+  VALUES (
+    v_qr, p_jp_id, p_user_id, 'checkIn',
+    encode(gen_random_bytes(16), 'hex'),
+    v_work_date::text, true, now() + interval '1 day', now()
+  );
+  RETURN v_qr;
+END;
+$$;
+
+-- ============================================================================
 -- service_role 우회 헬퍼 (cascade/owner 이양 시나리오용)
 -- 메모리: pitfall_set_config_role_not_role_switch
 -- ============================================================================

--- a/uniqn-mobile/supabase/tests/jpc_event_qr_codes_rls.test.sql
+++ b/uniqn-mobile/supabase/tests/jpc_event_qr_codes_rls.test.sql
@@ -33,15 +33,9 @@
 -- DELETE 4 케이스는 SAVEPOINT 로 격리 (같은 row 1건이므로).
 
 BEGIN;
--- plan(16) → plan(12): DELETE 4 케이스 (SAVEPOINT 패턴) 가 pg_prove 환경에서
--- silent drop 됨 (planned 16 / ran 12). 로컬 supabase 부팅 drift 로 디버그 path
--- 막힘 (memory: pitfall_local_supabase_helper_drift). 후속 PR 에서 추적.
---   - 가설: SAVEPOINT 안의 set_config local 이 ROLLBACK TO 시 reset 되어
---     `is()` 결과가 emit 안 됨
---   - 또는 WITH d AS (DELETE...) SELECT is() 패턴이 CTE 안 DELETE 의 RLS reject 시
---     pgTAP 카운트 안 됨
--- 디버그 후 복원 시 plan(16) + DELETE 4 케이스 주석 해제.
-SELECT plan(12);
+-- plan(16) 복원: DELETE 4 케이스를 4 개 개별 qr_id 시드로 분리하여 SAVEPOINT
+-- 패턴 silent drop 회피 (jpc_seed_extra_qr helper 추가, 메모리 권장 옵션 1).
+SELECT plan(16);
 
 DO $$
 DECLARE s RECORD;
@@ -53,6 +47,16 @@ BEGIN
   PERFORM set_config('jpc.outsider_id', s.outsider_id::text,     true);
   PERFORM set_config('jpc.jp_id',       s.job_posting_id::text,  true);
   PERFORM set_config('jpc.qr_id',       s.qr_code_id::text,      true);
+
+  -- DELETE 4 케이스용 추가 qr 시드 (각 페르소나 명의로 1개씩, SAVEPOINT 불필요)
+  PERFORM set_config('jpc.qr_id_owner',
+    jpc_seed_extra_qr(s.job_posting_id, s.owner_id)::text, true);
+  PERFORM set_config('jpc.qr_id_editor',
+    jpc_seed_extra_qr(s.job_posting_id, s.ws_editor_id)::text, true);
+  PERFORM set_config('jpc.qr_id_collab',
+    jpc_seed_extra_qr(s.job_posting_id, s.collaborator_id)::text, true);
+  PERFORM set_config('jpc.qr_id_outsider',
+    jpc_seed_extra_qr(s.job_posting_id, s.outsider_id)::text, true);
 END $$;
 
 -- ============================================================================
@@ -186,61 +190,49 @@ SELECT is((SELECT count(*)::int FROM u), 1,
   'event_qr_codes UPDATE: user_id 본인 (user_id=self)');
 
 -- ============================================================================
--- DELETE (4 케이스) — 후속 PR 에서 복원
+-- DELETE (4 케이스) — 4 개 개별 qr_id 시드로 SAVEPOINT 없이 검증
 -- ============================================================================
--- 본 PR 에서 일시 주석 처리. plan mismatch (planned 16 / ran 12) 의 원인이
--- SAVEPOINT + ROLLBACK TO 패턴인지 다른 원인인지 디버그 필요. 로컬 supabase
--- 부팅 drift (memory: pitfall_local_supabase_helper_drift) 로 CI iteration 만으로
--- 추적 어려움. 후속 PR 에서:
---   1. SAVEPOINT 없이 4 개별 qr_id row 시드 (jpc_seed_extra_qr helper 추가)
---   2. 또는 SAVEPOINT 안의 set_config local 동작 추적 + 패치
---   3. plan(12) → plan(16) 복원 + 본 4 케이스 주석 해제
---
--- /*
--- SAVEPOINT sp_delete_owner;
--- SELECT jpc_test_set_user((current_setting('jpc.owner_id'))::uuid);
--- WITH d AS (
---   DELETE FROM public.event_qr_codes
---    WHERE id = (current_setting('jpc.qr_id'))::uuid
---   RETURNING 1
--- )
--- SELECT is((SELECT count(*)::int FROM d), 1,
---   'event_qr_codes DELETE: owner ALLOW (is_workspace_member via ws.owner_id)');
--- ROLLBACK TO SAVEPOINT sp_delete_owner;
---
--- SAVEPOINT sp_delete_editor;
--- SELECT jpc_test_set_user((current_setting('jpc.editor_id'))::uuid);
--- WITH d AS (
---   DELETE FROM public.event_qr_codes
---    WHERE id = (current_setting('jpc.qr_id'))::uuid
---   RETURNING 1
--- )
--- SELECT is((SELECT count(*)::int FROM d), 1,
---   'event_qr_codes DELETE: ws_editor ALLOW (is_workspace_member)');
--- ROLLBACK TO SAVEPOINT sp_delete_editor;
---
--- SAVEPOINT sp_delete_collab;
--- SELECT jpc_test_set_user((current_setting('jpc.collab_id'))::uuid);
--- WITH d AS (
---   DELETE FROM public.event_qr_codes
---    WHERE id = (current_setting('jpc.qr_id'))::uuid
---   RETURNING 1
--- )
--- SELECT is((SELECT count(*)::int FROM d), 1,
---   'event_qr_codes DELETE: collaborator ALLOW (is_posting_collaborator)');
--- ROLLBACK TO SAVEPOINT sp_delete_collab;
---
--- SAVEPOINT sp_delete_outsider;
--- SELECT jpc_test_set_user((current_setting('jpc.outsider_id'))::uuid);
--- WITH d AS (
---   DELETE FROM public.event_qr_codes
---    WHERE id = (current_setting('jpc.qr_id'))::uuid
---   RETURNING 1
--- )
--- SELECT is((SELECT count(*)::int FROM d), 1,
---   'event_qr_codes DELETE: outsider 본인 ALLOW (user_id=self)');
--- ROLLBACK TO SAVEPOINT sp_delete_outsider;
--- */
+-- 각 페르소나 명의의 qr 를 자기 권한으로 DELETE. 정책 OR 분기 평가:
+--   owner    → is_workspace_member (ws.owner=self) ALLOW
+--   editor   → is_workspace_member ALLOW
+--   collab   → is_posting_collaborator ALLOW
+--   outsider → user_id=self ALLOW (qr.user_id = outsider_id)
+
+SELECT jpc_test_set_user((current_setting('jpc.owner_id'))::uuid);
+WITH d AS (
+  DELETE FROM public.event_qr_codes
+   WHERE id = (current_setting('jpc.qr_id_owner'))::uuid
+  RETURNING 1
+)
+SELECT is((SELECT count(*)::int FROM d), 1,
+  'event_qr_codes DELETE: owner ALLOW (is_workspace_member via ws.owner_id)');
+
+SELECT jpc_test_set_user((current_setting('jpc.editor_id'))::uuid);
+WITH d AS (
+  DELETE FROM public.event_qr_codes
+   WHERE id = (current_setting('jpc.qr_id_editor'))::uuid
+  RETURNING 1
+)
+SELECT is((SELECT count(*)::int FROM d), 1,
+  'event_qr_codes DELETE: ws_editor ALLOW (is_workspace_member)');
+
+SELECT jpc_test_set_user((current_setting('jpc.collab_id'))::uuid);
+WITH d AS (
+  DELETE FROM public.event_qr_codes
+   WHERE id = (current_setting('jpc.qr_id_collab'))::uuid
+  RETURNING 1
+)
+SELECT is((SELECT count(*)::int FROM d), 1,
+  'event_qr_codes DELETE: collaborator ALLOW (is_posting_collaborator)');
+
+SELECT jpc_test_set_user((current_setting('jpc.outsider_id'))::uuid);
+WITH d AS (
+  DELETE FROM public.event_qr_codes
+   WHERE id = (current_setting('jpc.qr_id_outsider'))::uuid
+  RETURNING 1
+)
+SELECT is((SELECT count(*)::int FROM d), 1,
+  'event_qr_codes DELETE: outsider 본인 ALLOW (user_id=self)');
 
 SELECT * FROM finish();
 ROLLBACK;


### PR DESCRIPTION
## 요약

PR #90 머지 시점에 SAVEPOINT/ROLLBACK TO 패턴이 pg_prove 환경에서 silent drop 되어 plan mismatch (planned 16 / ran 12) 발생. DELETE 4 케이스가 주석 fallback 됐었음. 메모리 권장 옵션 1 (4 개 개별 qr_id 시드) 로 복원.

## 변경

### 1. `jpc_helpers.sql` — `jpc_seed_extra_qr` 추가

```sql
CREATE OR REPLACE FUNCTION jpc_seed_extra_qr(p_jp_id uuid, p_user_id uuid)
RETURNS uuid
LANGUAGE plpgsql
SECURITY DEFINER
SET search_path = public, pg_temp
AS $$ ... $$;
```

### 2. `jpc_event_qr_codes_rls.test.sql`

- `plan(12)` → `plan(16)`
- 시드 DO block 에 추가 qr 4개 시드 (`qr_id_owner / qr_id_editor / qr_id_collab / qr_id_outsider`)
- DELETE 4 케이스 주석 해제, SAVEPOINT 제거
- 각 페르소나가 자기 명의 qr 를 DELETE 시도 (정책 OR 분기로 모두 ALLOW)
- ROLLBACK 으로 전체 cleanup

## 정책 매트릭스 (16/16 ALLOW invariant 유지)

| Op | owner | editor | collab | outsider |
|---|---|---|---|---|
| SELECT | ✓ (jp.owner) | ✓ (ws_member) | ✓ (jpc) | ✓ (user_id) |
| INSERT | ✓ | ✓ | ✓ | ✓ (gap) |
| UPDATE | ✓ | ✓ | ✓ | ✓ (user_id) |
| **DELETE** | ✓ (ws_member) | ✓ (ws_member) | ✓ (jpc) | ✓ (user_id) |

DELETE 4 케이스도 SELECT/UPDATE 와 동일한 invariant 추가 — SECURITY GAP 가시화.

## 검증 기준

- DB Tests CI (pg_prove) 매트릭스 16/16 PASS
- `jpc_event_qr_codes_rls plan(16)` 매치
- 다른 매트릭스 5 파일 회귀 없음

## Scope guard

- 변경 금지: src/, app/, migrations/, 정책 자체 (SECURITY GAP invariant 유지)
- 허용: supabase/fixtures/, supabase/tests/

## Test plan

- [ ] DB Tests (pg_prove) workflow 통과
- [ ] CI 전체 통과
- [ ] `event_qr_codes_rls plan(16)` 매치

## 참조

- 메모리: `pitfall_local_supabase_helper_drift` (SAVEPOINT silent drop 가설)
- PR #90 `plan(12)` fallback 결정 commit 메시지

🤖 Generated with [Claude Code](https://claude.com/claude-code)