### PR TITLE
refactor(auth): 세션 비활성 타임아웃 제거 + Supabase auto-refresh 위임

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -80,3 +80,15 @@
 - 알림 emitter 통합: notifications 중복 SQL fix 후 code path 레거시 참조 정리
 - **레거시 trigger 함수 본체 정리**: `tr_notify_*` trigger DROP 후 `fn_notify_*` 함수 참조 경로 최종 확인 → DROP FUNCTION (2026-04-20 감사 `.gstack/qa-reports/LEGACY-TRIGGERS-AUDIT.md`)
 - **tr_notify_tournament_approval 이관**: UPDATE(재제출) 경로를 `notify_on_job_posting_update` 또는 전용 신규 trigger로 이관 후 레거시 DROP — 현재는 INSERT 중복이지만 재제출 알림 유실 방지 위해 보존
+
+## 옵저버빌리티 (2026-04-25 plan-eng-review)
+
+### tokenRefreshService → fcmTokenRefreshService 이름 변경
+
+- **What**: `src/services/observability/tokenRefreshService.ts`의 파일명/심볼/주석을 FCM 토큰 전용임이 드러나도록 변경. 이름이 "auth token 갱신"으로 읽혀 새로 들어온 사람이 Supabase 세션 코드와 혼동하기 쉬움.
+- **Why**: 실제 책임은 FCM(푸시) 토큰 주기 갱신 + Exponential Backoff 재시도. 본 plan(`2026-04-25-session-keep-alive`) 작성 중 Supabase auth token과 별개임을 추론하느라 시간 낭비. 다음 사람도 같은 함정에 빠질 가능성 높음.
+- **Pros**: 코드 의도가 즉시 명확. 검색/grep 시 auth와 분리됨. CLAUDE.md/AGENTS.md 새 룰 불필요.
+- **Cons**: import 경로 변경되는 파일 ~10개. 별도 PR 필요 (`chore` 스코프).
+- **Context**: 파일 헤더 주석 (line 1-12): "FCM 토큰 갱신 서비스 (Exponential Backoff 기반)" — 이미 명확하나 파일명이 거짓말. `src/hooks/useFCMTokenManager.ts`가 주 호출자.
+- **Depends on / blocked by**: `2026-04-25-session-keep-alive` PR 머지 후 (충돌 회피).
+- **Status**: 후속 chore PR로 처리 예정.

--- a/uniqn-mobile/app/_layout.tsx
+++ b/uniqn-mobile/app/_layout.tsx
@@ -1,5 +1,5 @@
 import '../global.css';
-import { Suspense, lazy, useCallback, useEffect, useRef } from 'react';
+import { Suspense, lazy, useEffect } from 'react';
 import { Stack } from 'expo-router';
 import { setStatusBarStyle } from 'expo-status-bar';
 import { LogBox, Platform, View } from 'react-native';
@@ -120,7 +120,6 @@ const SUPPRESSED_WARNINGS = [
   'Image: style.tintColor is deprecated',
   'SafeAreaView has been deprecated',
 ];
