### PR TITLE
fix(auth): Apple 로그인 reverify trap 해소 — handle_new_user 가 social_provider 자동 채움

### DIFF
--- a/uniqn-mobile/src/shared/navigation/__tests__/authRedirect.test.ts
+++ b/uniqn-mobile/src/shared/navigation/__tests__/authRedirect.test.ts
@@ -83,6 +83,20 @@ describe('getAuthenticatedEntryRoute', () => {
       })
     ).toBe(AUTH_ENTRY_ROUTES.socialSignup);
   });
+
+  it('routes email/password signup row with phoneVerified=false to plain signup (no socialProvider)', () => {
+    // 2026-05-16 사건 회귀 방지: handle_new_user trigger drift 또는 edge function
+    // 실패로 social_provider 가 NULL 인 상태에서 사용자가 재로그인하면 reverify trap
+    // 에 빠지던 버그. phone 인증조차 안 한 사용자는 reverify 가 아닌 가입 흐름으로
+    // 보내야 한다.
+    expect(
+      getAuthenticatedEntryRoute({
+        socialProvider: null,
+        phoneVerified: false,
+        identityVerified: false,
+      })
+    ).toBe(AUTH_ENTRY_ROUTES.signup);
+  });
 });
 
 describe('normalizePostAuthRedirect', () => {

--- a/uniqn-mobile/src/shared/navigation/authRedirect.ts
+++ b/uniqn-mobile/src/shared/navigation/authRedirect.ts
@@ -93,12 +93,24 @@ export function getLoginRoute(redirect?: string | null): string {
 export function getAuthenticatedEntryRoute(params: AuthenticatedEntryRouteParams): AuthEntryRoute {
   const { socialProvider, phoneVerified, profileCompleted, identityVerified } = params;
 
+  // 신규 가입 안전망 — phone 인증조차 안 한 사용자는 reverify 가 아니라 가입 흐름.
+  // 2026-05-16 사건: handle_new_user trigger 가 social_provider 누락 + edge function
+  // 실패 시 social_provider=null + phone_verified=false + identity_verified=false 인
+  // 신규 row 가 reverify trap 으로 빠지던 회귀. socialProvider truthy 의존만으로는
+  // 옛 사용자(phoneVerified=true, identityVerified=false)와 신규 미완성 사용자를
+  // 구분하지 못함.
+  if (phoneVerified !== true && identityVerified === false) {
+    return socialProvider ? AUTH_ENTRY_ROUTES.socialSignup : AUTH_ENTRY_ROUTES.signup;
+  }
+
   // 소셜 신규 사용자 — 본인인증 단계로 (signup?mode=social)
   if (socialProvider && phoneVerified !== true) {
     return AUTH_ENTRY_ROUTES.socialSignup;
   }
 
   // 본인인증 명시적 false — KG이니시스 재인증 강제 (signup?mode=reverify)
+  // phoneVerified=true 인 옛 사용자(Firebase 시절 phone 인증만 완료 + PortOne 미완료)
+  // 만 이 분기에 도달. 신규 미완성 사용자는 위 안전망에서 가입 흐름으로 분기.
   if (identityVerified === false) {
     return AUTH_ENTRY_ROUTES.identityReverify;
   }

--- a/uniqn-mobile/supabase/migrations/20260516031747_fix_handle_new_user_social_provider.sql
+++ b/uniqn-mobile/supabase/migrations/20260516031747_fix_handle_new_user_social_provider.sql
@@ -1,0 +1,32 @@
+-- handle_new_user trigger 수정 — social_provider 컬럼을 raw_app_meta_data 에서 추출
+-- 기존 trigger 는 social_provider 를 채우지 않아 모든 OAuth 가입자가 NULL 로 들어가
+-- authRedirect 의 socialSignup 분기를 통과 못하고 identity_verified=false reverify 게이트에 trap.
+-- root cause: handle_new_user 본문이 (id, email, name, role) 4개만 INSERT.
+-- fix: raw_app_meta_data->>'provider' 에서 OAuth provider 추출 → apple/google/kakao 화이트리스트.
+-- email/password 가입은 raw_app_meta_data.provider='email' 이므로 NULL 유지 (CASE ELSE).
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_provider text;
+BEGIN
+  v_provider := NEW.raw_app_meta_data ->> 'provider';
+
+  INSERT INTO public.users (id, email, name, role, social_provider)
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.email, ''),
+    COALESCE(NEW.raw_user_meta_data ->> 'name', ''),
+    COALESCE((NEW.raw_app_meta_data ->> 'role')::user_role, 'staff'),
+    CASE
+      WHEN v_provider IN ('apple', 'google', 'kakao') THEN v_provider
+      ELSE NULL
+    END
+  );
+  RETURN NEW;
+END;
+$function$;

--- a/uniqn-mobile/supabase/migrations/20260516032203_add_naver_to_handle_new_user.sql
+++ b/uniqn-mobile/supabase/migrations/20260516032203_add_naver_to_handle_new_user.sql
@@ -1,0 +1,30 @@
+-- handle_new_user 화이트리스트에 naver 추가 — DB CHECK 와 일치시킴
+-- 직전 migration(20260516031747)에서 apple/google/kakao 만 처리. CHECK 제약은
+-- ['apple','google','kakao','naver'] 4종 허용이므로 naver 누락은 향후 trap 재발 위험.
+-- 현재 naver 로그인 미구현이지만 일관성 확보 차원.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_provider text;
+BEGIN
+  v_provider := NEW.raw_app_meta_data ->> 'provider';
+
+  INSERT INTO public.users (id, email, name, role, social_provider)
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.email, ''),
+    COALESCE(NEW.raw_user_meta_data ->> 'name', ''),
+    COALESCE((NEW.raw_app_meta_data ->> 'role')::user_role, 'staff'),
+    CASE
+      WHEN v_provider IN ('apple', 'google', 'kakao', 'naver') THEN v_provider
+      ELSE NULL
+    END
+  );
+  RETURN NEW;
+END;
+$function$;


