### PR TITLE
fix(e2e): QA 계정 identity_verified=true 시드 — 본인인증 게이트 우회

### DIFF
--- a/uniqn-mobile/supabase/seed.sql
+++ b/uniqn-mobile/supabase/seed.sql
@@ -212,6 +212,8 @@ INSERT INTO public.users (
   terms_agreed,
   privacy_agreed,
   marketing_agreed,
+  identity_verified,
+  identity_verified_at,
   created_at,
   updated_at
 )
@@ -230,6 +232,8 @@ VALUES
     true,
     true,
     false,
+    true,
+    now(),
     now(),
     now()
   ),
@@ -247,6 +251,8 @@ VALUES
     true,
     true,
     false,
+    true,
+    now(),
     now(),
     now()
   ),
@@ -264,6 +270,8 @@ VALUES
     true,
     true,
     false,
+    true,
+    now(),
     now(),
     now()
   ),
@@ -281,6 +289,8 @@ VALUES
     true,
     true,
     false,
+    true,
+    now(),
     now(),
     now()
   )


### PR DESCRIPTION
## Summary

E2E 결정론적 실패 119건의 **근본 원인 95% (103/108)**를 단일 줄 수정으로 해결.

QA 계정 4종 (staff/employer/admin/collaborator) 의 `users.identity_verified` 가 default `false` 로 들어가 모든 protected route 가 본인인증 reverify 페이지로 리다이렉트되고 있었습니다.

## Root cause (PR #99 artifact 로 확정)

PR #99 의 list reporter + test-results upload 수정 덕에 run 25897707507 의 artifact 회수 가능해졌고, 다운받아 108 spec failure 의 error-context.md 를 분석:

| 분류 | 건수 | 비중 |
|------|------|------|
| 본인인증 페이지 stuck | **103** | **95%** |
| 회원가입 Step1 (signup-Step1) | 1 | 1% |
| 퍼블릭 공고 목록 접근 | 1 | 1% |
| (3 retry × 35 spec 추정) | 그 외 | retries 카운트 |

추적 체인:
1. `src/shared/navigation/authRedirect.ts:101` — `identityVerified === false` → `AUTH_ENTRY_ROUTES.identityReverify` (signup?mode=reverify)
2. `supabase/migrations/20260409000000_base_schema.sql:87` — `identity_verified boolean DEFAULT false`
3. `supabase/seed.sql` INSERT 컬럼 리스트에 `identity_verified` **누락** → 모두 default false

## Change

```sql
INSERT INTO public.users (
  ...,
  marketing_agreed,
+ identity_verified,
+ identity_verified_at,
  created_at,
  updated_at
)
VALUES
  (..., false, true, now(), now(), now()),  -- × 4 QA accounts
```

## Why prod 안전

- `seed.sql` 은 `supabase start` 시점에만 실행 (로컬/CI 전용)
- prod Supabase 는 이 파일 미참조
- 변경된 row 는 `ON CONFLICT (id) DO NOTHING` 라 기존 prod 데이터에도 무영향

## 남은 작업

- 본 PR + PR #99 머지 후 다음 e2e run 에서 ~103건 pass 확인
- 잔존 2 spec (signup-Step1, public-pages-목록) 은 별개 spec-level 이슈로 후속 PR
- 45min timeout 자체 / `continue-on-error: true` 제거 / dotenv 17 광고 / hardcoded UUID FK 등 별개 작업

## Test plan

- [ ] PR #99 머지
- [ ] 본 PR 머지 (또는 동시 merge)
- [ ] 다음 e2e run 통계 확인: pass 30% → ~80%+ 추정
- [ ] 잔존 실패 2건 분석 후속 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)