-const TOUCH_THROTTLE_MS = 5_000;
 const AuthenticatedRuntime = lazy(() => import('@/components/app/AuthenticatedRuntime'));
 
 try {
@@ -149,31 +148,6 @@ function MainNavigator() {
   const user = useAuthStore((state) => state.user);
   const isDark = isDarkMode;
   const isAuthenticated = !!user;
-  const lastTouchRef = useRef(0);
-
-  const handleTouchActivity = useCallback(() => {
-    if (!isAuthenticated) {
-      return;
-    }
-
-    const now = Date.now();
-    if (now - lastTouchRef.current <= TOUCH_THROTTLE_MS) {
-      return;
-    }
-
-    lastTouchRef.current = now;
-
-    void import('@/services/observability')
-      .then(({ recordActivity }) => {
-        recordActivity();
-      })
-      .catch((error) => {
-        logger.debug('Failed to load authenticated activity runtime', {
-          component: 'RootLayout',
-          error: error instanceof Error ? error.message : String(error),
-        });
-      });
-  }, [isAuthenticated]);
 
   useEffect(() => {
     const effectiveMode = mode === 'system' ? (isDark ? 'dark' : 'light') : mode;
@@ -193,7 +167,7 @@ function MainNavigator() {
   const cssVarStyle = Platform.OS !== 'web' ? vars(getCssVarTokens(isDark)) : undefined;
 
   return (
-    <View style={[{ flex: 1 }, cssVarStyle]} onTouchStart={handleTouchActivity}>
+    <View style={[{ flex: 1 }, cssVarStyle]}>
       {isAuthenticated ? (
         <Suspense fallback={null}>
           <AuthenticatedRuntime />

--- a/uniqn-mobile/docs/superpowers/plans/2026-04-25-session-keep-alive.md
+++ b/uniqn-mobile/docs/superpowers/plans/2026-04-25-session-keep-alive.md
@@ -1,0 +1,649 @@
+# 세션 유지 — 비활성 타임아웃 제거 및 Supabase auto-refresh 위임
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 앱에 직접 구현된 30분 비활성 세션 만료 로직을 제거하고, 세션 수명 관리를 Supabase SDK의 `autoRefreshToken` + `persistSession`에 완전히 위임한다. 사용자는 refresh token이 만료(기본 30일)될 때까지 재로그인 없이 세션을 이어간다.
+
+**Architecture:** `sessionService.ts`의 책임을 3가지 독립 관심사로 정리:
+
+1. **유지할 것:** `onAuthStateChange` → `authStore` 동기화, 로그인 시도 rate limiting (브루트포스 방어), 초기 부트스트랩 가드 (캐시 복원 타이밍)
+2. **삭제할 것:** 30분 비활성 타임아웃, 경고 토스트, 강제 `signOut`, 수동 `refreshSession` 인터벌 (SDK 내장 기능과 이중 구현), `recordActivity` export
+3. **SDK에 위임:** 모든 토큰 수명 관리 (access token 자동 갱신, refresh token 만료 감지)
+
+**Tech Stack:** TypeScript 5.9, Supabase JS v2 (`autoRefreshToken: true`, `persistSession: true`, `AsyncStorage`), Zustand, Jest 29, Expo Router v4
+
+**Blast Radius:**
+
+- `src/services/observability/sessionService.ts` (~600줄 → ~120줄, 관심사 A만 유지)
+- **NEW** `src/services/auth/loginAttemptService.ts` (~100줄, 관심사 B 분리)
+- `src/services/auth/authCoreService.ts` (import 경로 업데이트 1곳)
+- `src/services/observability/index.ts` (export 정리)
+- `src/services/observability/__tests__/sessionService.test.ts` (테스트 재작성)
+- **NEW** `src/services/auth/__tests__/loginAttemptService.test.ts` (login rate limit 테스트 이관)
+- `src/hooks/useAppInitialize.ts` (AppState 리스너에 `startAutoRefresh`/`stopAutoRefresh` 훅 추가)
+- `app/_layout.tsx` (`recordActivity` 호출 제거)
+- `src/hooks/useNavigationTracking.ts` (`recordActivity` 제거)
+
+**영향 밖 (의도적):** `src/stores/authStore.ts`의 `suppressedSessionUserId` 필드는 **유지**. 비활성 타임아웃과 무관하고 "auto-login 비활성화 후 자동 복원 차단" 기능에 독립적으로 사용됨 (`authStore.ts:407-417`의 `clearAutoLoginBlockedSession` 경로).
+
+---
+
+## Task 0.5: Supabase Auth 프로젝트 설정 확인 (사전 점검)
+
+Plan은 "기본 30일 refresh token, 1h access token"을 전제하지만, Supabase Dashboard 설정이 다를 수 있다. 구현 전 실제 값 확인.
+
+**Files:** N/A (설정 조회 후 plan 본문 갱신)
+
+- [ ] **Step 1: MCP로 Supabase Auth 설정 조회**
+
+  ```
+  mcp__supabase__execute_sql:
+    SELECT
+      raw_app_meta_data->'config'->>'jwt_exp' as jwt_exp,
+      raw_app_meta_data->'config'->>'refresh_token_rotation_enabled' as rotation_enabled,
+      raw_app_meta_data->'config'->>'security_refresh_token_reuse_interval' as reuse_interval
+    FROM auth.config LIMIT 1;
+  ```
+
+  또는 Supabase Dashboard → Authentication → Sessions에서 직접 확인:
+  - JWT expiry (access token)
+  - Refresh token rotation
+  - Refresh token reuse interval
+  - Inactivity timeout (없으면 무한)
+  - Time-box (절대 만료 시간)
+
+- [ ] **Step 2: Plan 본문 갱신**
+
+  실측 값으로 본문 "기본 30일" 부분 교체. Inactivity/timebox가 활성화돼 있다면 본 plan의 전제가 부분 무효 → 사용자에게 confirm 후 진행.
+
+---
+
+## Task 1: 제거 대상 / 유지 대상 정리
+
+현재 `sessionService.ts` 구조를 기준으로 변경 범위를 확정한다.
+
+**Files:**
+
+- Read: `src/services/observability/sessionService.ts`
+
+- [ ] **Step 1: 제거 대상 확정 (line 번호 기준)**
+
+  | 대상      | 범위                                                                                                                                | 사유                               |
+  | --------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+  | 상수      | `SESSION_TIMEOUT`, `SESSION_WARNING_BUFFER`, `TOKEN_REFRESH_INTERVAL` (20-22)                                                       | 비활성 타임아웃 제거               |
+  | 모듈 상태 | `lastActivity`, `sessionTimeoutId`, `sessionWarningTimeoutId`, `tokenRefreshIntervalId`, `managedSessionUserId` (41-48)             | 타임아웃 관리 제거                 |
+  | 헬퍼      | `shouldManageSessionForUser`, `clearSessionRuntime`, `syncManagedSessionState` (51-86)                                              | 타임아웃 전용                      |
+  | 이벤트    | `handleAppStateChange` 내 session-check/clearTimeout 분기 (226-238)                                                                 | 포그라운드 세션 체크 불필요        |
+  | 함수      | `checkSession`, `resetActivityTimer`, `clearSessionTimeout`, `clearSessionWarning`, `showSessionWarning`, `expireSession` (300-386) | 30분 만료 로직                     |
+  | 함수      | `startTokenRefreshInterval`, `clearTokenRefreshInterval`, `checkAndRefreshToken` (388-430)                                          | SDK autoRefreshToken과 중복        |
+  | Export    | `recordActivity`, `refreshToken`, `getValidToken`, `isSessionActive`, `getSessionState`                                             | 프로덕션 미사용 또는 타임아웃 전용 |
+
+- [ ] **Step 2: 유지 대상 확정**
+
+  | 대상                     | 사유                                                                                                                                                                                 |
+  | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+  | `initialize` / `cleanup` | Supabase auth 이벤트 구독 + authStore 동기화                                                                                                                                         |
+  | `handleAuthStateChange`  | SIGNED_IN/OUT/TOKEN_REFRESHED → authStore                                                                                                                                            |
+  | 부트스트랩 가드          | `armStartupAuthRestoreGuard`, `shouldWaitForStartupAuthRestore`, `waitForRestoredAuthUser`, `clearStartupAuthRestoreGuard`, `shouldSkipAuthStoreSync` (캐시 복원 타이밍 레이스 방지) |
+  | 로그인 시도 제한         | `checkLoginAttempts`, `incrementLoginAttempts`, `resetLoginAttempts`, `getRemainingLoginAttempts` (브루트포스 방어, 별개 관심사)                                                     |
+
+---
+
+## Task 2: sessionService.ts 리팩토링
+
+**Files:**
+
+- Modify: `src/services/observability/sessionService.ts`
+
+- [ ] **Step 1: 상수/모듈 상태 정리**
+
+  남길 상수: `AUTH_RESTORE_SETTLE_TIMEOUT_MS`, `MAX_LOGIN_ATTEMPTS`, `LOCKOUT_DURATION`.
+  남길 모듈 상태: `isInitialized`, `appStateSubscription`, `authUnsubscribe`, `authStoreUnsubscribe`, `startupAuthRestoreGuardUntil`.
+  제거: 위 Task 1 Step 1 표의 상수/모듈 상태.
+
+- [ ] **Step 2: `initialize` 재작성**
+
+  ```typescript
+  export function initialize(): void {
+    if (isInitialized) return;
+
+    armStartupAuthRestoreGuard();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      handleAuthStateChange(session?.user ?? null);
+    });
+    authUnsubscribe = () => subscription.unsubscribe();
+
+    isInitialized = true;
+    logger.info('세션 매니저 초기화 완료');
+  }
+  ```
+
+  주의: `AppState` 리스너, `authStore.subscribe`, `syncManagedSessionState` 호출 모두 제거. 타이머가 없으므로 포그라운드 복귀 시 재평가할 것이 없음.
+
+- [ ] **Step 3: `cleanup` 재작성**
+
+  제거 대상에서 파생된 state check 조건 단순화. 타이머/구독만 해제:
+
+  ```typescript
+  export function cleanup(): void {
+    if (!isInitialized && !authUnsubscribe) return;
+
+    clearStartupAuthRestoreGuard();
+    authUnsubscribe?.();
+    authUnsubscribe = null;
+
+    isInitialized = false;
+    logger.info('세션 매니저 정리 완료');
+  }
+  ```
+
+  `AppState` 구독/`authStoreUnsubscribe` 관련 코드 제거.
+
+- [ ] **Step 4: `handleAuthStateChange` 단순화**
+
+  `shouldManageSessionForUser` 호출 제거. authStore 동기화만 수행:
+
+  ```typescript
+  async function handleAuthStateChange(user: SupabaseUser | null): Promise<void> {
+    let nextUser = user;
+
+    if (nextUser) {
+      clearStartupAuthRestoreGuard();
+    } else if (shouldWaitForStartupAuthRestore(nextUser)) {
+      const restored = await waitForRestoredAuthUser();
+      clearStartupAuthRestoreGuard();
+      if (restored) {
+        logger.debug('Ignored transient null auth event while Supabase session restored', {
+          component: 'sessionService',
+          uid: restored.id,
+        });
+        nextUser = restored;
+      }
+    }
+
+    try {
+      if (!shouldSkipAuthStoreSync(nextUser)) {
+        await useAuthStore.getState().checkAuthState(nextUser);
+      }
+    } catch (error) {
+      logger.warn('인증 상태 변경 중 스토어 동기화에 실패했습니다', {
+        component: 'sessionService',
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  ```
+
+  토큰 갱신 관련 try/catch 블록 전체 제거 (282-287).
+
+- [ ] **Step 5: default export / named export 정리**
+
+  최종 export (관심사 A만):
+
+  ```typescript
+  export const sessionService = {
+    initialize,
+    cleanup,
+  };
+  ```
+
+  제거: `recordActivity`, `isSessionActive`, `getSessionState`, `refreshToken`, `getValidToken`, `checkLoginAttempts` 외 3개 (Task 2.5로 이관).
+
+---
+
+## Task 2.5: loginAttemptService로 rate limiting 분리
+
+`sessionService`의 책임을 **auth 이벤트 동기화**로만 제한하기 위해, 로그인 시도 제한 로직을 `src/services/auth/loginAttemptService.ts`로 뽑아낸다.
+
+**Files:**
+
+- Create: `src/services/auth/loginAttemptService.ts`
+- Create: `src/services/auth/__tests__/loginAttemptService.test.ts`
+- Modify: `src/services/auth/authCoreService.ts` (import 경로 변경)
+- Modify: `src/services/observability/index.ts` (이 함수들은 더 이상 observability에서 export하지 않음)
+
+- [ ] **Step 1: 새 파일로 4개 함수 이동**
+
+  `sessionService.ts`의 `checkLoginAttempts`, `incrementLoginAttempts`, `resetLoginAttempts`, `getRemainingLoginAttempts` 및 관련 상수(`MAX_LOGIN_ATTEMPTS`, `LOCKOUT_DURATION`)와 타입(`LoginAttempts`)을 `loginAttemptService.ts`로 그대로 복사. import는 `@/lib/secureStorage`, `@/utils/logger`, `@/errors`로 정리.
+
+- [ ] **Step 2: authCoreService.ts import 경로 업데이트**
+
+  `src/services/auth/authCoreService.ts:26-30`:
+
+  ```typescript
+  // Before
+  import {
+    checkLoginAttempts,
+    incrementLoginAttempts,
+    resetLoginAttempts,
+  } from '@/services/observability/sessionService';
+  // After
+  import {
+    checkLoginAttempts,
+    incrementLoginAttempts,
+    resetLoginAttempts,
+  } from './loginAttemptService';
+  ```
+
+- [ ] **Step 3: 테스트 이관**
+
+  `sessionService.test.ts`의 로그인 시도 관련 describe 블록 전체를 `loginAttemptService.test.ts`로 이관. mock shape 유지.
+
+- [ ] **Step 4: observability 공개 API 정리**
+
+  `src/services/observability/index.ts`에서 `checkLoginAttempts` 외 3개 export 제거. 외부 import는 이제 `@/services/auth/loginAttemptService`에서 가져옴.
+
+---
+
+## Task 2.7: onAuthStateChange callback deadlock 패턴 수정 (Codex 발견 #3)
+
+**문제:** Supabase 공식 troubleshooting 문서가 명시한 known bug — `onAuthStateChange` callback 안에서 `await`로 다른 Supabase auth/PostgREST 호출 시 다음 Supabase 호출이 hang됨. 현재 `sessionService.ts`가 3곳에서 위반:
+
+1. line 138: `await supabase.auth.getUser()` (callback 호출 경로 안)
+2. line 246: `await waitForRestoredAuthUser()` (위 호출 포함)
+3. line 260: `await useAuthStore.getState().checkAuthState(nextUser)` → `getUserProfile` (PostgREST)
+
+**Files:** Modify `src/services/observability/sessionService.ts`
+
+- [ ] **Step 1: `onAuthStateChange` 콜백 deferral 패턴 적용**
+
+  callback 본체를 다음 micro-tick으로 defer해 SDK 내부 상태 머신 재진입을 회피.
+
+  ```typescript
+  const {
+    data: { subscription },
+  } = supabase.auth.onAuthStateChange((_event, session) => {
+    // Supabase known bug: callback 내 await이 다음 supabase 호출을 hang 시킴.
+    // setTimeout(0)로 다음 tick에 실행해 SDK 내부 락에서 빠져나오게 함.
+    setTimeout(() => {
+      void handleAuthStateChange(session?.user ?? null);
+    }, 0);
+  });
+  ```
+
+  주석 필수 — 왜 setTimeout인지 모르면 후임자가 "이상한 코드"로 보고 제거할 위험.
+
+- [ ] **Step 2: `waitForRestoredAuthUser`의 `await getUser()` 검토**
+
+  이 함수는 `handleAuthStateChange` 안에서 호출되므로, Step 1의 deferral로 자동 해결됨 (이미 다음 tick에서 실행). 추가 변경 불필요.
+
+- [ ] **Step 3: 회귀 테스트 추가 (Task 4 Step 3에 통합)**
+
+  ```typescript
+  it('[REGRESSION] handleAuthStateChange가 다음 tick으로 defer되어 deadlock 회피', async () => {
+    sessionService.initialize();
+    const callback = mockSupabase.auth.onAuthStateChange.mock.calls[0][0];
+
+    callback('SIGNED_IN', { user: mockUser } as Session);
+    expect(mockCheckAuthState).not.toHaveBeenCalled(); // 같은 tick에선 미호출
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockCheckAuthState).toHaveBeenCalledWith(mockUser); // 다음 tick에 실행
+  });
+  ```
+
+---
+
+## Task 3: 호출부 정리 — `recordActivity` 제거
+
+**Files:**
+
+- Modify: `src/services/observability/index.ts:90-92`
+- Modify: `app/_layout.tsx:167-168`
+- Modify: `src/hooks/useNavigationTracking.ts:22, 252`
+
+- [ ] **Step 1: observability barrel export 정리**
+
+  `src/services/observability/index.ts`:
+
+  ```typescript
+  // Before
+  export { recordActivity, isSessionActive, getSessionState, ... } from './sessionService';
+  // After
+  export { checkLoginAttempts, incrementLoginAttempts, resetLoginAttempts, getRemainingLoginAttempts, initialize, cleanup } from './sessionService';
+  ```
+
+- [ ] **Step 2: `app/_layout.tsx` 호출 제거**
+
+  Line 166-170 주변의 dynamic import `.then(({ recordActivity }) => recordActivity())` 블록 삭제.
+
+- [ ] **Step 3: `useNavigationTracking.ts` 정리**
+
+  Line 22 `recordActivity` import 제거, Line 252 호출 제거. 라우트 변경 감지 자체는 Analytics 전송 목적으로 유지.
+
+- [ ] **Step 3.5: `useAppInitialize.ts` AppState 리스너에 autoRefresh 훅 추가**
+
+  Supabase JS RN 공식 가이드 준수: 백그라운드에서 JS 타이머가 멈추므로 `autoRefreshToken`도 함께 일시정지시키고, 포그라운드 복귀 시 재개해야 한다. 그렇지 않으면 백그라운드 장시간 체류 후 포그라운드 복귀 첫 요청이 401을 한 번 받을 수 있다.
+
+  `src/hooks/useAppInitialize.ts:879-889` 기존 `useEffect`의 handler를 확장:
+
+  ```typescript
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (nextAppState: AppStateStatus) => {
+      if (nextAppState === 'active') {
+        supabase.auth.startAutoRefresh();
+        if (state.isInitialized) {
+          void syncAuthStateOnForeground();
+        }
+      } else {
+        supabase.auth.stopAutoRefresh();
+      }
+    });
+
+    // 초기 1회 start — 첫 mount 시 AppState.currentState === 'active'여도 이벤트는 fire 안 함
+    if (AppState.currentState === 'active') {
+      supabase.auth.startAutoRefresh();
+    }
+
+    return () => {
+      subscription.remove();
+      supabase.auth.stopAutoRefresh();
+    };
+  }, [state.isInitialized, syncAuthStateOnForeground]);
+  ```
+
+  `supabase` import 추가 (`@/lib/supabase`). Web 환경에서는 `startAutoRefresh`/`stopAutoRefresh`가 no-op이라 분기 불필요.
+
+- [ ] **Step 4: 컴파일 검증**
+
+  ```bash
+  cd uniqn-mobile && npx tsc --noEmit
+  ```
+
+  `recordActivity`, `isSessionActive`, `getSessionState`, `refreshToken`, `getValidToken` 참조가 전부 제거됐는지 grep으로 재확인:
+
+  ```bash
+  grep -rn "recordActivity\|isSessionActive\|getSessionState\|sessionService\.refreshToken\|getValidToken" src/ app/
+  ```
+
+  hits: 0 (테스트 제외) 기대.
+
+---
+
+## Task 4: 테스트 재작성
+
+**Files:**
+
+- Modify: `src/services/observability/__tests__/sessionService.test.ts`
+
+- [ ] **Step 1: 삭제 대상 테스트 식별**
+
+  제거된 함수를 검증하는 모든 테스트 삭제:
+  - "세션 타임아웃 후 expireSession 호출" 류
+  - "30분 비활성 후 signOut 호출"
+  - "포그라운드 복귀 시 checkSession 실행"
+  - "tokenRefreshIntervalId 주기 갱신"
+  - `isSessionActive`/`getSessionState` 직접 assert하는 테스트
+
+- [ ] **Step 2: 유지 테스트 확인**
+
+  `handleAuthStateChange` 시나리오 (SIGNED_IN/OUT/TOKEN_REFRESHED → authStore.checkAuthState 호출), 부트스트랩 가드 동작 (`waitForRestoredAuthUser` 타임아웃), 로그인 시도 제한은 **필수 유지**.
+
+- [ ] **Step 3: 새 테스트 추가 (RED → GREEN)**
+
+  회귀 방지용 단위 테스트를 추가. **IRON RULE**: REGRESSION 표시된 테스트는 필수.
+
+  ```typescript
+  describe('세션 유지 정책', () => {
+    it('[REGRESSION] initialize 후 30분 경과해도 자동 signOut 호출되지 않는다', async () => {
+      jest.useFakeTimers();
+      sessionService.initialize();
+
+      jest.advanceTimersByTime(30 * 60 * 1000 + 1000);
+      await flushPromises();
+
+      expect(mockSupabase.auth.signOut).not.toHaveBeenCalled();
+      expect(routerReplaceSpy).not.toHaveBeenCalled();
+    });
+
+    it('[REGRESSION] AppState background → active 전환이 수동 refreshSession을 호출하지 않는다', async () => {
+      sessionService.initialize();
+      triggerAppStateChange('background');
+      triggerAppStateChange('active');
+      await flushPromises();
+
+      expect(mockSupabase.auth.refreshSession).not.toHaveBeenCalled();
+    });
+
+    it('TOKEN_REFRESHED 이벤트 시 동일 user면 authStore 재동기화 skip', async () => {
+      // shouldSkipAuthStoreSync 분기 검증
+      mockAuthStoreState.status = 'authenticated';
+      mockAuthStoreState.user = { uid: mockUser.id };
+      mockAuthStoreState.profile = { uid: mockUser.id };
+
+      sessionService.initialize();
+      supabaseAuthCallback?.('TOKEN_REFRESHED', { user: mockUser } as Session);
+      await flushPromises();
+
+      expect(mockCheckAuthState).not.toHaveBeenCalled();
+    });
+
+    it('[REGRESSION] SDK가 SIGNED_OUT emit 시 (refresh token revoked) authStore 초기화로 전파', async () => {
+      sessionService.initialize();
+      supabaseAuthCallback?.('SIGNED_OUT', null);
+      await flushPromises();
+
+      expect(mockCheckAuthState).toHaveBeenCalledWith(null);
+    });
+
+    it('[REGRESSION] initialize 실패 후 cleanup 호출해도 crash 없음', () => {
+      // onAuthStateChange mock throws
+      mockSupabase.auth.onAuthStateChange.mockImplementationOnce(() => {
+        throw new Error('init failed');
+      });
+
+      expect(() => sessionService.initialize()).toThrow();
+      expect(() => sessionService.cleanup()).not.toThrow();
+    });
+  });
+  ```
+
+- [ ] **Step 3.5: useAppInitialize AppState 훅 테스트 (`useAppInitialize.test.ts`)**
+
+  ```typescript
+  it('[REGRESSION] AppState active 전환 시 supabase.auth.startAutoRefresh 호출', () => {
+    renderHook(() => useAppInitialize());
+    triggerAppStateChange('active');
+    expect(mockSupabase.auth.startAutoRefresh).toHaveBeenCalled();
+  });
+
+  it('AppState background 전환 시 stopAutoRefresh 호출', () => {
+    renderHook(() => useAppInitialize());
+    triggerAppStateChange('background');
+    expect(mockSupabase.auth.stopAutoRefresh).toHaveBeenCalled();
+  });
+
+  it('cleanup(언마운트) 시 stopAutoRefresh 호출 (타이머 누수 방지)', () => {
+    const { unmount } = renderHook(() => useAppInitialize());
+    unmount();
+    expect(mockSupabase.auth.stopAutoRefresh).toHaveBeenCalled();
+  });
+  ```
+
+- [ ] **Step 4: 테스트 실행**
+
+  ```bash
+  cd uniqn-mobile && npx jest src/services/observability/__tests__/sessionService.test.ts
+  ```
+
+  기대: 모든 테스트 통과. 기존 테스트 수 대비 ~40% 감소 예상.
+
+---
+
+## Task 5: 통합 검증
+
+**Files:**
+
+- Run: `npm run quality`, `npm test`
+
+- [ ] **Step 1: 타입/린트/포맷 검증**
+
+  ```bash
+  cd uniqn-mobile && npm run quality
+  ```
+
+  실패 시 근본 원인 수정 (sessionService export 의존하는 곳 추가 발견 시 Task 3로 돌아가 그 파일도 정리).
+
+- [ ] **Step 2: Mock contract 사전 업데이트** (Codex 발견 #2)
+
+  Plan은 mock 변경을 "필요할 수 있음" 수준으로 다뤘으나, 실제로는 **필수**. 다음 mock에 신규 메서드 추가:
+  - `jest.setup.js`: `supabase.auth` mock에 `startAutoRefresh: jest.fn()`, `stopAutoRefresh: jest.fn()` 추가
+  - `src/__tests__/hooks/useAppInitialize.test.ts`: react-native mock의 `AppState`에 `currentState: 'active'` 명시 + `addEventListener` mock이 listener를 capture하도록 (이미 useNotificationHandler.test에 비슷한 패턴 있음 — 참조)
+  - `src/services/observability/__tests__/sessionService.test.ts`: setTimeout-deferral 패턴 검증을 위해 `jest.useFakeTimers()` 사용 시 `jest.advanceTimersByTime(0)` 호출 필요
+
+- [ ] **Step 3: 전체 테스트 실행**
+
+  ```bash
+  cd uniqn-mobile && npm test
+  ```
+
+  실패 시 mock contract부터 점검 (Step 2). 통과 후 다음 단계.
+
+- [ ] **Step 4: 수동 E2E 시나리오 (iOS 시뮬레이터)**
+
+  | 시나리오                                                                                              | 기대 결과                                                                   |
+  | ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+  | 로그인 후 앱을 40분간 그대로 둠                                                                       | 로그인 상태 유지, 로그인 화면 튕김 없음                                     |
+  | 로그인 후 앱 백그라운드 30분 → 포그라운드                                                             | 세션 유지, API 호출 정상                                                    |
+  | 비행기 모드 1분 후 해제                                                                               | `signOut` 호출 없이 다음 요청부터 정상                                      |
+  | Supabase Dashboard에서 해당 user 강제 logout (JWT invalidate)                                         | 다음 API 요청에서 401 → SDK `onAuthStateChange('SIGNED_OUT')` → 로그인 화면 |
+  | refresh token 만료 (실제 30일 경과는 어려우니 JWT expiry 짧게 설정하거나 Supabase에서 session revoke) | SIGNED_OUT 이벤트 정상 전파 → authStore 초기화 → 로그인 화면                |
+
+- [ ] **Step 5: 앱 포그라운드 복귀 시 `AppState` 리스너 회귀 확인**
+
+  `useNotificationSyncOnForeground`, `tokenRefreshService` (FCM), `queryClient.ts` AppState 리스너가 **sessionService와 독립**으로 계속 동작하는지 확인. sessionService에서 AppState 구독만 빼면 나머지는 영향 없어야 함.
+
+---
+
+## Rollback
+
+변경이 회귀를 일으키면:
+
+1. `git revert <commit-sha>` — 단일 리팩토링 커밋이므로 되돌리기 간단.
+2. Supabase Dashboard에서 JWT expiry를 짧게 (예: 10분) 설정하면 기존 30분 타임아웃과 유사한 보안 프로파일 복원 가능 (refresh token rotation은 기본 ON이므로 자동 갱신 주기만 짧아짐).
+
+---
+
+## Non-Goals (명시적 제외)
+
+- `authStore.suppressedSessionUserId` 필드 제거: auto-login 비활성화 경로가 독립적으로 사용 중. 별도 작업.
+- `tokenRefreshService.ts` 수정: 이름이 혼동 유발하지만 **FCM 푸시 토큰 갱신 전용**으로 auth 세션과 무관. 이름 변경은 별개 cleanup.
+- `AuthErrorBoundary.tsx`의 "세션이 만료되었습니다" UI: Supabase 자체에서 `SIGNED_OUT` 전파 시 여전히 표시 가능. 문구 유지.
+- "모든 기기에서 로그아웃" UX 추가: 별개 feature. TODO.
+
+---
+
+## 리뷰 포인트 (`/plan-eng-review`용)
+
+- **아키텍처:** `sessionService`의 관심사 분리 (타임아웃 제거 vs auth sync vs login rate limit) 명확한가?
+- **회귀 리스크:** `useAppInitialize`가 `sessionService.initialize` 호출 경로 — mock shape 변경 시 그 테스트 스위트 깨질 가능성 측정.
+- **테스트 커버리지:** 제거된 동작을 검증하는 테스트 수와 새로 추가하는 "유지 보장" 회귀 테스트 수 대비.
+- **보안:** 30분 → 30일 유효 세션 연장이 앱 특성(스태프 관리, PII 취급)에 적절한가? Refresh token rotation이 ON인 전제를 문서화.
+- **SDK 위임 전제 검증:** Supabase JS v2의 `autoRefreshToken` 동작이 RN `AppState` 백그라운드에서도 예상대로 동작하는지 (Supabase 공식 문서 RN 가이드 확인 필요).
+
+---
+
+## What already exists (재사용 항목)
+
+| 기존 코드                                                                                   | 본 plan에서 활용                                                                         |
+| ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Supabase JS v2 `autoRefreshToken` + `persistSession` (`src/lib/supabase.ts:21-22`)          | 30분 타임아웃 제거 후 토큰 수명 관리를 여기로 완전 위임                                  |
+| `AsyncStorage` adapter (`src/lib/supabase.ts:20`)                                           | 앱 재시작 후 세션 복원 — 변경 없이 유지                                                  |
+| `authStore.suppressedSessionUserId` 필드 (`src/stores/authStore.ts:35,141,248,264,410,511`) | auto-login 비활성화 경로 — sessionService와 분리되어 그대로 유지                         |
+| `useAppInitialize.ts:880` AppState 리스너                                                   | 이미 존재 — Task 3.5에서 `startAutoRefresh`/`stopAutoRefresh` 훅을 같은 핸들러 안에 추가 |
+| `queryClient.ts:86-92` AppState 리스너                                                      | TanStack Query refocus용 — 독립적, 영향 받지 않음                                        |
+| `loginAttempts*` 함수 (현 `sessionService.ts`)                                              | Task 2.5로 `loginAttemptService.ts` 분리 — 로직 자체는 1:1 이관                          |
+| 부트스트랩 가드 (`armStartupAuthRestoreGuard` 외)                                           | 그대로 유지, deferral 적용 후에도 동작 동일                                              |
+
+**잘못 재구현하지 않은 것:** Supabase autoRefreshToken을 manual interval로 감싸지 않음 (Plan은 오히려 그 manual 래퍼를 제거).
+
+---
+
+## Failure Modes Registry
+
+| 시나리오                                                   | 테스트 커버                                       | 에러 처리                                                                      | 사용자 체감                                     | 위험도                          |
+| ---------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------ | ----------------------------------------------- | ------------------------------- |
+| Refresh token revoke (Supabase Dashboard에서 sign-out all) | Task 4 Step 3 SIGNED_OUT 회귀 ✓                   | `handleAuthStateChange(null)` → authStore.checkAuthState(null) → 로그인 화면 ✓ | 명확 (로그인 화면)                              | LOW                             |
+| Access token 만료 + 네트워크 오프라인                      | 단위 ✗, 수동 E2E (Task 5 Step 4) ✓                | SDK 자체 재시도, 더 이상 강제 signOut 안 함 ✓                                  | 다음 요청에서 자동 복구                         | LOW                             |
+| 백그라운드 30분 후 포그라운드 → 첫 요청 401                | E2E ✓, 단위 ✗                                     | startAutoRefresh가 active 전환 시 재개 (Task 3.5) ✓                            | 사용자 모름 (1-tick 지연)                       | LOW                             |
+| onAuthStateChange callback deadlock                        | Task 2.7 회귀 테스트 ✓                            | setTimeout deferral ✓                                                          | 더 이상 hang 안 함                              | RESOLVED                        |
+| `initialize` 실행 중 onAuthStateChange 구독 실패           | Task 4 Step 3 cleanup idempotent ✓                | cleanup 가드 (initialize 부분 실패 후 호출 OK) ✓                               | 앱 부팅 실패 toast                              | LOW                             |
+| Supabase JWT expiry 설정이 5분 미만                        | E2E 실측 (Task 5 Step 4 시나리오 5) ✗ → 추가 필요 | autoRefreshToken이 expiry 80% 시점에 갱신 시도 — 5분 미만이면 race 발생 가능   | 첫 요청 후 401 → 토큰 갱신 → 재시도 (지연 가능) | **MEDIUM** — Task 0.5 검증 필수 |
+
+**Critical gap**: 위 표 마지막 행 — JWT expiry 5분 미만 설정 시 race 가능성. **Task 0.5 (Supabase config 사전 검증)이 이 gap을 닫는 게이트.** 통과하지 못하면 plan 진행 불가.
+
+---
+
+## Worktree parallelization strategy
+
+**Sequential implementation, no parallelization opportunity.** 모든 Task가 `sessionService.ts` + 직접 의존 파일을 순차로 수정. 분산 가능한 독립 워크스트림 없음.
+
+순서:
+
+```
+Task 0.5 (Supabase config 검증) [GATE]
+   ↓
+Task 1 (제거/유지 분류) ─► Task 2 (sessionService 리팩토링)
+                              ↓
+                          Task 2.5 (loginAttemptService 분리)
+                              ↓
+                          Task 2.7 (deadlock fix)
+                              ↓
+                          Task 3 (호출부 정리)
+                              ↓
+                          Task 4 (테스트 재작성)
+                              ↓
+                          Task 5 (통합 검증)
+```
+
+---
+
+## Completion Summary (Eng Review)
+
+- **Step 0 (Scope Challenge):** scope 적정 — 5 files, 0 새 클래스, 8개 미만 임계 통과
+- **Architecture Review:** 3 issues found, 3 resolved (파일 분리, autoRefresh 훅, 실패 시나리오 검증)
+- **Code Quality Review:** 0 issues found (cleanup 방향, DRY/error handling positive)
+- **Test Review:** coverage diagram 생성, 7 gaps identified, 5 신규 테스트로 폐쇄 (4 REGRESSION 포함)
+- **Performance Review:** 0 issues found (순수 개선 — 50min 폴링 + 30min 타이머 제거)
+- **Outside voice (Codex):** 3 추가 발견 (deadlock pattern, Supabase config 미검증, mock contract 과소평가) — 모두 plan에 반영
+- **Cross-model tension:** Codex finding 3 검증 후 옵션 A 선택 — 함께 수정
+- **Failure modes:** 1 critical gap → Task 0.5(Supabase config 검증) 게이트로 폐쇄
+- **TODOS.md:** 1 item 추가 (`tokenRefreshService` rename)
+- **Parallelization:** N/A — 순차 구현
+- **Lake Score:** 5/5 권장 — 모두 complete option 선택 (B파일분리, A autoRefresh, A deadlock fix, A config+mock 명시, A TODO add)
+
+---
+
+## NOT in scope (명시적 제외, 별도 PR)
+
+| 항목                                                      | 사유                                                       | 후속 PR 후보                                                                |
+| --------------------------------------------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `tokenRefreshService.ts` 이름 변경 (FCM 전용임을 명확히)  | 별개 cleanup, 본 PR scope 밖                               | `chore(observability): tokenRefreshService → fcmTokenRefreshService rename` |
+| `authStore.suppressedSessionUserId` 제거                  | auto-login 비활성화 경로 독립 사용 — 본 plan의 변경과 무관 | 분리 가능하면 별도 분석 PR                                                  |
+| "모든 기기에서 로그아웃" UX                               | feature 추가, 보안 강화. 세션 유지 정책 확정 후 진행       | 신규 feature                                                                |
+| Inactivity timeout을 admin 역할에만 선택 적용             | "다른 보안 프로파일 필요" 의견 수렴되면 검토               | 신규 design doc                                                             |
+| `AuthErrorBoundary` 메시지 카피 변경                      | SDK SIGNED_OUT 시 여전히 적절 — 변경 불필요                | N/A                                                                         |
+| Codex가 본 plan 외에서 발견한 다른 deadlock 패턴 (있다면) | 본 plan은 sessionService 한정                              | 별도 audit PR                                                               |
+
+---
+
+## GSTACK REVIEW REPORT
+
+| Review        | Trigger               | Why                             | Runs | Status       | Findings                                                                       |
+| ------------- | --------------------- | ------------------------------- | ---- | ------------ | ------------------------------------------------------------------------------ |
+| CEO Review    | `/plan-ceo-review`    | Scope & strategy                | 0    | —            | —                                                                              |
+| Codex Review  | `/codex review`       | Independent 2nd opinion         | 1    | issues_found | 3 발견 (deadlock pattern, JWT 설정 미검증, mock contract 과소평가) — 모두 반영 |
+| Eng Review    | `/plan-eng-review`    | Architecture & tests (required) | 1    | CLEAR        | 3 issues, 1 critical gap (Task 0.5 게이트로 폐쇄)                              |
+| Design Review | `/plan-design-review` | UI/UX gaps                      | 0    | —            | UI scope 없음                                                                  |
+| DX Review     | `/plan-devex-review`  | Developer experience gaps       | 0    | —            | Dev API 변경 없음                                                              |
+
+**CODEX:** Codex가 3개 핵심 이슈 발견 — sessionService deadlock 패턴(공식 known bug 검증), Supabase 프로젝트 JWT 수명 미검증, useAppInitialize mock contract 과소평가. 전부 plan에 반영 완료.
+
+**CROSS-MODEL:** Codex finding 3에서 cross-model tension — Claude review는 부트스트랩 가드 "유지" 권장, Codex는 callback deadlock pattern 즉시 수정 권장. 사용자가 광범위 검증 후 Codex 옵션 채택, Task 2.7로 추가.
+
+**UNRESOLVED:** 0
+
+**VERDICT:** ENG CLEARED — 구현 진행 가능. 단, **Task 0.5 (Supabase config 검증)은 구현 전 게이트**. JWT expiry/refresh token 설정이 plan 전제와 다르면 사용자에게 confirm 후 진행.

--- a/uniqn-mobile/jest.setup.js
+++ b/uniqn-mobile/jest.setup.js
@@ -132,6 +132,9 @@ jest.mock('@/lib/supabase', () => ({
       signInWithPassword: jest.fn(),
       signUp: jest.fn(),
       signOut: jest.fn(),
+      startAutoRefresh: jest.fn(),
+      stopAutoRefresh: jest.fn(),
+      refreshSession: jest.fn(),
     },
     from: jest.fn(() => ({
       select: jest.fn().mockReturnThis(),

--- a/uniqn-mobile/src/__tests__/hooks/useAppInitialize.test.ts
+++ b/uniqn-mobile/src/__tests__/hooks/useAppInitialize.test.ts
@@ -96,6 +96,9 @@ jest.mock('@/lib/supabase', () => ({
         return { data: { subscription: { unsubscribe: jest.fn() } } };
       }),
       signOut: jest.fn().mockResolvedValue({ error: null }),
+      startAutoRefresh: jest.fn(),
+      stopAutoRefresh: jest.fn(),
+      refreshSession: jest.fn(),
     },
   },
 }));

--- a/uniqn-mobile/src/hooks/useAppInitialize.ts
+++ b/uniqn-mobile/src/hooks/useAppInitialize.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { AppState, Platform, type AppStateStatus } from 'react-native';
 import * as SplashScreen from 'expo-splash-screen';
 import type { User as SupabaseUser } from '@supabase/supabase-js';
+import { supabase } from '@/lib/supabase';
 import { useAuthStore, waitForHydration } from '@/stores/authStore';
 import { useAppStartupStore, type StartupPhase } from '@/stores/appStartupStore';
 import { validateEnv } from '@/lib/env';
@@ -877,14 +878,33 @@ export function useAppInitialize(): UseAppInitializeReturn {
   }, [reconcileIfNeeded]);
 
   useEffect(() => {
+    // Supabase RN: 백그라운드에서 JS 타이머가 멈추므로 autoRefreshToken도 함께
+    // 일시정지/재개해야 한다. Supabase 공식 RN 가이드 권고.
     const subscription = AppState.addEventListener('change', (nextAppState: AppStateStatus) => {
-      if (nextAppState === 'active' && state.isInitialized) {
-        void syncAuthStateOnForeground();
+      if (nextAppState === 'active') {
+        if (Platform.OS !== 'web') {
+          supabase.auth.startAutoRefresh();
+        }
+        if (state.isInitialized) {
+          void syncAuthStateOnForeground();
+        }
+      } else {
+        if (Platform.OS !== 'web') {
+          supabase.auth.stopAutoRefresh();
+        }
       }
     });
 
+    // 초기 mount 시 AppState 이벤트가 fire되지 않으므로 currentState 기반 1회 호출
+    if (Platform.OS !== 'web' && AppState.currentState === 'active') {
+      supabase.auth.startAutoRefresh();
+    }
+
     return () => {
       subscription.remove();
+      if (Platform.OS !== 'web') {
+        supabase.auth.stopAutoRefresh();
+      }
     };
   }, [state.isInitialized, syncAuthStateOnForeground]);
 

--- a/uniqn-mobile/src/hooks/useNavigationTracking.ts
+++ b/uniqn-mobile/src/hooks/useNavigationTracking.ts
@@ -19,7 +19,6 @@ import {
   analyticsService,
   crashlyticsService,
   recordNavigationTime,
-  recordActivity,
 } from '@/services/observability';
 
 // ============================================================================
@@ -247,9 +246,6 @@ export function useNavigationTracking(): void {
     // 로깅 및 Analytics
     logNavigation(screenInfo, previousPath, pathname);
     trackScreenView(screenInfo, pathname);
-
-    // 세션 활동 기록 (세션 타임아웃 리셋)
-    recordActivity();
   }, [pathname, segments, logNavigation, trackScreenView]);
 }
 

--- a/uniqn-mobile/src/services/auth/__tests__/loginAttemptService.test.ts
+++ b/uniqn-mobile/src/services/auth/__tests__/loginAttemptService.test.ts
@@ -1,0 +1,148 @@
+import {
+  checkLoginAttempts,
+  incrementLoginAttempts,
+  resetLoginAttempts,
+  getRemainingLoginAttempts,
+} from '../loginAttemptService';
+
+jest.mock('@/lib/secureStorage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  deleteItem: jest.fn(),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('@/errors', () => ({
+  AuthError: class MockAuthError extends Error {
+    code: string;
+
+    constructor(
+      code: string,
+      options?: { userMessage?: string; metadata?: Record<string, unknown> }
+    ) {
+      super(options?.userMessage || code);
+      this.code = code;
+      this.name = 'AuthError';
+    }
+  },
+  ERROR_CODES: {
+    AUTH_RATE_LIMITED: 'E2006',
+  },
+  isAppError: (error: unknown) => error instanceof Error && 'code' in error,
+  toError: (error: unknown) => (error instanceof Error ? error : new Error(String(error))),
+}));
+
+const { getItem, setItem, deleteItem } = jest.requireMock('@/lib/secureStorage') as {
+  getItem: jest.Mock;
+  setItem: jest.Mock;
+  deleteItem: jest.Mock;
+};
+
+const TEST_EMAIL = 'user@example.com';
+const KEY = `login_attempts_${TEST_EMAIL.toLowerCase()}`;
+
+describe('loginAttemptService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  describe('checkLoginAttempts', () => {
+    it('기록 없으면 통과', async () => {
+      getItem.mockResolvedValueOnce(null);
+      await expect(checkLoginAttempts(TEST_EMAIL)).resolves.toBeUndefined();
+    });
+
+    it('잠금 만료 시간 이전이면 AuthError throw', async () => {
+      getItem.mockResolvedValueOnce({
+        count: 5,
+        lockUntil: Date.now() + 5 * 60 * 1000,
+        lastAttempt: Date.now(),
+      });
+
+      await expect(checkLoginAttempts(TEST_EMAIL)).rejects.toThrow();
+    });
+
+    it('잠금 만료 시간 지나면 기록 삭제 후 통과', async () => {
+      getItem.mockResolvedValueOnce({
+        count: 5,
+        lockUntil: Date.now() - 1000,
+        lastAttempt: Date.now() - 60000,
+      });
+
+      await expect(checkLoginAttempts(TEST_EMAIL)).resolves.toBeUndefined();
+      expect(deleteItem).toHaveBeenCalledWith(KEY);
+    });
+  });
+
+  describe('incrementLoginAttempts', () => {
+    it('첫 시도는 count=1, lockUntil=null', async () => {
+      getItem.mockResolvedValueOnce(null);
+
+      await incrementLoginAttempts(TEST_EMAIL);
+
+      expect(setItem).toHaveBeenCalledWith(
+        KEY,
+        expect.objectContaining({ count: 1, lockUntil: null })
+      );
+    });
+
+    it('5회째 시도에서 잠금 시작', async () => {
+      getItem.mockResolvedValueOnce({
+        count: 4,
+        lockUntil: null,
+        lastAttempt: Date.now(),
+      });
+
+      await incrementLoginAttempts(TEST_EMAIL);
+
+      expect(setItem).toHaveBeenCalledWith(
+        KEY,
+        expect.objectContaining({
+          count: 5,
+          lockUntil: expect.any(Number),
+        })
+      );
+    });
+  });
+
+  describe('resetLoginAttempts', () => {
+    it('기록 삭제', async () => {
+      await resetLoginAttempts(TEST_EMAIL);
+      expect(deleteItem).toHaveBeenCalledWith(KEY);
+    });
+  });
+
+  describe('getRemainingLoginAttempts', () => {
+    it('기록 없으면 5 반환', async () => {
+      getItem.mockResolvedValueOnce(null);
+      await expect(getRemainingLoginAttempts(TEST_EMAIL)).resolves.toBe(5);
+    });
+
+    it('count=2면 3 반환', async () => {
+      getItem.mockResolvedValueOnce({
+        count: 2,
+        lockUntil: null,
+        lastAttempt: Date.now(),
+      });
+      await expect(getRemainingLoginAttempts(TEST_EMAIL)).resolves.toBe(3);
+    });
+
+    it('count=10이어도 0 이상 반환', async () => {
+      getItem.mockResolvedValueOnce({
+        count: 10,
+        lockUntil: Date.now() + 60000,
+        lastAttempt: Date.now(),
+      });
+      await expect(getRemainingLoginAttempts(TEST_EMAIL)).resolves.toBe(0);
+    });
+  });
+});

--- a/uniqn-mobile/src/services/auth/authCoreService.ts
+++ b/uniqn-mobile/src/services/auth/authCoreService.ts
@@ -33,7 +33,7 @@ import {
   checkLoginAttempts,
   incrementLoginAttempts,
   resetLoginAttempts,
-} from '@/services/observability/sessionService';
+} from './loginAttemptService';
 import type { SignUpFormData, LoginFormData } from '@/schemas';
 import { type UserProfile, type AuthResult } from './authTypes';
 import { getUserProfile as fetchUserProfile } from './userProfileService';

--- a/uniqn-mobile/src/services/auth/loginAttemptService.ts
+++ b/uniqn-mobile/src/services/auth/loginAttemptService.ts
@@ -1,0 +1,111 @@
+/**
+ * UNIQN Mobile - Login Attempt Rate Limiting Service
+ *
+ * @description 로그인 시도 횟수 추적 및 계정 잠금. 브루트포스 공격 완화.
+ *
+ * 정책:
+ *  - 5회 연속 실패 시 15분 잠금
+ *  - 잠금 시간 경과 시 자동 해제
+ *  - 성공 시 카운트 리셋
+ *
+ * @note 이전에 sessionService에 있던 로직. 단일 책임 원칙으로 분리됨.
+ */
+
+import { getItem, setItem, deleteItem } from '@/lib/secureStorage';
+import { logger } from '@/utils/logger';
+import { AuthError, ERROR_CODES, isAppError, toError } from '@/errors';
+
+const MAX_LOGIN_ATTEMPTS = 5;
+const LOCKOUT_DURATION = 15 * 60 * 1000;
+
+export interface LoginAttempts {
+  count: number;
+  lockUntil: number | null;
+  lastAttempt: number;
+}
+
+export async function checkLoginAttempts(email: string): Promise<void> {
+  const key = `login_attempts_${email.toLowerCase()}`;
+
+  try {
+    const attempts = await getItem<LoginAttempts>(key);
+    if (!attempts) {
+      return;
+    }
+
+    if (attempts.lockUntil && Date.now() < attempts.lockUntil) {
+      const remainingTime = Math.ceil((attempts.lockUntil - Date.now()) / 60000);
+      throw new AuthError(ERROR_CODES.AUTH_RATE_LIMITED, {
+        userMessage: `로그인 시도 횟수를 초과했습니다. ${remainingTime}분 후에 다시 시도해 주세요.`,
+        metadata: { remainingMinutes: remainingTime },
+      });
+    }
+
+    if (attempts.lockUntil && Date.now() >= attempts.lockUntil) {
+      await deleteItem(key);
+    }
+  } catch (error) {
+    if (isAppError(error)) {
+      throw error;
+    }
+
+    logger.error('로그인 시도 횟수 확인 실패', toError(error));
+  }
+}
+
+export async function incrementLoginAttempts(email: string): Promise<void> {
+  const key = `login_attempts_${email.toLowerCase()}`;
+
+  try {
+    const current = (await getItem<LoginAttempts>(key)) ?? {
+      count: 0,
+      lockUntil: null,
+      lastAttempt: 0,
+    };
+
+    const newCount = current.count + 1;
+    const shouldLock = newCount >= MAX_LOGIN_ATTEMPTS;
+
+    const nextAttempts: LoginAttempts = {
+      count: newCount,
+      lockUntil: shouldLock ? Date.now() + LOCKOUT_DURATION : null,
+      lastAttempt: Date.now(),
+    };
+
+    await setItem(key, nextAttempts);
+
+    if (shouldLock) {
+      logger.warn('로그인 시도 횟수 초과 - 계정 잠금', {
+        email: email.substring(0, 3) + '***',
+      });
+    }
+  } catch (error) {
+    logger.error('로그인 시도 횟수 증가 실패', toError(error));
+  }
+}
+
+export async function resetLoginAttempts(email: string): Promise<void> {
+  const key = `login_attempts_${email.toLowerCase()}`;
+
+  try {
+    await deleteItem(key);
+    logger.debug('로그인 시도 횟수 초기화', { email: email.substring(0, 3) + '***' });
+  } catch (error) {
+    logger.error('로그인 시도 횟수 초기화 실패', toError(error));
+  }
+}
+
+export async function getRemainingLoginAttempts(email: string): Promise<number> {
+  const key = `login_attempts_${email.toLowerCase()}`;
+
+  try {
+    const attempts = await getItem<LoginAttempts>(key);
+    if (!attempts) {
+      return MAX_LOGIN_ATTEMPTS;
+    }
+
+    return Math.max(0, MAX_LOGIN_ATTEMPTS - attempts.count);
+  } catch {
+    return MAX_LOGIN_ATTEMPTS;
+  }
+}

--- a/uniqn-mobile/src/services/observability/__tests__/sessionService.test.ts
+++ b/uniqn-mobile/src/services/observability/__tests__/sessionService.test.ts
@@ -1,65 +1,39 @@
-import { AppState, Platform } from 'react-native';
-import {
-  checkLoginAttempts,
-  getRemainingLoginAttempts,
-  getValidToken,
-  incrementLoginAttempts,
-  refreshToken,
-  resetLoginAttempts,
-  sessionService,
-} from '../sessionService';
+import type { Session, User } from '@supabase/supabase-js';
+import { sessionService, getSessionState } from '../sessionService';
 
-const mockAuthStoreSubscribers = new Set<() => void>();
-const mockToastAddToast = jest.fn();
 const mockAuthStoreState = {
-  status: 'authenticated',
+  status: 'authenticated' as 'authenticated' | 'unauthenticated' | 'loading',
+  isInitialized: true,
   bootstrapSource: 'server' as 'none' | 'cache' | 'server',
-  suppressedSessionUserId: null as string | null,
   user: { uid: 'test-user-id', email: 'test@example.com' } as Record<string, unknown> | null,
+  profile: { uid: 'test-user-id' } as Record<string, unknown> | null,
   reset: jest.fn(),
   checkAuthState: jest.fn().mockResolvedValue(undefined),
 };
 
-const mockRefreshSession = jest.fn();
-const mockGetSession = jest.fn();
+let supabaseAuthCallback: ((event: string, session: Session | null) => void) | null = null;
+const mockUnsubscribe = jest.fn();
 
 jest.mock('@/lib/supabase', () => ({
   supabase: {
     auth: {
       getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: null }),
       signOut: jest.fn().mockResolvedValue({ error: null }),
-      onAuthStateChange: jest.fn(() => ({ data: { subscription: { unsubscribe: jest.fn() } } })),
-      refreshSession: (...args: unknown[]) => mockRefreshSession(...args),
-      getSession: (...args: unknown[]) => mockGetSession(...args),
+      onAuthStateChange: jest.fn((callback) => {
+        supabaseAuthCallback = callback;
+        return { data: { subscription: { unsubscribe: mockUnsubscribe } } };
+      }),
+      refreshSession: jest.fn(),
+      getSession: jest.fn(),
+      startAutoRefresh: jest.fn(),
+      stopAutoRefresh: jest.fn(),
     },
   },
-}));
-
-jest.mock('@/lib/secureStorage', () => ({
-  authStorage: {
-    setAuthToken: jest.fn(),
-  },
-  userSessionStorage: {},
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-  deleteItem: jest.fn(),
 }));
 
 jest.mock('@/stores/authStore', () => ({
   useAuthStore: {
     getState: jest.fn(() => mockAuthStoreState),
-    subscribe: jest.fn((listener: () => void) => {
-      mockAuthStoreSubscribers.add(listener);
-      return () => {
-        mockAuthStoreSubscribers.delete(listener);
-      };
-    }),
-  },
-}));
-
-jest.mock('@/stores/toastStore', () => ({
-  useToastStore: {
-    getState: jest.fn(() => ({ addToast: mockToastAddToast })),
   },
 }));
 
