### PR TITLE
fix(e2e): workspace_id seed 헬퍼 추출 — 8 spec 동기화 (Phase 1)

### DIFF
--- a/uniqn-mobile/e2e/helpers/workspace-seed.ts
+++ b/uniqn-mobile/e2e/helpers/workspace-seed.ts
@@ -1,0 +1,50 @@
+/**
+ * E2E 테스트용 workspace 시드 헬퍼.
+ *
+ * 2026-05-14 migration 으로 `job_postings.workspace_id NOT NULL` 전환되어
+ * job_postings 시드 전에 workspace 가 사전 보장되어야 한다.
+ *
+ * 본 헬퍼는 (owner_id, name) 매칭으로 멱등 — 동일 owner 의 'E2E 테스트 워크스페이스'
+ * 가 이미 있으면 재사용. job_postings 시드 시 반환된 workspace_id 를 함께 INSERT.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export const E2E_TEST_WORKSPACE_NAME = 'E2E 테스트 워크스페이스';
+
+/**
+ * 주어진 owner 의 E2E 워크스페이스를 보장하고 ID 반환 (멱등).
+ *
+ * @throws workspace SELECT/INSERT 실패 시 (admin client 권한/네트워크 문제 등)
+ */
+export async function ensureE2EWorkspace(
+  adminClient: SupabaseClient,
+  ownerId: string
+): Promise<string> {
+  const { data: existing, error: selectError } = await adminClient
+    .from('workspaces')
+    .select('id')
+    .eq('owner_id', ownerId)
+    .eq('name', E2E_TEST_WORKSPACE_NAME)
+    .maybeSingle();
+
+  if (selectError) {
+    throw new Error(`workspace SELECT 실패: ${selectError.message}`);
+  }
+  if (existing?.id) {
+    return existing.id as string;
+  }
+
+  const { data, error } = await adminClient
+    .from('workspaces')
+    .insert({
+      name: E2E_TEST_WORKSPACE_NAME,
+      owner_id: ownerId,
+    })
+    .select('id')
+    .single();
+
+  if (error || !data?.id) {
+    throw new Error(`workspace 시드 실패: ${error?.message ?? '응답 데이터 없음'}`);
+  }
+  return data.id as string;
+}

--- a/uniqn-mobile/e2e/tests/p0-critical/cancellation-lifecycle.spec.ts
+++ b/uniqn-mobile/e2e/tests/p0-critical/cancellation-lifecycle.spec.ts
@@ -13,6 +13,7 @@ import { test, expect } from '@playwright/test';
 import path from 'path';
 import { getAdminClient, SUPABASE_QA_ACCOUNTS } from '../../helpers/supabase-admin';
 import { waitForAppReady } from '../../helpers/wait-helpers';
+import { ensureE2EWorkspace } from '../../helpers/workspace-seed';
 
 // ---------------------------------------------------------------------------
 // storageState 경로 (상대 경로)