### PR DESCRIPTION
## Summary

PR #95 (2026-05-13) 의 `identity_verified=false` reverify 강제 게이트 + `handle_new_user` trigger 의 `social_provider` 컬럼 누락 결합으로 **2026-05-13 이후 신규 OAuth 가입자가 약관 동의 화면 없이 본인인증 1/1 단계에 갇히던 P0 회귀** 해소.

## 사용자 증상

- Apple 로그인 후 약관 동의 단계 없이 바로 "본인인증 1/1 단계" 화면
- 뒤로가기 버튼 무력
- 앱 강제 종료 후 재실행해도 동일 화면 반복

## Root cause

1. `public.handle_new_user()` trigger 본문이 `(id, email, name, role)` 4개만 INSERT → `social_provider=NULL`
2. `socialLoginService.signInWithApple` 은 `existingProfile` 이 truthy (trigger 가 미리 row 생성) 라서 `createOrMerge` 호출 분기 skip → social_provider 영영 NULL
3. `authRedirect.getAuthenticatedEntryRoute` 분기 `socialProvider && phoneVerified !== true` 가 truthy 의존 → NULL skip → `identityVerified === false` 분기에서 **reverify trap**

증거:
- `public.users` 6 row 전체 `social_provider=NULL`
- `auth.identities` provider='apple' 2명 모두 `(null, false, false)` 패턴
- `pu_created_at < auth_created_at` 약 20-70ms → trigger 가 먼저 row 생성 확정
- 직전 PR `8e91a5a9f` 가 QA 계정만 `identity_verified=true` 시드한 것이 같은 증상의 우회 — 일반 사용자 누락

## 변경 내용

### 1. `handle_new_user` trigger 수정 (2 migrations)

- `20260516031747_fix_handle_new_user_social_provider.sql`
  - `raw_app_meta_data->>'provider'` 추출해 `apple/google/kakao` 화이트리스트로 `social_provider` 채움
- `20260516032203_add_naver_to_handle_new_user.sql`
  - `naver` 추가 (DB `users_social_provider_check` 제약과 일치)
- email/password 가입자는 `raw_app_meta_data.provider='email'` 이라 화이트리스트 skip → NULL 유지 (의도)

### 2. `authRedirect.ts` 안전망 분기

신규 가입자가 reverify trap 으로 빠지지 않도록 분기 우선순위 보강:

\`\`\`ts
// 신규 가입 안전망 — phone 인증조차 안 한 사용자는 reverify 가 아니라 가입 흐름
if (phoneVerified !== true && identityVerified === false) {
  return socialProvider ? AUTH_ENTRY_ROUTES.socialSignup : AUTH_ENTRY_ROUTES.signup;
}
\`\`\`

의미:
- **reverify** = 과거에 phone 인증은 했는데 PortOne 본인인증만 안 한 옛 사용자만
- **socialSignup/signup** = 처음부터 가입 흐름

trigger drift / edge function 부분실패 / 미래 비슷한 사건의 안전망.

### 3. Regression test

`authRedirect.test.ts` 에 회귀 방지 케이스 1건 추가 (16/16 pass).

## Prod 적용 상태

- 원격 DB 에 두 migration 모두 적용 완료 (`schema_migrations` 등록)
- 갇혔던 row 2건 (`6dbe4e5d-...`, `e3a5713d-...`) `social_provider='apple'` 수동 UPDATE 로 즉시 해제 — 두 사용자는 앱 재로그인 시 정상 socialSignup 흐름 진입
- 향후 신규 OAuth 가입자는 trigger 가 자동 처리

## Test plan

- [x] `npx jest src/shared/navigation/__tests__/authRedirect.test.ts` 16/16 pass
- [x] DB trigger 본문 새 코드 반영 확인 (`pg_get_functiondef`)
- [x] 갇혔던 2 row 분기 시뮬레이션 `socialSignup` 으로 정상 분기 확인
- [ ] 사용자 본인 폰: 앱 강제 종료 → Apple 로그인 → 약관 → 본인인증 2단계 정상 진입 확인
- [ ] 신규 Apple 가입 (다른 계정) E2E: trigger 가 social_provider='apple' 자동 세팅 확인

## 잔존 이슈 (별도 작업)

- email/password signup 의 edge function 부분실패 시 dangling row 발생 가능성 — 이번 안전망으로 reverify trap 만 차단, dangling 자체 청소는 후속
- `socialLoginService` 의 `existingProfile.socialProvider IS NULL` 케이스에서 createOrMerge 강제 호출 (옵션 C) — 클라이언트 측 추가 방어선

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>