@@ -72,448 +46,165 @@ jest.mock('@/utils/logger', () => ({
   },
 }));
 
-jest.mock('../sentryService', () => ({
-  sentryService: {
-    recordError: jest.fn(),
-  },
-}));
+// 실제 timer + 마이크로태스크 flush 패턴 (fake timers와 setImmediate 충돌 회피)
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
 
-jest.mock('@/shared/realtime', () => ({
-  RealtimeManager: {
-    unsubscribeAll: jest.fn(),
-  },
-}));
+const mockUser: User = {
+  id: 'test-user-id',
+  app_metadata: {},
+  user_metadata: {},
+  aud: 'authenticated',
+  created_at: new Date().toISOString(),
+} as User;
 
-jest.mock('@/shared/cache/counterSyncCache', () => ({
-  clearCounterSyncCache: jest.fn(),
-}));
-
-jest.mock('expo-router', () => ({
-  router: {
-    replace: jest.fn(),
-  },
-}));
-
-jest.mock('@/errors', () => ({
-  AuthError: class MockAuthError extends Error {
-    code: string;
-
-    constructor(
-      code: string,
-      options?: { userMessage?: string; metadata?: Record<string, unknown> }
-    ) {
-      super(options?.userMessage || code);
-      this.code = code;
-      this.name = 'AuthError';
-    }
-  },
-  ERROR_CODES: {
-    AUTH_RATE_LIMITED: 'E2006',
-  },
-  isAppError: (error: unknown) => error instanceof Error && 'code' in error,
-  toError: (error: unknown) => (error instanceof Error ? error : new Error(String(error))),
-}));
-
-const { authStorage, deleteItem, getItem, setItem } = jest.requireMock('@/lib/secureStorage') as {
-  authStorage: { setAuthToken: jest.Mock };
-  deleteItem: jest.Mock;
-  getItem: jest.Mock;
-  setItem: jest.Mock;
-};
-const { supabase: mockSupabase } = jest.requireMock('@/lib/supabase') as {
-  supabase: {
-    auth: { signOut: jest.Mock; onAuthStateChange: jest.Mock; getUser: jest.Mock };
+const mockSupabase = jest.requireMock('@/lib/supabase').supabase as {
+  auth: {
+    getUser: jest.Mock;
+    signOut: jest.Mock;
+    onAuthStateChange: jest.Mock;
+    refreshSession: jest.Mock;
+    getSession: jest.Mock;
+    startAutoRefresh: jest.Mock;
+    stopAutoRefresh: jest.Mock;
   };
 };
-const syncSignOut = mockSupabase.auth.signOut;
-const { router } = jest.requireMock('expo-router') as {
-  router: { replace: jest.Mock };
-};
-const { useToastStore } = jest.requireMock('@/stores/toastStore') as {
-  useToastStore: { getState: jest.Mock };
-};
-const mockAddToast = (useToastStore.getState() as { addToast: jest.Mock }).addToast;
-const { RealtimeManager } = jest.requireMock('@/shared/realtime') as {
-  RealtimeManager: { unsubscribeAll: jest.Mock };
-};
-const { clearCounterSyncCache } = jest.requireMock('@/shared/cache/counterSyncCache') as {
-  clearCounterSyncCache: jest.Mock;
-};
-
-function setAuthStoreState(partial: Partial<typeof mockAuthStoreState>) {
-  Object.assign(mockAuthStoreState, partial);
-  mockAuthStoreSubscribers.forEach((listener) => listener());
-}
 
 describe('sessionService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.useFakeTimers();
-    mockAuthStoreSubscribers.clear();
+    supabaseAuthCallback = null;
     mockAuthStoreState.status = 'authenticated';
+    mockAuthStoreState.isInitialized = true;
     mockAuthStoreState.bootstrapSource = 'server';
-    mockAuthStoreState.suppressedSessionUserId = null;
     mockAuthStoreState.user = { uid: 'test-user-id', email: 'test@example.com' };
-    mockAuthStoreState.reset.mockReset();
-    mockAuthStoreState.checkAuthState.mockResolvedValue(undefined);
-    mockToastAddToast.mockReset();
-    // clearAllMocks는 구현을 지우므로 기본값 명시적 복원
-    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null }, error: null });
-    mockSupabase.auth.onAuthStateChange.mockImplementation(() => ({
-      data: { subscription: { unsubscribe: jest.fn() } },
-    }));
-    mockRefreshSession.mockResolvedValue({
-      data: { session: { access_token: 'new-token' } },
-      error: null,
-    });
-    mockGetSession.mockResolvedValue({
-      data: { session: { access_token: 'test-token' } },
-      error: null,
-    });
+    mockAuthStoreState.profile = { uid: 'test-user-id' };
+    sessionService.cleanup();
   });
 
   afterEach(() => {
-    sessionService.cleanup();
     jest.useRealTimers();
   });
 
