### PR TITLE
fix(master): c9aa0c837 직접 push 회귀 — unit test 1 + e2e race 14건 해소

### DIFF
--- a/uniqn-mobile/e2e/helpers/workspace-seed.ts
+++ b/uniqn-mobile/e2e/helpers/workspace-seed.ts
@@ -6,13 +6,19 @@
  *
  * 본 헬퍼는 (owner_id, name) 매칭으로 멱등 — 동일 owner 의 'E2E 테스트 워크스페이스'
  * 가 이미 있으면 재사용. job_postings 시드 시 반환된 workspace_id 를 함께 INSERT.
+ *
+ * 2026-05-17 race fix: Playwright workers=4 병렬 환경에서 같은 owner 로 다중
+ * `ensureE2EWorkspace` 가 동시 INSERT 하면 duplicate workspaces 생성됨.
+ * 후속 SELECT 가 `.maybeSingle()` 에 다중 row 매칭으로 fail. workspaces 에
+ * (owner_id, name) unique 제약이 없어 INSERT 자체는 막을 수 없음 → 읽기 측
+ * `.order().limit(1)` 로 가장 오래된 것 1건 deterministic 선택.
  */
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 export const E2E_TEST_WORKSPACE_NAME = 'E2E 테스트 워크스페이스';
 
 /**
- * 주어진 owner 의 E2E 워크스페이스를 보장하고 ID 반환 (멱등).
+ * 주어진 owner 의 E2E 워크스페이스를 보장하고 ID 반환 (멱등 + race-safe).
  *
  * @throws workspace SELECT/INSERT 실패 시 (admin client 권한/네트워크 문제 등)
  */
