### PR TITLE
chore(e2e): dotenv 광고 음소거 + BasePage 안전망 텍스트 동기화

### DIFF
--- a/uniqn-mobile/e2e/global-setup.ts
+++ b/uniqn-mobile/e2e/global-setup.ts
@@ -14,7 +14,7 @@ import { config as loadDotenv } from 'dotenv';
 
 // .env.test 로드 (E2E_CONFIG가 EXPO_PUBLIC_SUPABASE_URL 등을 requireEnv로 읽기 때문에
 // config import 전에 반드시 선행되어야 함)
-loadDotenv({ path: path.join(__dirname, '.env.test') });
+loadDotenv({ path: path.join(__dirname, '.env.test'), quiet: true });
 
 // eslint-disable-next-line import/first
 import { TEST_ACCOUNTS, type TestAccount } from './fixtures/test-accounts';

--- a/uniqn-mobile/e2e/pages/base.page.ts
+++ b/uniqn-mobile/e2e/pages/base.page.ts
@@ -16,15 +16,11 @@ export class BasePage {
     await this.page.waitForLoadState('domcontentloaded');
 
     try {
-      const loadingTexts = ['앱 로딩 중...', '앱을 불러오는 중...'];
+      const loadingText = this.page.getByText('앱을 불러오는 중...');
+      const isVisible = await loadingText.isVisible().catch(() => false);
 
-      for (const text of loadingTexts) {
-        const loadingText = this.page.getByText(text);
-        const isVisible = await loadingText.isVisible().catch(() => false);
-
-        if (isVisible) {
-          await loadingText.waitFor({ state: 'hidden', timeout: 30_000 });
-        }
+      if (isVisible) {
+        await loadingText.waitFor({ state: 'hidden', timeout: 30_000 });
       }
     } catch {
       // 이미 사라졌거나 에러 화면으로 전환됨
@@ -40,7 +36,7 @@ export class BasePage {
    */
   async dismissNotificationOnboarding(): Promise<void> {
     try {
-      const skipButton = this.page.getByText('나중에 하기');
+      const skipButton = this.page.getByText('지금 닫기');
       const isVisible = await skipButton.isVisible().catch(() => false);
       if (isVisible) {
         await skipButton.click({ timeout: 3_000 });

--- a/uniqn-mobile/e2e/playwright.config.ts
+++ b/uniqn-mobile/e2e/playwright.config.ts
@@ -2,7 +2,7 @@ import { config as loadDotenv } from 'dotenv';
 import path from 'path';
 
 // E2E_CONFIG의 requireEnv가 모듈 로드 시점에 실행되므로 반드시 먼저 로드
-loadDotenv({ path: path.join(__dirname, '.env.test') });
+loadDotenv({ path: path.join(__dirname, '.env.test'), quiet: true });
 
 // eslint-disable-next-line import/first
 import { defineConfig, devices } from '@playwright/test';

--- a/uniqn-mobile/scripts/run-e2e.js
+++ b/uniqn-mobile/scripts/run-e2e.js
@@ -3,7 +3,7 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 // .env.test를 playwright.config.ts보다 먼저 로드 (import hoisting으로 config.ts가 먼저 평가되기 때문)
-require('dotenv').config({ path: path.join(__dirname, '../e2e/.env.test') });
+require('dotenv').config({ path: path.join(__dirname, '../e2e/.env.test'), quiet: true });
 
 const extraArgs = process.argv.slice(2);
 const appRoot = process.cwd();


### PR DESCRIPTION
## Summary

PR #99 (artifact 회수) 머지 후 list reporter 가 작동하므로 dotenv 17 광고가 progress 라인을 망치는 가독성 문제 해소 + BasePage 안전망의 dead 텍스트 정리.

## 변경

### 1. dotenv 17 광고 음소거 (3 파일)
`dotenv@^17.4.2` 가 기본으로 출력하는 `tip: ⌁ auth for agents [www.vestauth.com]` 등의 광고 라인이 Playwright dot/list reporter 출력에 섞여 실패 spec 추적을 방해.

```diff
- loadDotenv({ path: ... });
+ loadDotenv({ path: ..., quiet: true });
```

- `scripts/run-e2e.js`
- `e2e/playwright.config.ts`
- `e2e/global-setup.ts`

### 2. BasePage 안전망 텍스트 동기화

- `'앱 로딩 중...'` (앱 어디에도 존재하지 않는 dead text) → 제거
  - 앱 실제: `app/_layout.tsx:204` 의 `'앱을 불러오는 중...'` 만 사용
- `'나중에 하기'` → `'지금 닫기'`
  - 앱 실제: `NotificationPermissionScreen.tsx:85,94` 의 `secondaryLabel: '지금 닫기'`

## 영향

- 동작 변경 없음. storage state 가 onboarding flag 를 셋하므로 모달 자체가 안 뜨지만 edge case 대비 안전망의 텍스트만 실제 앱과 맞춤
- 광고 음소거는 CI 로그 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)