### PR TITLE
ci(e2e): artifact 업로드 경로 수정 — report/trace 복구

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -112,7 +112,7 @@ jobs:
         if: always()
         with:
           name: playwright-report
-          path: uniqn-mobile/playwright-report/
+          path: uniqn-mobile/output/playwright/report/
           retention-days: 14
 
       - name: Upload Test Results
@@ -121,7 +121,7 @@ jobs:
         with:
           name: e2e-test-results
           path: |
-            uniqn-mobile/e2e/test-results/
+            uniqn-mobile/output/playwright/test-results/
           retention-days: 7
 
       - name: Comment E2E Results on PR

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
-        if: failure()
+        if: always()
         with:
           name: e2e-test-results
           path: |

--- a/uniqn-mobile/e2e/playwright.config.ts
+++ b/uniqn-mobile/e2e/playwright.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
   workers: isCI ? 4 : 1,
   outputDir: testResultsDir,
   reporter: isCI
-    ? [['html', { open: 'never', outputFolder: htmlReportDir }], ['github']]
+    ? [['list'], ['html', { open: 'never', outputFolder: htmlReportDir }], ['github']]
     : [['html', { open: 'on-failure', outputFolder: htmlReportDir }]],
 
   globalSetup: require.resolve('./global-setup'),


### PR DESCRIPTION
## Summary

3건의 e2e artifact 회수 차단 버그를 수정.

### 1. Upload Playwright Report 경로 mismatch
`playwright.config.ts` 의 `outputFolder` 는 `output/playwright/report` 인데 워크플로는 `playwright-report/` 를 업로드 시도해 16연속 cancelled run 동안 0건 업로드.
- `playwright-report/` → `output/playwright/report/`

### 2. Upload Test Results 경로 mismatch
`e2e/test-results/` → `output/playwright/test-results/`

### 3. `if: failure()` 가 cancelled 시 skip + HTML reporter 가 cancel 시 빈 폴더
GitHub Actions `failure()` 는 **이전 step 이 failed 일 때만** true. timeout cancel 시 false → test-results 영영 회수 못함.
HTML reporter 는 run 끝나야 final write — 45min timeout cancel 시 빈 폴더.

해결:
- `Upload Test Results`: `if: failure()` → `if: always()` (per-test trace.zip 은 incremental 이라 cancel 되어도 회수 가능)
- `playwright.config.ts`: `['list']` reporter 추가 — 각 테스트 PASS/FAIL 명세를 GH Actions 로그에 실시간 출력

## Why

- 마지막 정상 통과: 2026-05-11 (4일 전)
- 이후 17번 run 모두 cancelled (45min job timeout)
- artifact 미회수로 정확한 실패 spec / selector / stack trace 분석 불가
- 본 PR 머지 후 다음 run 부터 trace + 실시간 log 확보 → 후속 PR 에서 결정적 실패 119건 추적

## Scope

- `.github/workflows/e2e.yml` 3줄
- `uniqn-mobile/e2e/playwright.config.ts` 1줄
- `continue-on-error: true` 그대로 유지 (별도 PR 에서 결정)
- 45min timeout / dotenv 17 광고 / dead code / hardcoded UUID 등 별개 작업

## Test plan

- [ ] PR 머지 → 새 e2e run 트리거
- [ ] Actions Artifacts 탭에 `playwright-report` (run 완주 시) + `e2e-test-results` (cancel/fail 시) 표시
- [ ] HTML 리포트 또는 list reporter 로그 다운로드 → 실제 실패 spec 명세 확보
- [ ] 다음 후속 PR 에서 119건 결정적 실패 분류 시작

🤖 Generated with [Claude Code](https://claude.com/claude-code)