@@ -20,18 +26,20 @@ export async function ensureE2EWorkspace(
   adminClient: SupabaseClient,
   ownerId: string
 ): Promise<string> {
-  const { data: existing, error: selectError } = await adminClient
+  // race-safe: limit(1) + order 로 다중 duplicate 시에도 deterministic 선택
+  const { data: existingRows, error: selectError } = await adminClient
     .from('workspaces')
     .select('id')
     .eq('owner_id', ownerId)
     .eq('name', E2E_TEST_WORKSPACE_NAME)
-    .maybeSingle();
+    .order('created_at', { ascending: true })
+    .limit(1);
 
   if (selectError) {
     throw new Error(`workspace SELECT 실패: ${selectError.message}`);
   }
-  if (existing?.id) {
-    return existing.id as string;
+  if (existingRows && existingRows.length > 0 && existingRows[0]?.id) {
+    return existingRows[0].id as string;
   }
 
   const { data, error } = await adminClient
@@ -44,6 +52,17 @@ export async function ensureE2EWorkspace(
     .single();
 
   if (error || !data?.id) {
+    // race: 동시에 다른 worker 가 INSERT 했을 가능성 — 재SELECT 로 회복
+    const { data: retryRows } = await adminClient
+      .from('workspaces')
+      .select('id')
+      .eq('owner_id', ownerId)
+      .eq('name', E2E_TEST_WORKSPACE_NAME)
+      .order('created_at', { ascending: true })
+      .limit(1);
+    if (retryRows && retryRows.length > 0 && retryRows[0]?.id) {
+      return retryRows[0].id as string;
+    }
     throw new Error(`workspace 시드 실패: ${error?.message ?? '응답 데이터 없음'}`);
   }
   return data.id as string;

--- a/uniqn-mobile/src/components/auth/__tests__/PortOneIdentityVerification.web.test.tsx
+++ b/uniqn-mobile/src/components/auth/__tests__/PortOneIdentityVerification.web.test.tsx
@@ -214,17 +214,27 @@ describe('PortOneIdentityVerification (web)', () => {
     });
   });
 
-  it('gender 없을 시 에러 메시지를 표시한다', async () => {
+  // 2026-05-16: PortOne 이니시스 통합인증에서 인증수단별로 gender 응답이 다름
+  // (PASS/토스/카카오/네이버/신한/KB 등). 누락 시 차단하지 않고 후속 step
+  // (SignupStepIdentity / profile-setup) 에서 사용자가 직접 선택하는 정책.
+  it('gender 누락 시에도 인증을 통과시키고 성별 필드를 렌더링하지 않는다', async () => {
+    const onVerified = jest.fn();
     mockCallVerify.mockResolvedValue({
       ...mockVerification,
       identity: { ...mockIdentity, gender: undefined },
     });
-    const { getByText } = render(<PortOneIdentityVerification {...defaultProps} />);
+    const { getByText, queryByText } = render(
+      <PortOneIdentityVerification {...defaultProps} onVerified={onVerified} />
+    );
     await act(async () => {
       fireEvent.press(getByText('본인인증 시작'));
     });
     await waitFor(() => {
-      expect(getByText(/성별 정보가 누락되었어요/)).toBeTruthy();
+      expect(onVerified).toHaveBeenCalledWith(expect.objectContaining({ gender: undefined }));
     });
+    // 완료 화면 표시
+    expect(getByText('이니시스 본인인증 완료')).toBeTruthy();
+    // gender 필드는 conditional render → 누락 시 비표시
+    expect(queryByText('성별')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

[c9aa0c837](https://github.com/snosnosno/uniqn/commit/c9aa0c837) (PortOne 본인인증 prod 차단 fix) 가 **PR 우회 master 직접 push** 로 들어가면서 도입한 회귀 2건 hotfix.

직후 PR #110 e2e 에서 14 e2e fail + 1 unit test fail 발견 → 본 PR 로 우선 master gate 복구.

## 1. PortOne web unit test — gender optional 정책 반영

`PortOneIdentityVerification (web) › gender 없을 시 에러 메시지를 표시한다` 가 production 정책 변경에 맞춰 업데이트되지 않음:

- **production** (c9aa0c837): gender 누락 시 `onVerified` 호출 + \"이니시스 본인인증 완료\" 화면 표시. PASS/토스/카카오/네이버/신한/KB 등 인증수단별 응답 차이 수용. 가입 후 profile-setup/settings/profile 에서 사용자 직접 선택.
- **테스트**: 여전히 `/성별 정보가 누락되었어요/` 에러 메시지를 expect → fail

**Fix**: 테스트를 새 정책에 맞춰 \"gender undefined 시에도 onVerified + 완료 화면 + 성별 필드 conditional render 부재\" 검증으로 rewrite.

## 2. e2e workspace race condition — 14건 fail 원인

`e2e/helpers/workspace-seed.ts:ensureE2EWorkspace` 가 Playwright `workers: 4` 병렬에서 race:

```
1. Worker A,B,C,D: SELECT.maybeSingle() → 모두 0 rows (workspace 비어있음)
2. 모두 INSERT → 4 duplicate workspaces 생성
3. 후속 Worker E: SELECT.maybeSingle() → 4 rows match → JSON object requested, multiple (or no) rows returned 에러
```

이 race 가 다음 14 specs fail 원인:
- cancellation-lifecycle (2), job-detail-apply (4), employer-applicants (1), employer-posting-crud (2), employer-settlement (4), collaborator-shared-postings (1)

`workspaces` 에 `(owner_id, name)` unique 제약이 없어 INSERT 자체는 막을 수 없음 → **읽기 측 race-safe 패턴**으로 회복:
- `.order('created_at').limit(1)` 로 deterministic 1건 선택
- INSERT 실패 시 retry SELECT 로 회복

## 검증

- [x] 로컬: PortOne web test 12/12 pass (gender 누락 시 인증 통과 + 성별 필드 부재 검증)
- [x] 로컬: typecheck pass, prettier pass
- [ ] CI: 14 e2e fail → 0 fail 회복
- [ ] CI: 1 unit test fail → 0 회복

## 후속 PR

- #110 (Cat 2 selector stale 8 tests) — 본 PR 머지 후 rebase → CI 통과 → 머지 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)