@@ -43,10 +44,14 @@ async function seedConfirmedApplication(
   const jobId = uniqueId('test-cancel-job');
   const applicationId = uniqueId('test-cancel-app');
 
+  // 0. workspace 보장 — 2026-05-14 migration 으로 job_postings.workspace_id NOT NULL
+  const workspaceId = await ensureE2EWorkspace(adminClient, SUPABASE_QA_ACCOUNTS.employer.id);
+
   // 1. job_posting 생성 (정원 1, filled_positions 1 — confirmed 상태 반영)
   const { error: jobError } = await adminClient.from('job_postings').insert({
     id: jobId,
     schema_version: 3,
+    workspace_id: workspaceId,
     title: '취소 라이프사이클 테스트 공고',
     description: 'E2E 취소 테스트용 공고',
     status: 'active',

--- a/uniqn-mobile/e2e/tests/p1-important/collaborator-self-leave.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/collaborator-self-leave.spec.ts
@@ -15,6 +15,7 @@
 
 import { expect, test, type Page } from '@playwright/test';
 import { getAdminClient } from '../../helpers/supabase-admin';
+import { ensureE2EWorkspace } from '../../helpers/workspace-seed';
 import { TEST_ACCOUNTS } from '../../fixtures/test-accounts';
 
 async function waitForReady(page: Page): Promise<void> {
@@ -31,11 +32,13 @@ test.describe('Collaborator Self Leave', () => {
     if (!admin) throw new Error('E2E_SUPABASE_SERVICE_ROLE_KEY 필요');
 
     const workDate = new Date(Date.now() + 7 * 86_400_000).toISOString().slice(0, 10);
+    const workspaceId = await ensureE2EWorkspace(admin, TEST_ACCOUNTS.employer.uid);
     const { data: jp, error: jpErr } = await admin
       .from('job_postings')
       .insert({
         title: 'e2e self leave posting',
         status: 'active',
+        workspace_id: workspaceId,
         owner_id: TEST_ACCOUNTS.employer.uid,
         owner_name: TEST_ACCOUNTS.employer.displayName,
         posting_type: 'regular',

--- a/uniqn-mobile/e2e/tests/p1-important/collaborator-shared-postings.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/collaborator-shared-postings.spec.ts
@@ -14,6 +14,7 @@
 
 import { expect, test, type Page } from '@playwright/test';
 import { getAdminClient } from '../../helpers/supabase-admin';
+import { ensureE2EWorkspace } from '../../helpers/workspace-seed';
 import { TEST_ACCOUNTS } from '../../fixtures/test-accounts';
 
 async function waitForReady(page: Page): Promise<void> {
@@ -30,11 +31,13 @@ test.describe('Collaborator Shared Postings', () => {
     if (!admin) throw new Error('E2E_SUPABASE_SERVICE_ROLE_KEY 필요');
 
     const workDate = new Date(Date.now() + 7 * 86_400_000).toISOString().slice(0, 10);
+    const workspaceId = await ensureE2EWorkspace(admin, TEST_ACCOUNTS.employer.uid);
     const { data: jp, error: jpErr } = await admin
       .from('job_postings')
       .insert({
         title: 'e2e shared posting',
         status: 'active',
+        workspace_id: workspaceId,
         owner_id: TEST_ACCOUNTS.employer.uid,
         owner_name: TEST_ACCOUNTS.employer.displayName,
         posting_type: 'regular',

--- a/uniqn-mobile/e2e/tests/p1-important/employer-applicants.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/employer-applicants.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Locator, type Page } from '@playwright/test';
 import { getAdminClient, SUPABASE_QA_ACCOUNTS } from '../../helpers/supabase-admin';
+import { ensureE2EWorkspace } from '../../helpers/workspace-seed';
 
 async function waitForReady(page: Page): Promise<void> {
   await page.waitForLoadState('domcontentloaded');
@@ -39,12 +40,14 @@ async function seedJobPosting(title: string): Promise<string> {
     throw new Error('E2E_SUPABASE_SERVICE_ROLE_KEY 미설정 — 시딩에 service_role이 필요합니다.');
 
   const workDate = new Date(Date.now() + 10 * 86_400_000).toISOString().slice(0, 10);
+  const workspaceId = await ensureE2EWorkspace(admin, SUPABASE_QA_ACCOUNTS.employer.id);
 
   const { data, error } = await admin
     .from('job_postings')
     .insert({
       title,
       status: 'active',
+      workspace_id: workspaceId,
       owner_id: SUPABASE_QA_ACCOUNTS.employer.id,
       owner_name: SUPABASE_QA_ACCOUNTS.employer.name,
       posting_type: 'regular',

--- a/uniqn-mobile/e2e/tests/p1-important/employer-collaborator-add.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/employer-collaborator-add.spec.ts
@@ -15,6 +15,7 @@
 
 import { expect, test, type Page } from '@playwright/test';
 import { getAdminClient } from '../../helpers/supabase-admin';
+import { ensureE2EWorkspace } from '../../helpers/workspace-seed';
 import { TEST_ACCOUNTS } from '../../fixtures/test-accounts';
 
 async function waitForReady(page: Page): Promise<void> {
@@ -31,11 +32,13 @@ test.describe('Employer Collaborator Add', () => {
     if (!admin) throw new Error('E2E_SUPABASE_SERVICE_ROLE_KEY 필요');
 
     const workDate = new Date(Date.now() + 7 * 86_400_000).toISOString().slice(0, 10);
+    const workspaceId = await ensureE2EWorkspace(admin, TEST_ACCOUNTS.employer.uid);
     const { data, error } = await admin
       .from('job_postings')
       .insert({
         title: 'e2e collab add posting',
         status: 'active',
+        workspace_id: workspaceId,
         owner_id: TEST_ACCOUNTS.employer.uid,
         owner_name: TEST_ACCOUNTS.employer.displayName,
         posting_type: 'regular',

--- a/uniqn-mobile/e2e/tests/p1-important/employer-posting-crud.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/employer-posting-crud.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Locator, type Page } from '@playwright/test';
 import { getAdminClient } from '../../helpers/supabase-admin';
+import { ensureE2EWorkspace } from '../../helpers/workspace-seed';
 import { TEST_ACCOUNTS } from '../../fixtures/test-accounts';
 
 async function waitForReady(page: Page): Promise<void> {
@@ -20,12 +21,14 @@ async function seedJobPosting(
   if (!admin) throw new Error('E2E_SUPABASE_SERVICE_ROLE_KEY 필요 — job_postings 시드 불가');
 
   const workDate = new Date(Date.now() + 10 * 86_400_000).toISOString().slice(0, 10);
+  const workspaceId = await ensureE2EWorkspace(admin, TEST_ACCOUNTS.employer.uid);
 
   const { data, error } = await admin
     .from('job_postings')
     .insert({
       title,
       status,
+      workspace_id: workspaceId,
       owner_id: TEST_ACCOUNTS.employer.uid,
       owner_name: TEST_ACCOUNTS.employer.displayName,
       work_date: workDate,

--- a/uniqn-mobile/e2e/tests/p1-important/employer-settlement.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/employer-settlement.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Locator, type Page } from '@playwright/test';
 import { getAdminClient } from '../../helpers/supabase-admin';
+import { ensureE2EWorkspace } from '../../helpers/workspace-seed';
 import { TEST_ACCOUNTS } from '../../fixtures/test-accounts';
 
 async function waitForReady(page: Page): Promise<void> {
@@ -46,12 +47,14 @@ async function seedJobPosting(title: string): Promise<string> {
   if (!admin) throw new Error('E2E_SUPABASE_SERVICE_ROLE_KEY 필요 — job_postings 시드 불가');
 
   const workDate = new Date(Date.now() + 10 * 86_400_000).toISOString().slice(0, 10);
+  const workspaceId = await ensureE2EWorkspace(admin, TEST_ACCOUNTS.employer.uid);
 
   const { data, error } = await admin
     .from('job_postings')
     .insert({
       title,
       status: 'active',
+      workspace_id: workspaceId,
       owner_id: TEST_ACCOUNTS.employer.uid,
       owner_name: TEST_ACCOUNTS.employer.displayName,
       work_date: workDate,

--- a/uniqn-mobile/e2e/tests/p1-important/job-detail-apply.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/job-detail-apply.spec.ts
@@ -5,6 +5,7 @@ import { expect, test } from '@playwright/test';
 import path from 'path';
 import { JobDetailPage } from '../../pages/app/job-detail.page';
 import { getAdminClient, SUPABASE_QA_ACCOUNTS } from '../../helpers/supabase-admin';
+import { ensureE2EWorkspace } from '../../helpers/workspace-seed';
 
 const staffState = path.join(__dirname, '../../fixtures/storage-states/staff.json');
 const employerState = path.join(__dirname, '../../fixtures/storage-states/employer.json');
@@ -23,12 +24,14 @@ test.describe('공고 상세와 지원 흐름', () => {
     }
 
     const workDate = new Date(Date.now() + 10 * 86_400_000).toISOString().slice(0, 10);
+    const workspaceId = await ensureE2EWorkspace(admin, SUPABASE_QA_ACCOUNTS.employer.id);
 
     const { data, error } = await admin
       .from('job_postings')
       .insert({
         title: TEST_JOB_TITLE,
         status: 'active',
+        workspace_id: workspaceId,
         owner_id: SUPABASE_QA_ACCOUNTS.employer.id,
         owner_name: SUPABASE_QA_ACCOUNTS.employer.name,
         posting_type: 'regular',


### PR DESCRIPTION
## Summary

- PR #103 이 admin-report-resolution 1 spec 만 fix 한 동일 패턴이 8 spec 잔존 — 2026-05-14 `job_postings.workspace_id NOT NULL` migration 따라잡지 못함 (master e2e 23 fail)
- 공통 헬퍼 `ensureE2EWorkspace(adminClient, ownerId)` 추출, 8 spec INSERT 에 `workspace_id` 추가
- **e2e/** 만 수정** — production code 변경 0건

## Context

`master` run [25951946403](https://github.com/snosnosno/uniqn/actions/runs/25951946403) 결과 59 fail / 147 pass / 20 did not run.

5 그룹 분류 (전체 plan: `docs/superpowers/plans/2026-05-16-e2e-failure-resolution-plan.md`):
- **Group A — workspace_id NOT NULL seed 실패**: **23 / 59 (39%)** ← 본 PR 대상
- Group B toBeVisible (22), Group C locator timeout (12), D/E (2)

## Changes

| 파일 | 변경 |
|------|------|
| `e2e/helpers/workspace-seed.ts` | 신규 — `ensureE2EWorkspace` (`owner_id` + `name='E2E 테스트 워크스페이스'` 매칭 멱등) |
| `e2e/tests/p0-critical/cancellation-lifecycle.spec.ts` | seed 헬퍼 호출 + `workspace_id` 추가 (6 tests) |
| `e2e/tests/p1-important/job-detail-apply.spec.ts` | 동상 (4 tests) |
| `e2e/tests/p1-important/employer-applicants.spec.ts` | 동상 (3 tests) |
| `e2e/tests/p1-important/employer-posting-crud.spec.ts` | 동상 (3 tests) |
| `e2e/tests/p1-important/employer-settlement.spec.ts` | 동상 (4 tests) |
| `e2e/tests/p1-important/employer-collaborator-add.spec.ts` | 동상 (1 test) |
| `e2e/tests/p1-important/collaborator-self-leave.spec.ts` | 동상 (1 test) |
| `e2e/tests/p1-important/collaborator-shared-postings.spec.ts` | 동상 (1 test) |

## Expected Effect

- master e2e fail **59 → 36 이하**:
  - Group A 23 해소
  - Group B 일부 downstream (rbac-access:132 등 seed 후 진행 가능한 케이스) 추가 감소
- runtime 변화 미미 (헬퍼 1 SELECT + 최초 1 INSERT)

## Test plan

- [x] `npx tsc --noEmit` — 본 PR 변경에 신규 TS 에러 0
- [ ] master 머지 후 e2e workflow 트리거 → 59 → 36 이하 확인
- [ ] cancellation-lifecycle 6 tests pass 확인
- [ ] employer-* 11 tests pass 확인
- [ ] collaborator-* 3 tests pass 확인

## Scope discipline

- production code (`src/**`, `app/**`, `supabase/migrations/**`) 변경 0건
- 전체 plan Phase 1/4 — 후속 Phase 2/3/4 는 별도 PR 로 분리

🤖 Generated with [Claude Code](https://claude.com/claude-code)