-  it('registers listeners on initialize and cleans them up', () => {
-    const remove = jest.fn();
-    jest.spyOn(AppState, 'addEventListener').mockReturnValue({ remove });
-
-    sessionService.initialize();
-
-    expect(AppState.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
-    expect(mockSupabase.auth.onAuthStateChange).toHaveBeenCalledWith(expect.any(Function));
-
-    sessionService.cleanup();
-
-    expect(remove).toHaveBeenCalled();
-  });
-
-  it('keeps suppressed auto-login sessions inactive', async () => {
-    const supabaseUser = { id: 'test-user-id', email: 'test@example.com' };
-    let supabaseAuthCallback:
-      | ((event: string, session: { user: typeof supabaseUser } | null) => void)
-      | undefined;
-    mockSupabase.auth.onAuthStateChange.mockImplementation(
-      (callback: (event: string, session: { user: typeof supabaseUser } | null) => void) => {
-        supabaseAuthCallback = callback;
-        return { data: { subscription: { unsubscribe: jest.fn() } } };
-      }
-    );
-    setAuthStoreState({
-      status: 'unauthenticated',
-      suppressedSessionUserId: 'test-user-id',
-    });
-
-    sessionService.initialize();
-    supabaseAuthCallback?.('SIGNED_IN', { user: supabaseUser });
-    await jest.runOnlyPendingTimersAsync();
-
-    expect(mockAuthStoreState.checkAuthState).toHaveBeenCalledWith(supabaseUser);
-    expect(sessionService.getSessionState().isActive).toBe(false);
-    expect(sessionService.isSessionActive()).toBe(false);
-  });
-
-  it('ignores a transient null auth event while Supabase restores the session', async () => {
-    // Arrange: guard가 활성화되는 조건 — cache 부트스트랩 + 인증 상태 + user 없음
-    setAuthStoreState({
-      status: 'authenticated',
-      bootstrapSource: 'cache',
-      user: null,
-    });
-
-    // getUser()는 null 반환 (아직 복원 중)
-    const restoredUser = { id: 'test-user-id', email: 'test@example.com' };
-    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null }, error: null });
-
-    // waitForRestoredAuthUser 내 임시 onAuthStateChange가 복원된 user 전달
-    let restoreCallback:
-      | ((event: string, session: { user: typeof restoredUser } | null) => void)
-      | undefined;
-    let mainAuthCallback:
-      | ((event: string, session: { user: typeof restoredUser } | null) => void)
-      | undefined;
-    const restoreUnsubscribe = jest.fn();
-
-    mockSupabase.auth.onAuthStateChange.mockImplementation(
-      (callback: (event: string, session: { user: typeof restoredUser } | null) => void) => {
-        if (!mainAuthCallback) {
-          // 첫 번째 호출 = initialize()의 메인 구독
-          mainAuthCallback = callback;
-          return { data: { subscription: { unsubscribe: jest.fn() } } };
-        }
-        // 두 번째 호출 = waitForRestoredAuthUser 내 임시 구독
-        restoreCallback = callback;
-        return { data: { subscription: { unsubscribe: restoreUnsubscribe } } };
-      }
-    );
-
-    sessionService.initialize();
-
-    // Act: 메인 콜백에 null 이벤트 전달 (transient null)
-    const handlePromise = mainAuthCallback?.('INITIAL_SESSION', null);
-
-    // 임시 구독이 복원된 user를 전달
-    await Promise.resolve();
-    restoreCallback?.('SIGNED_IN', { user: restoredUser });
-
-    await handlePromise;
-    await jest.runOnlyPendingTimersAsync();
-
-    // Assert: null이 아닌 복원된 user로 checkAuthState가 호출됨
-    expect(mockAuthStoreState.checkAuthState).toHaveBeenCalledWith(restoredUser);
-    expect(mockAuthStoreState.checkAuthState).not.toHaveBeenCalledWith(null);
-  });
-
-  it('ignores a synchronous initial null auth snapshot while Supabase restores the session', async () => {
-    // Arrange: guard 활성화 조건 — cache 부트스트랩 + 인증 상태 + user 없음
-    setAuthStoreState({
-      status: 'authenticated',
-      bootstrapSource: 'cache',
-      user: null,
-    });
-
-    const restoredUser = { id: 'test-user-id', email: 'test@example.com' };
-
-    // getUser()가 즉시 복원된 user를 반환 (동기 초기 null 처리)
-    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: restoredUser }, error: null });
-
-    let mainAuthCallback:
-      | ((event: string, session: { user: typeof restoredUser } | null) => void)
-      | undefined;
-    mockSupabase.auth.onAuthStateChange.mockImplementation(
-      (callback: (event: string, session: { user: typeof restoredUser } | null) => void) => {
-        mainAuthCallback = callback;
-        return { data: { subscription: { unsubscribe: jest.fn() } } };
-      }
-    );
-
-    sessionService.initialize();
-
-    // Act: null 이벤트 전달 (초기 null 스냅샷)
-    const handlePromise = mainAuthCallback?.('INITIAL_SESSION', null);
-    await handlePromise;
-    await jest.runOnlyPendingTimersAsync();
-
-    // Assert: getUser()가 반환한 복원된 user로 checkAuthState 호출
-    expect(mockAuthStoreState.checkAuthState).toHaveBeenCalledWith(restoredUser);
-    expect(mockAuthStoreState.checkAuthState).not.toHaveBeenCalledWith(null);
-  });
-
-  it('does not delay a real null auth event after startup restore guard is absent', async () => {
-    let supabaseAuthCallback: ((event: string, session: null) => void | Promise<void>) | undefined;
-
-    mockSupabase.auth.onAuthStateChange.mockImplementation(
-      (callback: (event: string, session: null) => void | Promise<void>) => {
-        supabaseAuthCallback = callback;
-        return { data: { subscription: { unsubscribe: jest.fn() } } };
-      }
-    );
-
-    sessionService.initialize();
-    jest.clearAllMocks();
-
-    const nullEventPromise = supabaseAuthCallback?.('SIGNED_OUT', null);
-    await Promise.resolve();
-
-    expect(mockAuthStoreState.checkAuthState).toHaveBeenCalledWith(null);
-    await nullEventPromise;
-  });
-
-  it('cleans up the temporary restore listener after waitForRestoredAuthUser resolves', async () => {
-    // Arrange: guard 활성화 조건 — cache 부트스트랩 + 인증 상태 + user 없음
-    setAuthStoreState({
-      status: 'authenticated',
-      bootstrapSource: 'cache',
-      user: null,
-    });
-
-    const restoredUser = { id: 'test-user-id', email: 'test@example.com' };
-
-    // getUser()는 null 반환 — waitForRestoredAuthUser가 임시 onAuthStateChange 구독으로 진입
-    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null }, error: null });
-
-    let mainAuthCallback:
-      | ((event: string, session: { user: typeof restoredUser } | null) => void)
-      | undefined;
-    let restoreCallback:
-      | ((event: string, session: { user: typeof restoredUser } | null) => void)
-      | undefined;
-    const restoreUnsubscribe = jest.fn();
-
-    mockSupabase.auth.onAuthStateChange.mockImplementation(
-      (callback: (event: string, session: { user: typeof restoredUser } | null) => void) => {
-        if (!mainAuthCallback) {
-          mainAuthCallback = callback;
-          return { data: { subscription: { unsubscribe: jest.fn() } } };
-        }
-        restoreCallback = callback;
-        return { data: { subscription: { unsubscribe: restoreUnsubscribe } } };
-      }
-    );
-
-    sessionService.initialize();
-
-    // Act: null 이벤트 → waitForRestoredAuthUser 진입 → 임시 구독 생성
-    const handlePromise = mainAuthCallback?.('INITIAL_SESSION', null);
-
-    await Promise.resolve();
-    // 임시 구독이 복원된 user 전달 → Promise resolve
-    restoreCallback?.('SIGNED_IN', { user: restoredUser });
-
-    await handlePromise;
-    await jest.runOnlyPendingTimersAsync();
-
-    // Assert: 임시 restore 구독이 settled 후 해제됨
-    expect(restoreUnsubscribe).toHaveBeenCalled();
-  });
-
-  it('starts session timers after suppressed session becomes authenticated again', async () => {
-    setAuthStoreState({
-      status: 'unauthenticated',
-      suppressedSessionUserId: 'test-user-id',
-    });
-
-    sessionService.initialize();
-    jest.clearAllMocks();
-
-    setAuthStoreState({
-      status: 'authenticated',
-      suppressedSessionUserId: null,
-    });
-
-    expect(sessionService.isSessionActive()).toBe(true);
-    await jest.runOnlyPendingTimersAsync();
-    await jest.advanceTimersByTimeAsync(50 * 60 * 1000);
-
-    // Supabase handles token refresh via getSession, not getIdTokenResult
-    expect(mockGetSession).toHaveBeenCalled();
-    expect(sessionService.getSessionState().isActive).toBe(true);
-  });
-
-  it('does not force-refresh the token on web auth changes', async () => {
-    const originalPlatform = Platform.OS;
-    const supabaseUser = { id: 'test-user-id', email: 'test@example.com' };
-    let supabaseAuthCallback:
-      | ((event: string, session: { user: typeof supabaseUser } | null) => void)
-      | undefined;
-
-    Object.defineProperty(Platform, 'OS', { configurable: true, value: 'web' });
-    mockSupabase.auth.onAuthStateChange.mockImplementation(
-      (callback: (event: string, session: { user: typeof supabaseUser } | null) => void) => {
-        supabaseAuthCallback = callback;
-        return { data: { subscription: { unsubscribe: jest.fn() } } };
-      }
-    );
-
-    try {
+  describe('initialize', () => {
+    it('onAuthStateChange를 1회 구독한다', () => {
       sessionService.initialize();
-      supabaseAuthCallback?.('SIGNED_IN', { user: supabaseUser });
-      await jest.runOnlyPendingTimersAsync();
 
-      // Supabase handles tokens automatically - just verify getSession was called for token check
-      expect(mockGetSession).toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(Platform, 'OS', { configurable: true, value: originalPlatform });
-    }
-  });
-
-  it('expires managed sessions after inactivity', async () => {
-    const supabaseUser = { id: 'test-user-id', email: 'test@example.com' };
-    let supabaseAuthCallback:
-      | ((event: string, session: { user: typeof supabaseUser } | null) => void)
-      | undefined;
-    mockSupabase.auth.onAuthStateChange.mockImplementation(
-      (callback: (event: string, session: { user: typeof supabaseUser } | null) => void) => {
-        supabaseAuthCallback = callback;
-        return { data: { subscription: { unsubscribe: jest.fn() } } };
-      }
-    );
-
-    sessionService.initialize();
-    supabaseAuthCallback?.('SIGNED_IN', { user: supabaseUser });
-    await jest.runOnlyPendingTimersAsync();
-    await jest.advanceTimersByTimeAsync(30 * 60 * 1000 + 1000);
-
-    expect(RealtimeManager.unsubscribeAll).toHaveBeenCalled();
-    expect(clearCounterSyncCache).toHaveBeenCalled();
-    expect(syncSignOut).toHaveBeenCalled();
-    expect(mockAuthStoreState.reset).toHaveBeenCalled();
-    expect(mockAddToast).toHaveBeenCalledWith({
-      type: 'warning',
-      message: expect.stringContaining('다시 로그인해 주세요.'),
-    });
-    expect(router.replace).toHaveBeenCalledWith('/(auth)/login');
-  });
-
-  it('refreshes tokens successfully', async () => {
-    const token = await refreshToken();
-
-    expect(token).toBe('new-token');
-    expect(mockRefreshSession).toHaveBeenCalled();
-    expect(authStorage.setAuthToken).toHaveBeenCalledWith('new-token');
-  });
-
-  it('expires the session when token refresh fails', async () => {
-    mockRefreshSession.mockResolvedValue({
-      data: { session: null },
-      error: { message: 'refresh failed' },
+      expect(mockSupabase.auth.onAuthStateChange).toHaveBeenCalledTimes(1);
     });
 
-    const token = await refreshToken();
+    it('중복 호출은 idempotent (구독 1회만)', () => {
+      sessionService.initialize();
+      sessionService.initialize();
 
-    expect(token).toBeNull();
-    expect(syncSignOut).toHaveBeenCalled();
-    expect(router.replace).toHaveBeenCalledWith('/(auth)/login');
-  });
-
-  it('returns the current session token when available', async () => {
-    const token = await getValidToken();
-
-    expect(token).toBe('test-token');
-    expect(mockGetSession).toHaveBeenCalled();
-  });
-
-  it('tracks login attempts and resets them', async () => {
-    getItem.mockResolvedValue(null);
-    setItem.mockResolvedValue(undefined);
-    deleteItem.mockResolvedValue(undefined);
-
-    await incrementLoginAttempts('test@example.com');
-    await resetLoginAttempts('test@example.com');
-
-    expect(setItem).toHaveBeenCalledWith(
-      'login_attempts_test@example.com',
-      expect.objectContaining({
-        count: 1,
-        lockUntil: null,
-      })
-    );
-    expect(deleteItem).toHaveBeenCalledWith('login_attempts_test@example.com');
-  });
-
-  it('throws when login attempts are currently locked', async () => {
-    getItem.mockResolvedValue({
-      count: 5,
-      lockUntil: Date.now() + 10 * 60 * 1000,
-      lastAttempt: Date.now(),
-    });
-
-    await expect(checkLoginAttempts('test@example.com')).rejects.toMatchObject({
-      name: 'AuthError',
-      code: 'E2006',
+      expect(mockSupabase.auth.onAuthStateChange).toHaveBeenCalledTimes(1);
     });
   });
 
-  it('returns remaining login attempts', async () => {
-    getItem.mockResolvedValue({
-      count: 2,
-      lockUntil: null,
-      lastAttempt: Date.now(),
+  describe('cleanup', () => {
+    it('초기화되지 않은 상태에서 호출 시 no-op', () => {
+      expect(() => sessionService.cleanup()).not.toThrow();
+      expect(mockUnsubscribe).not.toHaveBeenCalled();
     });
 
-    await expect(getRemainingLoginAttempts('test@example.com')).resolves.toBe(3);
+    it('initialize 후 cleanup 시 구독 해제', () => {
+      sessionService.initialize();
+      sessionService.cleanup();
+
+      expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('[REGRESSION] cleanup 중복 호출해도 crash 없음', () => {
+      sessionService.initialize();
+      sessionService.cleanup();
+      expect(() => sessionService.cleanup()).not.toThrow();
+    });
+  });
+
+  describe('handleAuthStateChange (Supabase deadlock 회피)', () => {
+    it('[REGRESSION] callback이 다음 tick으로 defer되어 deadlock 회피', async () => {
+      // 다른 user로 호출되어 동기화가 발생하도록 store user를 다르게 설정
+      mockAuthStoreState.user = { uid: 'different-user', email: 'other@example.com' };
+      mockAuthStoreState.profile = null;
+
+      sessionService.initialize();
+      supabaseAuthCallback?.('SIGNED_IN', { user: mockUser } as Session);
+
+      // 같은 tick에서는 미실행 (deferral 검증)
+      expect(mockAuthStoreState.checkAuthState).not.toHaveBeenCalled();
+
+      await tick();
+
+      // 다음 tick에서 실행
+      expect(mockAuthStoreState.checkAuthState).toHaveBeenCalledWith(mockUser);
+    });
+  });
+
+  describe('shouldSkipAuthStoreSync 분기', () => {
+    it('동일 user의 TOKEN_REFRESHED 이벤트 시 authStore 재동기화 skip', async () => {
+      sessionService.initialize();
+
+      supabaseAuthCallback?.('TOKEN_REFRESHED', { user: mockUser } as Session);
+      await tick();
+
+      expect(mockAuthStoreState.checkAuthState).not.toHaveBeenCalled();
+    });
+
+    it('다른 user 이벤트 시 authStore 동기화', async () => {
+      mockAuthStoreState.user = { uid: 'old-user', email: 'old@example.com' };
+      mockAuthStoreState.profile = { uid: 'old-user' };
+
+      sessionService.initialize();
+      supabaseAuthCallback?.('SIGNED_IN', { user: mockUser } as Session);
+      await tick();
+
+      expect(mockAuthStoreState.checkAuthState).toHaveBeenCalledWith(mockUser);
+    });
+  });
+
+  describe('SIGNED_OUT 전파', () => {
+    it('[REGRESSION] SDK가 SIGNED_OUT emit 시 authStore 초기화 호출', async () => {
+      mockAuthStoreState.bootstrapSource = 'server';
+      sessionService.initialize();
+
+      supabaseAuthCallback?.('SIGNED_OUT', null);
+      await tick();
+
+      expect(mockAuthStoreState.checkAuthState).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('세션 유지 정책', () => {
+    it('[REGRESSION] initialize 후 자동 signOut 타이머가 등록되지 않음', () => {
+      const setIntervalSpy = jest.spyOn(global, 'setInterval');
+
+      sessionService.initialize();
+
+      // 30분 timeout / 50분 refresh interval 등 일체의 setInterval 등록 없음
+      expect(setIntervalSpy).not.toHaveBeenCalled();
+      expect(mockSupabase.auth.signOut).not.toHaveBeenCalled();
+
+      setIntervalSpy.mockRestore();
+    });
+
+    it('[REGRESSION] auth 이벤트 처리 시 수동 refreshSession 호출 안함 (SDK autoRefreshToken에 위임)', async () => {
+      sessionService.initialize();
+
+      supabaseAuthCallback?.('TOKEN_REFRESHED', { user: mockUser } as Session);
+      await tick();
+
+      expect(mockSupabase.auth.refreshSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getSessionState', () => {
+    it('인증된 상태에서 isActive=true', () => {
+      mockAuthStoreState.status = 'authenticated';
+      expect(getSessionState().isActive).toBe(true);
+    });
+
+    it('미인증 상태에서 isActive=false', () => {
+      mockAuthStoreState.status = 'unauthenticated';
+      expect(getSessionState().isActive).toBe(false);
+    });
   });
 });

--- a/uniqn-mobile/src/services/observability/index.ts
+++ b/uniqn-mobile/src/services/observability/index.ts
@@ -87,17 +87,8 @@ export {
   sessionService,
   initialize as initializeSession,
   cleanup as cleanupSession,
-  recordActivity,
-  isSessionActive,
   getSessionState,
-  refreshToken,
-  getValidToken,
-  checkLoginAttempts,
-  incrementLoginAttempts,
-  resetLoginAttempts,
-  getRemainingLoginAttempts,
   type SessionState,
-  type LoginAttempts,
 } from './sessionService';
 
 // Token Refresh Service

--- a/uniqn-mobile/src/services/observability/sessionService.ts
+++ b/uniqn-mobile/src/services/observability/sessionService.ts
@@ -1,89 +1,37 @@
 /**
  * UNIQN Mobile - Session Management Service
+ *
+ * @description Supabase auth 이벤트를 authStore와 동기화한다.
+ *
+ * 책임:
+ *  - `onAuthStateChange` 구독 → `authStore.checkAuthState` 호출
+ *  - 부트스트랩 가드: 캐시에서 복원된 인증 상태와 SDK의 비동기 복원 사이의 race 방지
+ *
+ * 비책임 (의도적 제외):
+ *  - 토큰 수명 관리 — Supabase SDK의 `autoRefreshToken: true`에 위임
+ *  - 비활성 타임아웃 — 제거됨 (refresh token이 만료되거나 revoke될 때까지 세션 유지)
+ *  - 로그인 시도 rate limiting — `@/services/auth/loginAttemptService`로 분리
+ *
+ * Supabase known bug 회피: `onAuthStateChange` callback 내부에서 await로
+ * 다른 Supabase 호출 시 deadlock 발생 가능. `setTimeout(handler, 0)`로 다음
+ * tick에 실행해 SDK 내부 락에서 빠져나오게 한다.
+ * (https://supabase.com/docs/troubleshooting/why-is-my-supabase-api-call-not-returning-PGzXw0)
  */
 
-import { AppState, type AppStateStatus } from 'react-native';
 import type { User as SupabaseUser } from '@supabase/supabase-js';
-import { router } from 'expo-router';
 import { supabase } from '@/lib/supabase';
-import { authStorage, userSessionStorage, getItem, setItem, deleteItem } from '@/lib/secureStorage';
 import { useAuthStore } from '@/stores/authStore';
-import { useToastStore } from '@/stores/toastStore';
-import { AuthError, ERROR_CODES, isAppError, toError } from '@/errors';
-import { clearCounterSyncCache } from '@/shared/cache/counterSyncCache';
-import { RealtimeManager } from '@/shared/realtime';
 import { logger } from '@/utils/logger';
-import { sentryService } from './sentryService';
 
-void userSessionStorage;
-
-const SESSION_TIMEOUT = 30 * 60 * 1000;
-const SESSION_WARNING_BUFFER = 5 * 60 * 1000;
-const TOKEN_REFRESH_INTERVAL = 50 * 60 * 1000;
-const MAX_LOGIN_ATTEMPTS = 5;
-const LOCKOUT_DURATION = 15 * 60 * 1000;
-// TOKEN_EXPIRY_BUFFER removed - Supabase handles token refresh automatically
 const AUTH_RESTORE_SETTLE_TIMEOUT_MS = 2000;
 
 export interface SessionState {
   isActive: boolean;
-  lastActivity: number;
-  tokenExpiresAt: number | null;
-}
-
-export interface LoginAttempts {
-  count: number;
-  lockUntil: number | null;
-  lastAttempt: number;
 }
 
 let isInitialized = false;
-let lastActivity = Date.now();
-let sessionTimeoutId: ReturnType<typeof setTimeout> | null = null;
-let sessionWarningTimeoutId: ReturnType<typeof setTimeout> | null = null;
-let tokenRefreshIntervalId: ReturnType<typeof setInterval> | null = null;
-let appStateSubscription: { remove: () => void } | null = null;
 let authUnsubscribe: (() => void) | null = null;
-let authStoreUnsubscribe: (() => void) | null = null;
-let managedSessionUserId: string | null = null;
 let startupAuthRestoreGuardUntil: number | null = null;
-
-function shouldManageSessionForUser(user: { uid?: string; id?: string } | null): boolean {
-  if (!user) {
-    return false;
-  }
-
-  const userId = user.uid ?? user.id;
-  const authState = useAuthStore.getState();
-  return authState.status === 'authenticated' && authState.suppressedSessionUserId !== userId;
-}
-
-function clearSessionRuntime(): void {
-  clearSessionTimeout();
-  clearSessionWarning();
-  clearTokenRefreshInterval();
-  managedSessionUserId = null;
-}
-
-function syncManagedSessionState(): void {
-  const currentUser = useAuthStore.getState().user;
-  const nextManagedUserId =
-    currentUser && shouldManageSessionForUser(currentUser) ? currentUser.uid : null;
-
-  if (!nextManagedUserId) {
-    clearSessionRuntime();
-    return;
-  }
-
-  if (managedSessionUserId === nextManagedUserId) {
-    return;
-  }
-
-  managedSessionUserId = nextManagedUserId;
-  lastActivity = Date.now();
-  resetActivityTimer();
-  startTokenRefreshInterval();
-}
 
 function shouldSkipAuthStoreSync(user: SupabaseUser | null): boolean {
   if (!user) {
@@ -134,13 +82,13 @@ function shouldWaitForStartupAuthRestore(user: SupabaseUser | null): boolean {
 async function waitForRestoredAuthUser(
   timeoutMs = AUTH_RESTORE_SETTLE_TIMEOUT_MS
 ): Promise<SupabaseUser | null> {
-  // Try to get the current user directly
+  // 이 함수는 setTimeout deferral 안쪽에서 호출되므로 callback context 밖.
+  // Supabase deadlock 회피 안전 영역.
   const { data } = await supabase.auth.getUser();
   if (data.user) {
     return data.user;
   }
 
-  // Wait for auth state change with timeout
   return new Promise<SupabaseUser | null>((resolve) => {
     let settled = false;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -169,72 +117,37 @@ export function initialize(): void {
     return;
   }
 
-  appStateSubscription = AppState.addEventListener('change', handleAppStateChange);
   armStartupAuthRestoreGuard();
+
   const {
     data: { subscription },
   } = supabase.auth.onAuthStateChange((_event, session) => {
-    handleAuthStateChange(session?.user ?? null);
+    // Supabase known bug: callback 안에서 await로 다른 supabase 호출 시 deadlock.
+    // setTimeout(0)로 다음 tick에 실행해 SDK 내부 상태 머신에서 빠져나옴.
+    setTimeout(() => {
+      void handleAuthStateChange(session?.user ?? null);
+    }, 0);
   });
   authUnsubscribe = () => subscription.unsubscribe();
-  authStoreUnsubscribe = useAuthStore.subscribe(() => {
-    syncManagedSessionState();
-  });
 
   isInitialized = true;
-  syncManagedSessionState();
   logger.info('세션 매니저 초기화 완료');
 }
 
 export function cleanup(): void {
-  const hadSessionState =
-    isInitialized ||
-    appStateSubscription !== null ||
-    authUnsubscribe !== null ||
-    authStoreUnsubscribe !== null ||
-    sessionTimeoutId !== null ||
-    sessionWarningTimeoutId !== null ||
-    tokenRefreshIntervalId !== null ||
-    managedSessionUserId !== null;
-
-  if (!hadSessionState) {
+  if (!isInitialized && !authUnsubscribe) {
     return;
   }
 
-  clearSessionRuntime();
   clearStartupAuthRestoreGuard();
-
-  if (appStateSubscription) {
-    appStateSubscription.remove();
-    appStateSubscription = null;
-  }
 
   if (authUnsubscribe) {
     authUnsubscribe();
     authUnsubscribe = null;
   }
 
-  if (authStoreUnsubscribe) {
-    authStoreUnsubscribe();
-    authStoreUnsubscribe = null;
-  }
-
   isInitialized = false;
   logger.info('세션 매니저 정리 완료');
-}
-
-function handleAppStateChange(state: AppStateStatus): void {
-  if (state === 'active') {
-    checkSession();
-    logger.debug('앱 포그라운드 복귀 - 세션 체크');
-    return;
-  }
-
-  if (state === 'background') {
-    clearSessionTimeout();
-    clearSessionWarning();
-    logger.debug('앱 백그라운드 전환 - 세션 타이머 중지');
-  }
 }
 
 async function handleAuthStateChange(user: SupabaseUser | null): Promise<void> {
@@ -265,339 +178,18 @@ async function handleAuthStateChange(user: SupabaseUser | null): Promise<void> {
       error: error instanceof Error ? error.message : String(error),
     });
   }
-
-  syncManagedSessionState();
-
-  if (!shouldManageSessionForUser(nextUser)) {
-    logger.info(nextUser ? '인증 상태 변경 - 세션 관리 보류' : '인증 상태 변경 - 세션 종료');
-    return;
-  }
-
-  try {
-    const activeUser = nextUser;
-    if (!activeUser) {
-      return;
-    }
-    // Supabase handles token refresh automatically
-    logger.debug('세션 상태 확인 완료');
-  } catch (error) {
-    logger.warn('토큰 갱신 실패', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-
-  logger.info('인증 상태 변경 - 세션 시작');
-}
-
-export function recordActivity(): void {
-  lastActivity = Date.now();
-
-  if (shouldManageSessionForUser(useAuthStore.getState().user)) {
-    resetActivityTimer();
-  }
-}
-
-function checkSession(): void {
-  const currentUser = useAuthStore.getState().user;
-  if (!shouldManageSessionForUser(currentUser)) {
-    return;
-  }
-
-  const inactive = Date.now() - lastActivity;
-
-  if (inactive > SESSION_TIMEOUT) {
-    void expireSession('세션이 만료되었습니다.');
-    return;
-  }
-
-  if (inactive > SESSION_TIMEOUT - SESSION_WARNING_BUFFER) {
-    showSessionWarning();
-    clearSessionTimeout();
-    clearSessionWarning();
-    sessionTimeoutId = setTimeout(() => {
-      void expireSession('비활성 상태로 인해 세션이 만료되었습니다.');
-    }, SESSION_TIMEOUT - inactive);
-    return;
-  }
-
-  resetActivityTimer();
-  void checkAndRefreshToken();
-}
-
-function resetActivityTimer(): void {
-  clearSessionTimeout();
-  clearSessionWarning();
-
-  sessionWarningTimeoutId = setTimeout(() => {
-    showSessionWarning();
-  }, SESSION_TIMEOUT - SESSION_WARNING_BUFFER);
-
-  sessionTimeoutId = setTimeout(() => {
-    void expireSession('비활성 상태로 인해 세션이 만료되었습니다.');
-  }, SESSION_TIMEOUT);
-}
-
-function clearSessionTimeout(): void {
-  if (sessionTimeoutId) {
-    clearTimeout(sessionTimeoutId);
-    sessionTimeoutId = null;
-  }
-}
-
-function clearSessionWarning(): void {
-  if (sessionWarningTimeoutId) {
-    clearTimeout(sessionWarningTimeoutId);
-    sessionWarningTimeoutId = null;
-  }
-}
-
-function showSessionWarning(): void {
-  const currentUser = useAuthStore.getState().user;
-  if (!shouldManageSessionForUser(currentUser)) {
-    return;
-  }
-
-  logger.info('세션 만료 경고', { component: 'sessionService' });
-  useToastStore.getState().addToast({
-    type: 'warning',
-    message: '세션이 5분 뒤 만료됩니다. 활동을 계속하면 자동 연장됩니다.',
-  });
-}
-
-async function expireSession(message: string): Promise<void> {
-  logger.warn('세션 만료', { message });
-
-  useToastStore.getState().addToast({
-    type: 'warning',
-    message: `${message} 다시 로그인해 주세요.`,
-  });
-
-  try {
-    RealtimeManager.unsubscribeAll();
-    clearCounterSyncCache();
-    await supabase.auth.signOut();
-    useAuthStore.getState().reset();
-  } catch (error) {
-    logger.error('세션 만료 처리 중 로그아웃에 실패했습니다', toError(error));
-  }
-
-  clearSessionRuntime();
-  router.replace('/(auth)/login');
-}
-
-function startTokenRefreshInterval(): void {
-  if (!shouldManageSessionForUser(useAuthStore.getState().user)) {
-    clearTokenRefreshInterval();
-    return;
-  }
-
-  clearTokenRefreshInterval();
-  void checkAndRefreshToken();
-  tokenRefreshIntervalId = setInterval(() => {
-    void checkAndRefreshToken();
-  }, TOKEN_REFRESH_INTERVAL);
-}
-
-function clearTokenRefreshInterval(): void {
-  if (tokenRefreshIntervalId) {
-    clearInterval(tokenRefreshIntervalId);
-    tokenRefreshIntervalId = null;
-  }
-}
-
-async function checkAndRefreshToken(): Promise<void> {
-  const currentUser = useAuthStore.getState().user;
-  if (!shouldManageSessionForUser(currentUser)) {
-    return;
-  }
-
-  try {
-    // Supabase handles token refresh automatically via autoRefreshToken
-    const {
-      data: { session },
-      error,
-    } = await supabase.auth.getSession();
-    if (error || !session) {
-      await refreshToken();
-    }
-  } catch (error) {
-    logger.error('토큰 체크 실패', toError(error));
-    void sentryService.recordError(toError(error), {
-      component: 'sessionService',
-      action: 'checkAndRefreshToken',
-    });
-  }
-}
-
-export async function refreshToken(): Promise<string | null> {
-  const currentUser = useAuthStore.getState().user;
-  if (!currentUser) {
-    logger.warn('토큰 갱신 실패 - 로그인 필요');
-    return null;
-  }
-
-  try {
-    const {
-      data: { session },
-      error,
-    } = await supabase.auth.refreshSession();
-    if (error) throw error;
-
-    const accessToken = session?.access_token ?? null;
-    if (accessToken) {
-      await authStorage.setAuthToken(accessToken);
-      logger.info('토큰 갱신 성공');
-    }
-    return accessToken;
-  } catch (error) {
-    logger.error('토큰 갱신 실패', toError(error));
-    void sentryService.recordError(toError(error), {
-      component: 'sessionService',
-      action: 'refreshToken',
-    });
-    await expireSession('인증 토큰 갱신에 실패했습니다.');
-    return null;
-  }
-}
-
-export async function getValidToken(): Promise<string | null> {
-  const currentUser = useAuthStore.getState().user;
-  if (!currentUser) {
-    return null;
-  }
-
-  try {
-    const {
-      data: { session },
-    } = await supabase.auth.getSession();
-    if (!session) {
-      return await refreshToken();
-    }
-    return session.access_token;
-  } catch (error) {
-    logger.error('유효 토큰 조회 실패', toError(error));
-    return null;
-  }
-}
-
-export async function checkLoginAttempts(email: string): Promise<void> {
-  const key = `login_attempts_${email.toLowerCase()}`;
-
-  try {
-    const attempts = await getItem<LoginAttempts>(key);
-    if (!attempts) {
-      return;
-    }
-
-    if (attempts.lockUntil && Date.now() < attempts.lockUntil) {
-      const remainingTime = Math.ceil((attempts.lockUntil - Date.now()) / 60000);
-      throw new AuthError(ERROR_CODES.AUTH_RATE_LIMITED, {
-        userMessage: `로그인 시도 횟수를 초과했습니다. ${remainingTime}분 후에 다시 시도해 주세요.`,
-        metadata: { remainingMinutes: remainingTime },
-      });
-    }
-
-    if (attempts.lockUntil && Date.now() >= attempts.lockUntil) {
-      await deleteItem(key);
-    }
-  } catch (error) {
-    if (isAppError(error)) {
-      throw error;
-    }
-
-    logger.error('로그인 시도 횟수 확인 실패', toError(error));
-  }
-}
-
-export async function incrementLoginAttempts(email: string): Promise<void> {
-  const key = `login_attempts_${email.toLowerCase()}`;
-
-  try {
-    const current = (await getItem<LoginAttempts>(key)) ?? {
-      count: 0,
-      lockUntil: null,
-      lastAttempt: 0,
-    };
-
-    const newCount = current.count + 1;
-    const shouldLock = newCount >= MAX_LOGIN_ATTEMPTS;
-
-    const nextAttempts: LoginAttempts = {
-      count: newCount,
-      lockUntil: shouldLock ? Date.now() + LOCKOUT_DURATION : null,
-      lastAttempt: Date.now(),
-    };
-
-    await setItem(key, nextAttempts);
-
-    if (shouldLock) {
-      logger.warn('로그인 시도 횟수 초과 - 계정 잠금', {
-        email: email.substring(0, 3) + '***',
-      });
-    }
-  } catch (error) {
-    logger.error('로그인 시도 횟수 증가 실패', toError(error));
-  }
-}
-
-export async function resetLoginAttempts(email: string): Promise<void> {
-  const key = `login_attempts_${email.toLowerCase()}`;
-
-  try {
-    await deleteItem(key);
-    logger.debug('로그인 시도 횟수 초기화', { email: email.substring(0, 3) + '***' });
-  } catch (error) {
-    logger.error('로그인 시도 횟수 초기화 실패', toError(error));
-  }
-}
-
-export async function getRemainingLoginAttempts(email: string): Promise<number> {
-  const key = `login_attempts_${email.toLowerCase()}`;
-
-  try {
-    const attempts = await getItem<LoginAttempts>(key);
-    if (!attempts) {
-      return MAX_LOGIN_ATTEMPTS;
-    }
-
-    return Math.max(0, MAX_LOGIN_ATTEMPTS - attempts.count);
-  } catch {
-    return MAX_LOGIN_ATTEMPTS;
-  }
 }
 
 export function getSessionState(): SessionState {
-  const currentUser = useAuthStore.getState().user;
-
   return {
-    isActive: shouldManageSessionForUser(currentUser),
-    lastActivity,
-    tokenExpiresAt: null,
+    isActive: useAuthStore.getState().status === 'authenticated',
   };
-}
-
-export function isSessionActive(): boolean {
-  const currentUser = useAuthStore.getState().user;
-  if (!shouldManageSessionForUser(currentUser)) {
-    return false;
-  }
-
-  const inactive = Date.now() - lastActivity;
-  return inactive < SESSION_TIMEOUT;
 }
 
 export const sessionService = {
   initialize,
   cleanup,
-  recordActivity,
-  isSessionActive,
   getSessionState,
-  refreshToken,
-  getValidToken,
-  checkLoginAttempts,
-  incrementLoginAttempts,
-  resetLoginAttempts,
-  getRemainingLoginAttempts,
 };
 
 export default sessionService;


### PR DESCRIPTION
## 요약

30분 비활성 강제 로그아웃 로직을 제거하고, 세션 수명 관리를 Supabase SDK의 `autoRefreshToken` + `persistSession`에 완전히 위임. 사용자는 refresh token이 만료/revoke될 때까지 재로그인 없이 세션을 이어간다.

- `sessionService.ts` 600줄 → 195줄 (60%+ 감소)
- brute-force 방어 로직은 `loginAttemptService.ts`로 단일 책임 분리
- AppState `active`/`background` 시 `startAutoRefresh`/`stopAutoRefresh` 호출 (Supabase RN 공식 가이드)
- `onAuthStateChange` callback에 `setTimeout(0)` deferral — Supabase known deadlock 우회

## 동기

- 30분마다 재로그인 강요 → 스태프 UX 저하
- 직접 짠 50분 refresh 인터벌 + 30분 타이머가 SDK 기능과 이중 구현
- 코드 폭 감소 → 유지보수 비용 감소

## 검증

- `tsc --noEmit`: 0 errors
- `jest --testPathPattern="sessionService|loginAttemptService|useAppInitialize"`: **44/44 passed** (4 REGRESSION 포함)
- `eslint`: 0 errors (영향 파일)
- `prettier --check`: clean
- `/plan-eng-review`: CLEAR (3 issues, 모두 폐쇄)
- Codex outside voice: 3 critical 발견 모두 반영

Plan doc: [`uniqn-mobile/docs/superpowers/plans/2026-04-25-session-keep-alive.md`](./uniqn-mobile/docs/superpowers/plans/2026-04-25-session-keep-alive.md)

## ⚠️ 알려진 보안 trade-off

세션 만료 정책이 "30분 비활성 → 무기한 (refresh token revoke까지)"로 변경됨. 다음 방어선들이 trade-off를 일부 메꿈:

| 방어선 | 상태 |
|--------|------|
| Refresh token rotation + 10s reuse interval | ✅ Supabase Dashboard 확인 완료 |
| 5회 로그인 실패 → 15분 잠금 | ✅ loginAttemptService (별도 분리) |
| JWT access token 1시간 만료 + autoRefreshToken | ✅ SDK 표준 |
| Session time-box (절대 만료) | ❌ Supabase Free Plan에서는 설정 불가 |
| Inactivity timeout | ❌ Supabase Free Plan에서는 설정 불가 |
| "모든 기기에서 로그아웃" UX | ❌ 미구현 (P1 후속) |

### 남은 위험 시나리오

분실폰 + 잠금 미설정 + 본인이 "모든 기기 로그아웃" 안 누름 → refresh token revoke 전까지 무기한 노출.

베타 단계 + 포커룸 스태프 관리 앱 특성상 발생 빈도 낮음으로 평가, UX 개선을 우선해 land 결정. 본격 출시 전 P1 후속 작업 필요.

## 후속 TODO (별도 PR)

- [ ] **P1**: "모든 기기에서 로그아웃" UX — plan line 626 명시
- [ ] **P2**: admin/employer 역할 한정 inactivity timeout (앱 레이어 구현) — plan line 627
- [ ] **P2**: 민감 작업(정산 수정, 권한 변경) 재인증 게이트 — biometricService 이미 존재
- [ ] **P3**: Supabase Pro Plan 검토 후 인프라 레이어 time-box(30일) 활성화

## Test plan

- [ ] iOS/Android 빌드 후 한 번 로그인 → 30분 이상 백그라운드 → 포그라운드 복귀 시 재로그인 강요 없는지 확인
- [ ] 앱 종료 → 재시작 시 세션 유지 확인
- [ ] 5회 로그인 실패 → 15분 잠금 동작 확인
- [ ] 다른 디바이스에서 SIGNED_OUT 강제 → 본 디바이스 다음 요청 시 로그인 화면 전환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)