### PR TITLE
fix(e2e): home/admin spec selector 동기화 + outdated home 시나리오 skip (Phase 3A)

### DIFF
--- a/uniqn-mobile/e2e/tests/p0-critical/e2e-user-journeys.spec.ts
+++ b/uniqn-mobile/e2e/tests/p0-critical/e2e-user-journeys.spec.ts
@@ -183,7 +183,9 @@ test.describe('E2E 유저 저니', () => {
     }
   });
 
-  test('계정 생명주기: 로그인 → 프로필 접근 → 설정 접근', async ({ browser }) => {
+  // SKIP: staff entry 가 `(app)/home` (standalone) 으로 변경되어 "프로필 탭" 접근 경로 무효.
+  // settings heading 매핑도 master UI 와 불일치. spec rewrite 필요 (follow-up issue).
+  test.skip('계정 생명주기: 로그인 → 프로필 접근 → 설정 접근', async ({ browser }) => {
     const context = await browser.newContext({ storageState: staffState });
     const page = await context.newPage();
 

--- a/uniqn-mobile/e2e/tests/p1-important/home-employer-toggle.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/home-employer-toggle.spec.ts
@@ -42,7 +42,7 @@ test.describe('Employer 뷰 전환 토글', () => {
     await expect(page.getByText('스태프로').first()).toBeVisible({ timeout: 5_000 });
 
     // Employer 대시보드 위젯 확인
-    await expect(page.getByText('이번 주 스태프 현황').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('이번 주 스태프').first()).toBeVisible({ timeout: 10_000 });
   });
 
   test('"스태프로" 탭하면 Staff 대시보드로 전환된다', async ({ page }) => {
@@ -60,7 +60,7 @@ test.describe('Employer 뷰 전환 토글', () => {
     // Staff 대시보드 위젯 표시 확인
     await expect(page.getByText('다음 근무').first()).toBeVisible({ timeout: 10_000 });
     // Employer 위젯은 사라짐
-    await expect(page.getByText('이번 주 스태프 현황'))
+    await expect(page.getByText('이번 주 스태프'))
       .not.toBeVisible({ timeout: 3_000 })
       .catch(() => {});
   });
@@ -78,7 +78,7 @@ test.describe('Employer 뷰 전환 토글', () => {
     // Employer 뷰로 복귀
     await page.getByText('내 업무').first().click();
     await page.waitForTimeout(300);
-    await expect(page.getByText('이번 주 스태프 현황').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('이번 주 스태프').first()).toBeVisible({ timeout: 10_000 });
   });
 
   test('홈 재진입 시 뷰가 기본값(employer)으로 리셋된다', async ({ page }) => {
@@ -106,6 +106,6 @@ test.describe('Employer 뷰 전환 토글', () => {
     }
 
     // Employer 대시보드가 기본값으로 표시
-    await expect(page.getByText('이번 주 스태프 현황').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('이번 주 스태프').first()).toBeVisible({ timeout: 10_000 });
   });
 });

--- a/uniqn-mobile/e2e/tests/p1-important/home-logo-no-stack-accumulation.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/home-logo-no-stack-accumulation.spec.ts
@@ -33,7 +33,11 @@ async function dismissOnboarding(page: Page): Promise<void> {
 
 test.use({ storageState: staffState });
 
-test.describe('홈 로고 탭 스택 누적 방지', () => {
+// SKIP: featureFlags.home_dashboard_enabled=true 도입 후 staff entry 가 tab 화면 아닌
+// `(app)/home` (standalone). 시나리오의 "탭에서 로고 클릭 → 이전 탭 복귀" 전제가 무효.
+// home 화면에서 로고 click 은 자기 자신 navigation 으로 click handler 가 stable check
+// 미통과 → 60s timeout. spec rewrite 필요 (follow-up issue).
+test.describe.skip('홈 로고 탭 스택 누적 방지', () => {
   test('로고를 10번 연속 탭해도 뒤로가기 1번으로 이전 탭 복귀', async ({ page }) => {
     await page.goto('/');
     await waitForAppInit(page);

--- a/uniqn-mobile/e2e/tests/p1-important/home-navigation-staff.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/home-navigation-staff.spec.ts
@@ -42,7 +42,9 @@ test.describe('홈 네비게이션 — Staff', () => {
     await expect(page.getByText('내 지원 현황').first()).toBeVisible({ timeout: 10_000 });
   });
 
-  test('탭에서 UNIQN 로고 탭 → 홈으로 이동', async ({ page }) => {
+  // SKIP: staff entry 가 `(app)/home` 이라 tab 화면 미진입 — logo click 자기참조 navigation
+  // 으로 click handler stable check 미통과. spec rewrite 필요 (follow-up issue).
+  test.skip('탭에서 UNIQN 로고 탭 → 홈으로 이동', async ({ page }) => {
     await page.goto('/');
     await waitForAppInit(page);
     await dismissOnboarding(page);

--- a/uniqn-mobile/e2e/tests/p3-nice-to-have/admin-dashboard.spec.ts
+++ b/uniqn-mobile/e2e/tests/p3-nice-to-have/admin-dashboard.spec.ts
@@ -22,25 +22,28 @@ test.describe('Admin 대시보드', () => {
 
   test('대시보드 메인 페이지 렌더링 → 제목 및 메뉴 카드 표시', async ({ page }) => {
     // admin 페이지 도달 확인 (대시보드 또는 앱 메인)
-    const anyContent = page.getByText('관리자 대시보드').or(page.getByText('구인구직').first());
+    // master `(admin)/index.tsx` 의 StackHeader/title 은 '관리자' (단축됨)
+    const anyContent = page.getByText('관리자').first().or(page.getByText('구인구직').first());
     await expect(anyContent).toBeVisible({ timeout: 30_000 });
 
     // 대시보드가 표시되는 경우에만 메뉴 카드 확인
     const hasDashboard = await page
-      .getByText('관리자 대시보드')
+      .getByText('관리자')
+      .first()
       .isVisible()
       .catch(() => false);
     if (hasDashboard) {
       await expect(dashboard.subtitle).toBeVisible({ timeout: 10_000 });
 
+      // master `(admin)/index.tsx` 의 menuItems 와 일치 (2026-05 시점)
       const menuLabels = [
-        '대회공고 승인',
+        '대회공고 검토',
         '사용자 관리',
         '신고 관리',
+        '게시판 신고',
         '문의 관리',
-        '시스템 설정',
+        '구인자 신청',
         '통계',
-        '보안 로그',
         '공지사항 관리',
       ];
 
@@ -53,7 +56,8 @@ test.describe('Admin 대시보드', () => {
   test('메뉴 카드 클릭 → 해당 관리 페이지로 이동', async ({ page }) => {
     // 대시보드 렌더링 대기
     const hasDashboard = await page
-      .getByText('관리자 대시보드')
+      .getByText('관리자')
+      .first()
       .isVisible({ timeout: 30_000 })
       .catch(() => false);
 

--- a/uniqn-mobile/e2e/tests/p3-nice-to-have/admin-reports-announcements.spec.ts
+++ b/uniqn-mobile/e2e/tests/p3-nice-to-have/admin-reports-announcements.spec.ts
@@ -20,9 +20,7 @@ test.describe('Admin 신고 관리', () => {
     // 상태 필터 확인
     const statusFilters = ['전체', '검토 대기', '검토 중', '처리 완료', '기각'];
     for (const status of statusFilters) {
-      await expect(
-        reportsPage.page.getByText(status, { exact: true }).first()
-      ).toBeVisible();
+      await expect(reportsPage.page.getByText(status, { exact: true }).first()).toBeVisible();
     }
   });
 
@@ -76,9 +74,7 @@ test.describe('Admin 공지사항 관리', () => {
     // 상태 탭 확인
     const statusTabs = ['전체', '초안', '발행됨', '보관됨'];
     for (const tab of statusTabs) {
-      await expect(
-        announcementsPage.getStatusTab(tab)
-      ).toBeVisible();
+      await expect(announcementsPage.getStatusTab(tab)).toBeVisible();
     }
   });
 
@@ -87,7 +83,8 @@ test.describe('Admin 공지사항 관리', () => {
     await announcementsPage.page.waitForTimeout(500);
 
     // 공지 목록 또는 빈 상태 확인
-    const hasEmpty = await announcementsPage.emptyState.isVisible();
+    // `.first()` 추가 — `공지사항이 없습니다` 가 page 에 2개 elements 매칭 (탭별 메시지)
+    const hasEmpty = await announcementsPage.emptyState.first().isVisible();
     // 빈 상태이거나 목록이 표시되어야 함
     expect(typeof hasEmpty).toBe('boolean');
   });


### PR DESCRIPTION
## Summary

PR #106 머지 후 잔존 master e2e 39 fail 분류 후 9 tests 처리:
- 5 selector mismatch fix
- 4 outdated 시나리오 .skip

## Changes

### A) Selector mismatch fix (5 tests)
- **home-employer-toggle.spec.ts**: `'이번 주 스태프 현황'` → `'이번 주 스태프'` (4 lines)
  - master `WeeklyStaffWidget` title 단축됨. `'OOO 현황'` 은 button aria-label 만 잔존
- **admin-dashboard.spec.ts**: `'관리자 대시보드'` → `'관리자'` + menu labels 정정
  - master `(admin)/index.tsx` title 단축, menu labels:
    - 제거: `'대회공고 승인'`, `'시스템 설정'`, `'보안 로그'`
    - 추가: `'대회공고 검토'`, `'게시판 신고'`, `'구인자 신청'`
- **admin-reports-announcements.spec.ts:85**: `emptyState.first()` — strict mode violation 해소

### B) Outdated 시나리오 .skip (4 tests)
`featureFlags.home_dashboard_enabled=true` 도입으로 staff entry 가 `(tabs)` 가 아닌 `(app)/home` standalone 으로 변경:
- **home-logo-no-stack-accumulation**: `describe.skip` (2 tests) — "탭에서 로고 클릭 → 이전 탭 복귀" 시나리오 무효
- **home-navigation-staff:45**: `test.skip` (1 test) — 동일
- **e2e-user-journeys:186**: `test.skip` (1 test) — "프로필 탭" 접근 경로 무효, settings heading 매핑 stale

## Expected Effect

- master e2e: 39 → 30 (-9)

## Test plan

- [x] `npx tsc --noEmit` — 신규 TS 에러 0
- [ ] PR e2e CI fail 감소 확인 (39 → 30)

## Follow-up

home dashboard 화면 분리 → 신규 spec 작성 (jobs/profile/settings 진입 경로 재정의) — 별도 issue

## Scope discipline

- production code 변경 0건 — e2e/** 만 수정
- 후속 Phase 3B/4: 잔존 admin-report/admin-board-reports, board, review/faq, public-pages, rbac, employer-* downstream, cancellation downstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)