### PR TITLE
test(e2e): Cat 4 Phase B 잔존 cancellation 4 tests RPC trace + unskip

### DIFF
--- a/uniqn-mobile/e2e/tests/p0-critical/cancellation-lifecycle.spec.ts
+++ b/uniqn-mobile/e2e/tests/p0-critical/cancellation-lifecycle.spec.ts
@@ -15,6 +15,12 @@ import { getAdminClient, SUPABASE_QA_ACCOUNTS } from '../../helpers/supabase-adm
 import { waitForAppReady } from '../../helpers/wait-helpers';
 import { ensureE2EWorkspace } from '../../helpers/workspace-seed';
 
+// PR #117: 각 describe 의 tests 는 beforeAll seed 를 공유하고 RPC 호출 → 상태 검증 순서로
+// 의존한다. fullyParallel:true 환경에서 describe 내부 tests 도 병렬 실행되면 RPC 호출 전에
+// DB-level filled_positions=0 검증이 먼저 실행되어 seed 상태 (filled=1) 를 검증하게 됨.
+// 따라서 파일 전체를 serial 모드로 고정하여 declaration 순서 보장.
+test.describe.configure({ mode: 'serial' });
+
 // ---------------------------------------------------------------------------
 // storageState 경로 (상대 경로)
 // ---------------------------------------------------------------------------

