### PR TITLE
fix(e2e): 잔존 2 spec 동기화 — 제3자 제공 체크박스 + Legacy public jobs

### DIFF
--- a/uniqn-mobile/e2e/pages/auth/signup.page.ts
+++ b/uniqn-mobile/e2e/pages/auth/signup.page.ts
@@ -23,6 +23,10 @@ export class SignupPage extends BasePage {
     return this.page.getByRole('checkbox', { name: /개인정보처리방침 동의/ }).first();
   }
 
+  get thirdPartyCheckbox(): Locator {
+    return this.page.getByRole('checkbox', { name: /개인정보 제3자 제공 동의/ }).first();
+  }
+
   get marketingCheckbox(): Locator {
     return this.page.getByRole('checkbox', { name: /마케팅 정보 수신 동의/ }).first();
   }
@@ -42,6 +46,7 @@ export class SignupPage extends BasePage {
   async acceptRequiredTermsOnly(): Promise<void> {
     await this.termsCheckbox.click();
     await this.privacyCheckbox.click();
+    await this.thirdPartyCheckbox.click();
   }
 
   async clickNext(): Promise<void> {

--- a/uniqn-mobile/e2e/tests/p1-important/public-pages.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/public-pages.spec.ts
@@ -10,12 +10,13 @@ const PUBLIC_SEED_JOB_TITLE = '긴급 딜러 모집';
 const staffState = path.join(__dirname, '../../fixtures/storage-states/staff.json');
 
 test.describe('퍼블릭 페이지', () => {
-  test('공개 공고 목록 페이지 접근 가능', async ({ page }) => {
+  test('비로그인 /jobs 진입 → 로그인 페이지로 리다이렉트', async ({ page }) => {
+    // a465d82c7 (2026-03-29) 이후 (public)/jobs 는 LegacyPublicJobsEntryRoute 로
+    // 비로그인 사용자를 무조건 /(auth)/login 으로 redirect 한다.
+    // 공개 목록은 더 이상 제공하지 않으며, 공개 상세(/jobs/:id) 만 비로그인 접근 가능.
     await page.goto('/jobs', { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByRole('heading', { name: '구인공고' })).toBeVisible({
-      timeout: 10_000,
-    });
+    await expect(page).toHaveURL(/\/login(?:[/?#]|$)/, { timeout: 10_000 });
   });
 
   test('공개 공고 상세 페이지에서 비로그인 사용자도 공고를 볼 수 있다', async ({ page }) => {


### PR DESCRIPTION
## Summary

PR #99 artifact 회수 후 분석한 108 unique fail 중 본인인증 게이트(103건) 외 **잔존 2건** spec drift 동기화.

이 PR + PR #100 머지 시 119 결정론적 실패 → 0 또는 극소수 예상.

## 1) auth-signup Step1 '필수만 동의 (마케팅 제외)'

**원인**: PR #95 (2026-05-13) 가 signup Step1 에 4번째 [필수] 체크박스 '개인정보 제3자 제공 동의 (구인자에게 제공)' 를 추가했으나 `acceptRequiredTermsOnly()` 는 terms + privacy 2개만 클릭 → '다음' 버튼 disabled → fail.

**해결**: `thirdPartyCheckbox` getter 추가 + `acceptRequiredTermsOnly()` 에서 클릭.

증거 (error-context.md from run 25897707507):
```
- checkbox '필수 이용약관 동의' [ref=e52]
- checkbox '필수 개인정보처리방침 동의' [active] [ref=e60]   ← 체크됨
- checkbox '필수 개인정보 제3자 제공 동의 (구인자에게 제공)' [ref=e68]   ← 미체크
- checkbox '선택 마케팅 정보 수신 동의' [ref=e76]
- button '다음' [disabled]   ← fail 지점
```

`acceptAllTerms` (selectAllCheckbox 단일 클릭) 는 영향 없음.

## 2) public-pages '공개 공고 목록 페이지 접근 가능'

**원인**: `a465d82c7` (2026-03-29) 이후 `(public)/jobs/index.tsx` 는 `LegacyPublicJobsEntryRoute` — 비로그인 사용자를 `/(auth)/login` 으로 무조건 redirect. 공개 목록은 더 이상 제공 안 함 (제품 결정). 그러나 spec 은 여전히 `구인공고` heading 을 기대 → **약 14개월간 drift**.

**해결**: 테스트 의도를 현재 동작 (login redirect) 검증으로 변경.
- 공개 상세 `/jobs/:id` 는 여전히 비로그인 접근 가능 — 그 spec 은 유지

## Dependency

본 PR 자체는 master 에서 머지 가능. 검증은 PR #99 (artifact 회수 인프라) 머지 후 새 run 결과로 확인 — 또는 PR #100 (identity_verified seed) 함께 머지 시 통계 확인.

## Test plan

- [ ] PR #100 머지
- [ ] 본 PR 머지
- [ ] 다음 e2e run 결과:
  - signup Step1 '필수만 동의 (마케팅 제외)' PASS
  - public-pages '비로그인 /jobs → login redirect' PASS
  - 119 결정론적 실패 → 0 (또는 새로 발견되는 별개 이슈만 잔존)

🤖 Generated with [Claude Code](https://claude.com/claude-code)