### PR TITLE
test(e2e): job-detail-apply:224 UUID-shape ID 사용 (Cat 4 Phase A)

### DIFF
--- a/uniqn-mobile/e2e/tests/p1-important/job-detail-apply.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/job-detail-apply.spec.ts
@@ -221,11 +221,15 @@ test.describe('공고 상세와 지원 흐름', () => {
     }
   });
 
-  test.skip('존재하지 않는 공고는 에러 화면을 보여준다', async ({ browser }) => {
+  test('존재하지 않는 공고는 에러 화면을 보여준다', async ({ browser }) => {
     const context = await browser.newContext({ storageState: staffState });
     const page = await context.newPage();
 
-    await page.goto('/jobs/nonexistent-job-99999', { waitUntil: 'domcontentloaded' });
+    // job_postings.id 는 uuid 타입 — 비-UUID 문자열은 Supabase eq() 에서
+    // `invalid input syntax for type uuid` 로 useJobDetail query 가 hang.
+    // valid UUID 형식이지만 DB 에 존재하지 않는 ID 사용 (PR #112 public-pages:59 동일 패턴)
+    const nonexistentValidUuid = '00000000-0000-0000-0000-000000000000';
+    await page.goto(`/jobs/${nonexistentValidUuid}`, { waitUntil: 'domcontentloaded' });
     await expect(page.getByText(ERROR_TEXT).last()).toBeVisible({ timeout: 10_000 });
 
     await context.close();


### PR DESCRIPTION
## Summary

PR #112 (Cat 3) 후속. Cat 4 (시드 환경 mismatch, 17 tests) 중 가장 명확한 1 test 처리.

## 재활성화 (1 test)

### `job-detail-apply.spec.ts:224` — `존재하지 않는 공고는 에러 화면을 보여준다`
- `/jobs/nonexistent-job-99999` → `/jobs/00000000-0000-0000-0000-000000000000`
- 사유: \`job_postings.id\` 는 uuid 타입 — 비-UUID 문자열은 Supabase eq() 에서 \`invalid input syntax for type uuid\` 로 useJobDetail query hang → 1m timeout 후 browserContext 종료
- PR #112 의 \`public-pages:59\` 와 동일 패턴

## Cat 4 Phase B (16 tests 후속 PR로 분리)

복잡도가 높아 별도 분석/migration 필요:

| spec | line | 분류 | 추정 작업 |
|------|------|------|----------|
| cancellation-lifecycle | 283/391/509/529 (4) | filled_positions trigger | denormalized counter trigger 동작 검증 (person_basis_filled_positions migration) |
| employer-applicants | 185/211/242/268 (4) | UI selector stale | StaffManagementTab 으로 이동 후 새 selector 필요 |
| employer-collaborator-add | 89 | UI selector | 협업자 추가 페이지 selector 검증 |
| employer-posting-crud | 96 | UI selector | my-postings 목록 tablist 선택자 |
| collaborator-self-leave | 95 | UI selector | 협업자 나가기 페이지 selector |
| job-detail-apply | 147 (마감), 260 (중복) | UI/seed | JobDetail UI 변경 |
| admin-report-resolution | 222 | fragile | 15s timeout 부족 가능성 |
| admin-board-reports | 5, 49 | board fixture seed | \`seed-board-report-*\` migration 또는 inline 전체 seed chain |

## Test plan
- [ ] master e2e CI 0 fail 유지 — Cat 4 Phase A 1 test 가 PASS
- [ ] \`chromium-unauthenticated\` project (file 명 \`*public*\` 아니라 staff project 가능 — 확인)
- [ ] 비-UUID 가 hang 하는 root cause 가 재발 안 함 (zero UUID 사용으로 query 정상 종료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)