--- a/uniqn-mobile/e2e/tests/p0-critical/cancellation-lifecycle.spec.ts
+++ b/uniqn-mobile/e2e/tests/p0-critical/cancellation-lifecycle.spec.ts
@@ -262,6 +262,8 @@ test.describe('WF-08-1 Staff 확정 취소 happy path', () => {
     const result = data as Record<string, unknown>;
     expect(result.success).toBe(true);
     expect(result.new_status).toBe('applied');
+    // PR #117: RPC return 값 trace — describe 3 의 :491 동일 assertion 으로 정렬
+    expect(result.new_filled_positions).toBe(0);
   });
 
   test('취소 후 application.status가 applied로 변경됐다', async () => {
@@ -280,10 +282,9 @@ test.describe('WF-08-1 Staff 확정 취소 happy path', () => {
     expect(data?.status).toBe('applied');
   });
 
-  // CI #115 fail: Expected 0, Received 1 — RPC :244 이전 호출 후에도 filled_positions 미감소.
-  // describe 3 의 :490 동일 검증은 PASS 하지만 describe 1/2 는 FAIL — 환경/seed 순서 mismatch.
-  // 후속 investigation: cancel_application_atomically RPC 가 describe 1/2 에서만 silent fail 하는 원인 추적.
-  test.skip('취소 후 job_posting.filled_positions가 복원됐다 (0으로 감소)', async () => {
+  // PR #117: RPC return assertion (:264) 추가로 silent fail 시 :244 에서 조기 노출.
+  // DB-level 검증 unskip — RPC return 통과 후 DB 상태 separation 확인.
+  test('취소 후 job_posting.filled_positions가 복원됐다 (0으로 감소)', async () => {
     if (!adminClient || !jobId) {
       test.skip(true, 'adminClient 또는 jobId 없음');
       return;
@@ -373,6 +374,8 @@ test.describe('WF-08-2 Employer 취소 요청 승인 happy path', () => {
     const result = data as Record<string, unknown>;
     expect(result.success).toBe(true);
     expect(result.new_status).toBe('cancelled');
+    // PR #117: RPC return 값 trace — staff_approves_cancel_request 도 person-basis -1
+    expect(result.new_filled_positions).toBe(0);
   });
 
   test('승인 후 application.status가 cancelled로 변경됐다', async () => {
@@ -391,8 +394,8 @@ test.describe('WF-08-2 Employer 취소 요청 승인 happy path', () => {
     expect(data?.status).toBe('cancelled');
   });
 
-  // CI #115 fail: 동일 패턴 (Expected 0, Received 1) — :283 와 같은 RPC silent fail.
-  test.skip('승인 후 job_posting.filled_positions가 복원됐다', async () => {
+  // PR #117: RPC return assertion (:380) 추가로 silent fail 시 :356 에서 조기 노출.
+  test('승인 후 job_posting.filled_positions가 복원됐다', async () => {
     if (!adminClient || !jobId) {
       test.skip(true, 'adminClient 또는 jobId 없음');
       return;
@@ -510,8 +513,8 @@ test.describe('WF-08-3 취소 후 capacity 복원 — DB 직접 검증', () => {
     expect(data?.filled_positions).toBeLessThan(data?.total_positions ?? 0);
   });
 
-  // CI #115 fail: filled_positions=1 (RPC silent fail 같은 원인) → 원자성 검증 무효.
-  test.skip('취소 후 application.status = applied, filled_positions = 0 동시 만족 (원자성 보장)', async () => {
+  // PR #117: describe 3 의 RPC return assertion(:491)이 이미 통과하므로 동일 원자성 검증 unskip
+  test('취소 후 application.status = applied, filled_positions = 0 동시 만족 (원자성 보장)', async () => {
     if (!adminClient || !applicationId || !jobId) {
       test.skip(true, 'adminClient 없음');
       return;
@@ -531,8 +534,8 @@ test.describe('WF-08-3 취소 후 capacity 복원 — DB 직접 검증', () => {
     expect(jobResult.data?.filled_positions).toBe(0);
   });
 
-  // CI #115 fail: 선행 RPC 가 silent fail 했으므로 status 가 applied 로 전환되지 않아 idempotency 검증 무효.
-  test.skip('idempotency: 동일 취소 RPC를 다시 호출해도 success 반환한다', async () => {
+  // PR #117: describe 3 의 :472 RPC + :494 DB 검증이 통과 후 idempotency 동작 검증
+  test('idempotency: 동일 취소 RPC를 다시 호출해도 success 반환한다', async () => {
     if (!adminClient || !applicationId) {
       test.skip(true, 'adminClient 없음');
       return;


### PR DESCRIPTION
## Summary

- Cat 4 Phase B 잔존 cancellation 4 tests (filled_positions silent fail) RPC return 값 trace 추가 + unskip
- 잔존: 34 → 30 skip 예상

## Changes

`e2e/tests/p0-critical/cancellation-lifecycle.spec.ts`:

| Line | Before | After |
|------|--------|-------|
| :264 | (없음) | `expect(result.new_filled_positions).toBe(0)` — RPC return assertion 추가 |
| :286 | `test.skip` | `test` — DB-level filled_positions=0 검증 unskip |
| :380 | (없음) | `expect(result.new_filled_positions).toBe(0)` — RPC return assertion 추가 |
| :395 | `test.skip` | `test` — DB-level filled_positions=0 검증 unskip |
| :514 | `test.skip` | `test` — 원자성 보장 검증 unskip |
| :535 | `test.skip` | `test` — idempotency 검증 unskip |

## Why

PR #115 에서 describe 1/2 만 silent fail (filled_positions stays 1, expected 0) — describe 3 의 :491 동일 검증은 PASS. 원인 진단을 위해 RPC return 값 (new_filled_positions) assertion 을 RPC 호출 직후 추가:

- **RPC silent fail 시**: :244 / :356 에서 조기 실패 → RPC 코드 문제 명확
- **DB drift 시**: :286 / :395 에서 실패 → trigger or post-RPC mutation 의심
- **모두 통과 시**: 환경 mismatch (PR #115 시점 문제) 가 PR #114-#116 변경으로 해소된 것

`person_basis_filled_positions` migration (20260418005000) 의 `v_new_filled := GREATEST(0, filled - 1)` 로직과 seed `filled_positions=1` 의 결과는 항상 0 이 되어야 함. describe 3 의 동일 assertion 은 PASS 하므로 describe 1/2 도 통과 예상.

## Test plan

- [ ] CI e2e workflow 통과 (gate 활성, fail 시 머지 차단)
- [ ] cancellation-lifecycle.spec.ts 의 3 scenarios 모두 PASS (admin client 환경 기준)
- [ ] 30 skip 잔존 (Cat 1: 15, Cat 4 B board-fixtures: 2, collaborator: 2, board:124: 1, others: 10)

## 관련

- 이전: PR #115 (Cat 4 Phase B2 0 net unskip 분석)
- pitfall: pitfall_e2e_seed_enum_and_url_patterns.md (PR #114/#116 후속)
- 메모리: project_e2e_gate_activated.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)