### PR TITLE
test(e2e): Cat 2 selector stale 8 tests 재활성화

### DIFF
--- a/uniqn-mobile/e2e/pages/admin/announcements.page.ts
+++ b/uniqn-mobile/e2e/pages/admin/announcements.page.ts
@@ -13,7 +13,9 @@ export class AdminAnnouncementsPage extends BasePage {
 
   constructor(page: Page) {
     super(page);
-    this.header = page.getByRole('heading', { name: '공지사항 관리' });
+    // StackHeader 는 plain <Text> 로 렌더 (accessibilityRole="header" 미적용)
+    // → getByRole('heading') 불가, getByText.first() 로 매칭
+    this.header = page.getByText('공지사항 관리', { exact: true }).first();
     this.createButton = page.locator('[aria-label*="추가"]');
     this.emptyState = page.getByText('공지사항이 없습니다', { exact: true });
     this.emptyCreateButton = page.getByText('공지사항 작성', { exact: true });
@@ -48,9 +50,9 @@ export class AdminAnnouncementsPage extends BasePage {
     await this.waitForReady();
   }
 
-  /** 작성 페이지 헤더 */
+  /** 작성 페이지 헤더 (StackHeader plain Text) */
   get createHeader(): Locator {
-    return this.page.getByRole('heading', { name: '공지사항 작성' });
+    return this.page.getByText('공지사항 작성', { exact: true }).first();
   }
 
   /** 저장 버튼 */

--- a/uniqn-mobile/e2e/pages/admin/dashboard.page.ts
+++ b/uniqn-mobile/e2e/pages/admin/dashboard.page.ts
@@ -14,8 +14,9 @@ export class AdminDashboardPage extends BasePage {
 
   constructor(page: Page) {
     super(page);
-    // app/(admin)/index.tsx: 신고 관리 링크 카드 (항상 표시, link role로 접근)
-    this.title = page.getByRole('link', { name: /신고 관리/ });
+    // app/(admin)/index.tsx: DashboardCard 는 Pressable + accessibilityRole="button" + accessibilityLabel={title}
+    // → web 에서는 role="button" + aria-label 로 노출
+    this.title = page.getByRole('button', { name: /신고 관리/ });
     // app/(admin)/index.tsx: 서브텍스트
     this.subtitle = page.getByText('주요 운영 화면을 한 곳에서 빠르게 확인합니다.');
   }
@@ -40,9 +41,9 @@ export class AdminDashboardPage extends BasePage {
     await this.page.getByText(label).click();
   }
 
-  /** 메뉴 카드 표시 여부 확인 (link role 사용 — Text 요소는 hidden 처리됨) */
+  /** 메뉴 카드 표시 여부 확인 (Pressable + accessibilityRole="button" → web role=button) */
   getMenuCard(label: string): Locator {
-    return this.page.getByRole('link', { name: new RegExp(label) });
+    return this.page.getByRole('button', { name: new RegExp(label) });
   }
 
   /** 통계 페이지로 이동 */

--- a/uniqn-mobile/e2e/tests/p0-critical/admin-report-resolution.spec.ts
+++ b/uniqn-mobile/e2e/tests/p0-critical/admin-report-resolution.spec.ts
@@ -157,7 +157,7 @@ test.describe('WF-17: 관리자 신고 처리', () => {
   // ── 시나리오 1: admin role에서 신고 목록 메뉴 접근 ──────────────────────
 
   test.describe('시나리오 1: admin — 신고 관리 메뉴 접근', () => {
-    test.skip('admin 대시보드에서 신고 관리 메뉴 카드가 보인다', async ({ browser }) => {
+    test('admin 대시보드에서 신고 관리 메뉴 카드가 보인다', async ({ browser }) => {
       const context = await browser.newContext({ storageState: adminState });
       const page = await context.newPage();
 

--- a/uniqn-mobile/e2e/tests/p3-nice-to-have/admin-dashboard.spec.ts
+++ b/uniqn-mobile/e2e/tests/p3-nice-to-have/admin-dashboard.spec.ts
@@ -20,7 +20,7 @@ test.describe('Admin 대시보드', () => {
     await dashboard.goto();
   });
 
-  test.skip('대시보드 메인 페이지 렌더링 → 제목 및 메뉴 카드 표시', async ({ page }) => {
+  test('대시보드 메인 페이지 렌더링 → 제목 및 메뉴 카드 표시', async ({ page }) => {
     // admin 페이지 도달 확인 (대시보드 또는 앱 메인)
     // master `(admin)/index.tsx` 의 StackHeader/title 은 '관리자' (단축됨)
     const anyContent = page.getByText('관리자').first().or(page.getByText('구인구직').first());

--- a/uniqn-mobile/e2e/tests/p3-nice-to-have/admin-reports-announcements.spec.ts
+++ b/uniqn-mobile/e2e/tests/p3-nice-to-have/admin-reports-announcements.spec.ts
@@ -68,7 +68,7 @@ test.describe('Admin 공지사항 관리', () => {
     await announcementsPage.goto();
   });
 
-  test.skip('공지사항 목록 렌더링 → 헤더 및 상태 탭 표시', async () => {
+  test('공지사항 목록 렌더링 → 헤더 및 상태 탭 표시', async () => {
     await expect(announcementsPage.header).toBeVisible();
 
     // 상태 탭 확인
@@ -89,7 +89,7 @@ test.describe('Admin 공지사항 관리', () => {
     expect(typeof hasEmpty).toBe('boolean');
   });
 
-  test.skip('공지사항 작성 페이지 접근 → 폼 렌더링', async () => {
+  test('공지사항 작성 페이지 접근 → 폼 렌더링', async () => {
     await announcementsPage.gotoCreate();
 
     await expect(announcementsPage.createHeader).toBeVisible();

--- a/uniqn-mobile/e2e/tests/p3-nice-to-have/review-system.spec.ts
+++ b/uniqn-mobile/e2e/tests/p3-nice-to-have/review-system.spec.ts
@@ -35,7 +35,7 @@ test.describe('리뷰 시스템', () => {
     await expect(tagSection).toBeVisible();
   });
 
-  test.skip('리뷰 작성 → 코멘트 입력 및 글자수 카운터 표시', async ({ page }) => {
+  test('리뷰 작성 → 코멘트 입력 및 글자수 카운터 표시', async ({ page }) => {
     await page.goto(
       '/reviews/write?workLogId=test&revieweeId=test&revieweeName=테스트&reviewerType=employer&jobPostingId=test&jobPostingTitle=테스트공고&workDate=2026-03-01',
       { waitUntil: 'domcontentloaded' }
@@ -45,8 +45,8 @@ test.describe('리뷰 시스템', () => {
     // 코멘트 입력란은 감정 선택 후에만 표시됨
     await page.getByText('좋았어요', { exact: true }).click();
 
-    // 한줄 코멘트 입력
-    const commentInput = page.getByPlaceholder('추가로 전하고 싶은 말이 있나요?');
+    // 한줄 코멘트 입력 (ReviewForm.tsx placeholder 와 동일)
+    const commentInput = page.getByPlaceholder('추가로 남기고 싶은 말이 있나요?');
     await expect(commentInput).toBeVisible();
 
     await commentInput.fill('좋은 근무였습니다');
@@ -56,7 +56,7 @@ test.describe('리뷰 시스템', () => {
     await expect(counter).toBeVisible();
   });
 
-  test.skip('리뷰 작성 → 제출 전 경고 메시지 표시', async ({ page }) => {
+  test('리뷰 작성 → 제출 전 경고 메시지 표시', async ({ page }) => {
     await page.goto(
       '/reviews/write?workLogId=test&revieweeId=test&revieweeName=테스트&reviewerType=employer&jobPostingId=test&jobPostingTitle=테스트공고&workDate=2026-03-01',
       { waitUntil: 'domcontentloaded' }
@@ -66,8 +66,8 @@ test.describe('리뷰 시스템', () => {
     // 경고 메시지는 감정 선택 후에만 표시됨
     await page.getByText('좋았어요', { exact: true }).click();
 
-    // 제출 불가 경고 메시지 확인
-    const warningText = page.getByText('평가는 제출 후 수정할 수 없습니다');
+    // 제출 불가 경고 메시지 (ReviewForm.tsx 와 동일한 부분 매칭)
+    const warningText = page.getByText('리뷰는 제출 후 수정할 수 없어요');
     await expect(warningText.first()).toBeVisible();
   });
 

--- a/uniqn-mobile/e2e/tests/p3-nice-to-have/support-faq.spec.ts
+++ b/uniqn-mobile/e2e/tests/p3-nice-to-have/support-faq.spec.ts
@@ -48,20 +48,22 @@ test.describe('FAQ', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/support/faq', { waitUntil: 'domcontentloaded' });
     await waitForAppBootstrap(page);
-    await expect(page.getByRole('heading', { name: '자주 묻는 질문' })).toBeVisible({
+    // StackHeader 는 plain <Text> 로 렌더 — getByRole('heading') 미적용
+    await expect(page.getByText('자주 묻는 질문', { exact: true }).first()).toBeVisible({
       timeout: 20_000,
     });
   });
 
-  test.skip('FAQ 화면은 카테고리와 CTA를 렌더링한다', async ({ page }) => {
+  test('FAQ 화면은 카테고리와 CTA를 렌더링한다', async ({ page }) => {
+    // FAQ_DATA(src/types/inquiry.ts) 첫 일반 문의 — 정적 데이터 (seed 불필요)
     await expect(page.getByText('UNIQN은 어떤 서비스인가요?')).toBeVisible();
     await expect(page.getByText('원하는 답변을 찾지 못하셨나요?')).toBeVisible();
-    await expect(page.getByText('1:1 문의하기')).toBeVisible();
+    await expect(page.getByText('1:1 문의하기').first()).toBeVisible();
   });
 
-  test.skip('FAQ 하단 CTA가 있으면 1:1 문의 버튼이 같이 보인다', async ({ page }) => {
+  test('FAQ 하단 CTA가 있으면 1:1 문의 버튼이 같이 보인다', async ({ page }) => {
     const ctaText = page.getByText('원하는 답변을 찾지 못하셨나요?');
-    const ctaButton = page.getByText('1:1 문의하기');
+    const ctaButton = page.getByText('1:1 문의하기').first();
 
     const hasCta = await ctaText.isVisible().catch(() => false);
     if (hasCta) {


### PR DESCRIPTION
## Summary

master e2e 0 fail 도달 후 follow-up — outdated/stale 57 skip 중 **selector 변경만으로 unskip 가능한 8 tests** 재활성화 (Cat 2: Selector stale).

## 수정 내역

### Page object selector 수정

- `e2e/pages/admin/dashboard.page.ts` — `title`, `getMenuCard` 의 role 매핑 `link` → `button`. production `app/(admin)/index.tsx` 의 DashboardCard 는 `<Pressable accessibilityRole=\"button\" accessibilityLabel={title}>` 로 렌더 → web role=button.
- `e2e/pages/admin/announcements.page.ts` — `header`, `createHeader` 의 `getByRole('heading')` → `getByText().first()`. StackHeader 는 plain `<Text>` 로 렌더 (accessibilityRole=\"header\" 미적용).

### Spec text 수정 (production 텍스트 동기화)

- `review-system.spec.ts:38` — 코멘트 placeholder `추가로 전하고 싶은 말이 있나요?` → `추가로 남기고 싶은 말이 있나요?`
- `review-system.spec.ts:59` — 경고 메시지 `평가는 제출 후 수정할 수 없습니다` → `리뷰는 제출 후 수정할 수 없어요`
- `support-faq.spec.ts` FAQ beforeEach — `getByRole('heading')` → `getByText().first()`, CTA 매칭에 `.first()` 추가

## Unskip 한 8 tests

| File | Line | 설명 |
|------|------|------|
| admin-dashboard.spec.ts | 23 | 대시보드 메인 페이지 — 제목 + 메뉴 카드 표시 |
| admin-report-resolution.spec.ts | 160 | admin 대시보드에서 신고 관리 메뉴 카드 |
| admin-reports-announcements.spec.ts | 71 | 공지사항 목록 헤더 + 상태 탭 표시 |
| admin-reports-announcements.spec.ts | 92 | 공지사항 작성 페이지 폼 렌더링 |
| review-system.spec.ts | 38 | 리뷰 작성 코멘트 입력 + 카운터 |
| review-system.spec.ts | 59 | 리뷰 작성 제출 전 경고 메시지 |
| support-faq.spec.ts | 56 | FAQ 카테고리와 CTA 렌더링 |
| support-faq.spec.ts | 62 | FAQ 하단 CTA 1:1 문의 버튼 |

## 제외 (Cat 4 follow-up 별도 PR)

- `admin-report-resolution.spec.ts:222` — seed 의존 (Cat 4 별도 PR 예정)
- `admin-board-reports.spec.ts:5,49` — board-fixtures seed 의존 (Cat 4)

## Test plan

- [x] 로컬: typecheck pass, prettier pass, eslint clean
- [ ] CI e2e: 8 tests 모두 pass (master e2e gate 0 fail 유지)
- [ ] 기존 통과 테스트 regression 없음 확인

남은 follow-up: Cat 3 (시나리오 outdated) + Cat 4 (seed mismatch) + Cat 1 (home_dashboard entry 재정의) — 별도 PR 들로 분리 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)