### PR TITLE
test(e2e): Cat 1 entry route 15 tests 재활성화 — home_dashboard_enabled 대응

### DIFF
--- a/uniqn-mobile/e2e/tests/p0-critical/e2e-user-journeys.spec.ts
+++ b/uniqn-mobile/e2e/tests/p0-critical/e2e-user-journeys.spec.ts
@@ -183,9 +183,9 @@ test.describe('E2E 유저 저니', () => {
     }
   });
 
-  // SKIP: staff entry 가 `(app)/home` (standalone) 으로 변경되어 "프로필 탭" 접근 경로 무효.
-  // settings heading 매핑도 master UI 와 불일치. spec rewrite 필요 (follow-up issue).
-  test.skip('계정 생명주기: 로그인 → 프로필 접근 → 설정 접근', async ({ browser }) => {
+  // PR #119: staff entry 가 (app)/home (standalone) 으로 변경. HomeTabBar 의
+  // "프로필 탭으로 이동" button + StackHeader title (heading role 없음) 으로 selector 재작성.
+  test('계정 생명주기: 로그인 → 프로필 접근 → 설정 접근', async ({ browser }) => {
     const context = await browser.newContext({ storageState: staffState });
     const page = await context.newPage();
 
@@ -193,23 +193,23 @@ test.describe('E2E 유저 저니', () => {
     await page.goto('/home', { waitUntil: 'domcontentloaded' });
     await waitForAppReady(page);
 
-    // 2. 프로필 탭 클릭
-    const profileTab = page.getByText('프로필');
-    if (await profileTab.isVisible()) {
-      await profileTab.click();
-      await page.waitForLoadState('domcontentloaded');
+    // 2. HomeTabBar 의 프로필 탭 click → (tabs)/profile
+    const profileTabButton = page.getByRole('button', { name: '프로필 탭으로 이동' });
+    await expect(profileTabButton).toBeVisible({ timeout: 10_000 });
+    await profileTabButton.click();
+    await page.waitForLoadState('domcontentloaded');
 
-      // 프로필 관련 콘텐츠가 보여야 함
-      await expect(page.getByRole('button', { name: /프로필 수정/ })).toBeVisible({
-        timeout: 10_000,
-      });
-    }
+    // 프로필 관련 콘텐츠가 보여야 함
+    await expect(page.getByRole('button', { name: /프로필 수정/ })).toBeVisible({
+      timeout: 10_000,
+    });
 
     // 3. 설정 접근
     await page.goto('/settings', { waitUntil: 'domcontentloaded' });
     await waitForAppReady(page);
 
-    await expect(page.getByRole('heading', { name: '설정' })).toBeVisible({ timeout: 10_000 });
+    // StackHeader 의 title='설정' — heading role 없으므로 text 매칭
+    await expect(page.getByText('설정').first()).toBeVisible({ timeout: 10_000 });
 
     await context.close();
   });

--- a/uniqn-mobile/e2e/tests/p1-important/home-logo-no-stack-accumulation.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/home-logo-no-stack-accumulation.spec.ts
@@ -33,20 +33,21 @@ async function dismissOnboarding(page: Page): Promise<void> {
 
 test.use({ storageState: staffState });
 
-// SKIP: featureFlags.home_dashboard_enabled=true 도입 후 staff entry 가 tab 화면 아닌
-// `(app)/home` (standalone). 시나리오의 "탭에서 로고 클릭 → 이전 탭 복귀" 전제가 무효.
-// home 화면에서 로고 click 은 자기 자신 navigation 으로 click handler 가 stable check
-// 미통과 → 60s timeout. spec rewrite 필요 (follow-up issue).
-test.describe.skip('홈 로고 탭 스택 누적 방지', () => {
-  test('로고를 10번 연속 탭해도 뒤로가기 1번으로 이전 탭 복귀', async ({ page }) => {
+// PR #119: home_dashboard_enabled=true 도입 후 staff entry 가 (app)/home (standalone).
+// 시나리오를 새 flow 에 맞게 재작성:
+//   1. /home 에서 로고 click → 자기 참조 (router.replace) — history 누적 없음
+//   2. 탭에서 로고 click → 홈 이동 — history 정상 push (push 1회만)
+test.describe('홈 로고 탭 스택 누적 방지', () => {
+  test('홈에서 로고를 10번 탭해도 history 가 누적되지 않는다', async ({ page }) => {
     await page.goto('/');
     await waitForAppInit(page);
     await dismissOnboarding(page);
 
-    // 홈 화면 진입 확인
+    // 홈 진입 확인
     await expect(page.getByText('다음 근무').first()).toBeVisible({ timeout: 15_000 });
 
-    // 로고 버튼 찾기
+    const initialHistoryLength = await page.evaluate(() => window.history.length);
+
     const logoButton = page.getByRole('button', { name: 'UNIQN 홈으로 이동' });
     await expect(logoButton).toBeVisible({ timeout: 5_000 });
 
@@ -56,40 +57,29 @@ test.describe.skip('홈 로고 탭 스택 누적 방지', () => {
       await page.waitForTimeout(100);
     }
 
-    // 여전히 홈 화면에 있어야 함
+    // 여전히 홈
     await expect(page.getByText('다음 근무').first()).toBeVisible({ timeout: 5_000 });
 
-    // 뒤로가기 1번
-    await page.goBack();
-    await page.waitForTimeout(500);
-
-    // 탭 화면으로 복귀 (홈이 아닌 탭 화면)
-    // 홈 위젯이 사라지거나, 탭 바가 다시 최상위에 있어야 함
-    // 스택이 10개 쌓였다면 여전히 홈에 있을 것 (실패)
-    const homeWidget = await page
-      .getByText('다음 근무')
-      .isVisible()
-      .catch(() => false);
-
-    // 탭 기반 앱에서 뒤로가기는 이전 History로 복귀
-    // 10번 탭이 스택에 쌓이지 않았다면 한 번의 뒤로가기로 이전 화면 복귀
-    // 구체적인 이전 탭 화면 텍스트 확인 (앱 진입 경로에 따라 다름)
-    // 최소한: 홈 대시보드가 아닌 다른 화면이거나 초기 화면
-    expect(typeof homeWidget).toBe('boolean'); // 실행 완료 확인
+    // history 증가가 거의 없음 (router.replace 또는 same-pathname no-op)
+    const finalHistoryLength = await page.evaluate(() => window.history.length);
+    expect(finalHistoryLength - initialHistoryLength).toBeLessThanOrEqual(2);
   });
 
-  test('홈 화면에서 로고 탭 시 navigation 히스토리가 증가하지 않는다', async ({ page }) => {
+  test('탭에서 홈 로고 5번 탭 후 history 가 비정상 증가하지 않는다', async ({ page }) => {
     await page.goto('/');
     await waitForAppInit(page);
     await dismissOnboarding(page);
 
-    // 홈 화면 확인
-    await expect(page.getByText('다음 근무').first()).toBeVisible({ timeout: 15_000 });
+    // 홈 → 구인구직 탭 (HomeTabBar)
+    const jobsTabButton = page.getByRole('button', { name: '구인구직 탭으로 이동' });
+    await expect(jobsTabButton).toBeVisible({ timeout: 10_000 });
+    await jobsTabButton.click();
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForTimeout(500);
 
-    // 초기 history 길이 기록
-    const initialHistoryLength = await page.evaluate(() => window.history.length);
+    const tabHistoryLength = await page.evaluate(() => window.history.length);
 
-    // 로고 5번 탭
+    // 탭 헤더의 로고 5번 click — 첫 click 만 home 이동, 나머지 4번은 self-replace
     const logoButton = page.getByRole('button', { name: 'UNIQN 홈으로 이동' });
     await expect(logoButton).toBeVisible({ timeout: 5_000 });
 
@@ -98,11 +88,11 @@ test.describe.skip('홈 로고 탭 스택 누적 방지', () => {
       await page.waitForTimeout(150);
     }
 
-    // history length가 크게 증가하지 않아야 함 (replace 사용 시 동일 유지)
-    const finalHistoryLength = await page.evaluate(() => window.history.length);
+    // 홈 도착
+    await expect(page.getByText('다음 근무').first()).toBeVisible({ timeout: 10_000 });
 
-    // replace 방식이면 history 증가 없음 (또는 최소 증가)
-    // push 방식이면 +5 증가
-    expect(finalHistoryLength - initialHistoryLength).toBeLessThanOrEqual(2);
+    // 탭 → 홈 push 1 회 만 발생 (+1) 예상, +5 가 아님
+    const finalHistoryLength = await page.evaluate(() => window.history.length);
+    expect(finalHistoryLength - tabHistoryLength).toBeLessThanOrEqual(2);
   });
 });

--- a/uniqn-mobile/e2e/tests/p1-important/home-navigation-staff.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/home-navigation-staff.spec.ts
@@ -42,22 +42,24 @@ test.describe('홈 네비게이션 — Staff', () => {
     await expect(page.getByText('내 지원 현황').first()).toBeVisible({ timeout: 10_000 });
   });
 
-  // SKIP: staff entry 가 `(app)/home` 이라 tab 화면 미진입 — logo click 자기참조 navigation
-  // 으로 click handler stable check 미통과. spec rewrite 필요 (follow-up issue).
-  test.skip('탭에서 UNIQN 로고 탭 → 홈으로 이동', async ({ page }) => {
+  // PR #119: staff entry 가 (app)/home (standalone) 으로 변경됨. HomeTabBar 의
+  // "구인구직 탭으로 이동" button 으로 tab 화면 진입 후 logo click → home 복귀 flow 로 재작성.
+  test('홈 → 탭 진입 → UNIQN 로고 탭으로 홈 복귀', async ({ page }) => {
     await page.goto('/');
     await waitForAppInit(page);
     await dismissOnboarding(page);
 
-    // 먼저 구인구직 탭으로 이동 (탭 클릭)
-    const jobsTab = page.getByRole('tab', { name: '구인구직' });
-    const jobsTabVisible = await jobsTab.isVisible().catch(() => false);
-    if (jobsTabVisible) {
-      await jobsTab.click();
-      await page.waitForTimeout(500);
-    }
+    // 홈 진입 확인
+    await expect(page.getByText('다음 근무').first()).toBeVisible({ timeout: 15_000 });
 
-    // 헤더의 UNIQN 로고 클릭
+    // HomeTabBar 의 "구인구직 탭으로 이동" button click → /(app)/(tabs) 진입
+    const jobsTabButton = page.getByRole('button', { name: '구인구직 탭으로 이동' });
+    await expect(jobsTabButton).toBeVisible({ timeout: 10_000 });
+    await jobsTabButton.click();
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForTimeout(800);
+
+    // 탭 헤더의 UNIQN 로고 click → home 복귀
     const logoButton = page.getByRole('button', { name: 'UNIQN 홈으로 이동' });
     await expect(logoButton).toBeVisible({ timeout: 10_000 });
     await logoButton.click();

--- a/uniqn-mobile/e2e/tests/p2-standard/jobs-home.spec.ts
+++ b/uniqn-mobile/e2e/tests/p2-standard/jobs-home.spec.ts
@@ -7,13 +7,10 @@ import { HomePage } from '../../pages/app/tabs/home.page';
 
 // storageState는 chromium 프로젝트에서 staff.json으로 자동 설정됨
 
-// SKIP: featureFlags.home_dashboard_enabled=true(default) 도입 후 staff/employer 인증
-// entry route 가 `(app)/(tabs)`(=jobs) 에서 `(app)/home`(standalone dashboard) 으로 변경됨.
-// 이 spec 의 11 test 모두 "/ 진입 = jobs 페이지" 를 전제로 작성됐으나 실제 master 흐름은
-// home dashboard → "공고 보기" CTA / sidebar 진입 → tabs/index. CTA click 후에도
-// (app)/_layout 의 redirect 로직이 다시 (app)/home 으로 보내므로 page object level fix 불가.
-// jobs 페이지를 검증하는 새 spec 작성 (follow-up issue) 까지 .skip.
-test.describe.skip('구인구직 홈', () => {
+// PR #119: HomePage.goto() 가 home_dashboard_enabled 도입 후 새 entry flow 처리 —
+// /home → "공고 보기" CTA click → /(app)/(tabs) 진입. (app)/_layout / (tabs)/_layout
+// 에 강제 redirect 로직은 실제로 없으므로 page object 만으로 정상 nav 가능. unskip 시도.
+test.describe('구인구직 홈', () => {
   let homePage: HomePage;
 
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Summary

- Cat 1 entry route 회귀 15 tests (4 spec 파일) 재작성 + 재활성화
- featureFlags.home_dashboard_enabled=true (default) 도입 후 staff entry 가 (app)/(tabs) → (app)/home (standalone) 변경된 master 흐름 반영
- 잔존: 24 → 9 skip 예상

## Changes

### `e2e/tests/p2-standard/jobs-home.spec.ts` (11 tests)
- `test.describe.skip` → `test.describe`
- HomePage.goto() 가 이미 새 entry flow 처리 (`/home` → "공고 보기" CTA → `/(app)/(tabs)`)
- (app)/_layout / (tabs)/_layout 강제 redirect 없음 확인

### `e2e/tests/p1-important/home-navigation-staff.spec.ts:47` (1 test)
- 시나리오 재작성: `/home` → HomeTabBar "구인구직 탭으로 이동" → 탭 진입 → UNIQN 로고 click → home 복귀
- 기존 `getByRole('tab')` 폐기 — HomeTabBar 는 `<Pressable accessibilityRole="button">`

### `e2e/tests/p1-important/home-logo-no-stack-accumulation.spec.ts` (2 tests)
- `test.describe.skip` → `test.describe`
- 시나리오 1: 홈에서 로고 10번 click — `router.replace` 로 history 누적 없음 검증
- 시나리오 2: 탭 진입 후 로고 5번 click — 첫 click 만 push, 나머지 4번 self-replace. history.length 증가 최대 +2

### `e2e/tests/p0-critical/e2e-user-journeys.spec.ts:188` (1 test)
- HomeTabBar "프로필 탭으로 이동" button 으로 (tabs)/profile 진입
- StackHeader title='설정' 은 heading role 없음 → `page.getByText('설정').first()`

## Why

이전 PR (#107, #108) 에서 `home_dashboard_enabled` 도입 회귀로 spec 의 entry 전제 (/ = jobs) 가 깨지자 .skip 처리. 그러나 page object (`HomePage.goto`) 는 새 flow 처리 로직을 이미 가지고 있고 (`(app)/_layout` 강제 redirect 없음 확인), HomeTabBar 의 accessibilityLabel ("구인구직 탭으로 이동", "프로필 탭으로 이동") 으로 selector 재작성 가능.

## Test plan

- [ ] CI e2e workflow 통과 (gate 활성, 일부 fail 발생 시 해당 test 만 skip 처리하는 follow-up PR 분리)
- [ ] jobs-home 11 tests PASS (HomePage page object 로 새 flow nav)
- [ ] home-navigation-staff 3 tests PASS (1 unskip + 2 기존)
- [ ] home-logo-no-stack-accumulation 2 tests PASS
- [ ] e2e-user-journeys 4 tests PASS (1 unskip + 3 기존)
- [ ] 잔존 9 skip (Cat 4 B collaborator 2 + board:124 1 + admin-report-resolution scenario 2 3 + cancellation env-conditional 등 환경 조건부)

## 관련

- PR #107/#108 — 이 회귀의 도입 시점
- PR #117 — cancellation serial mode fix (직전 진행)
- 메모리: project_e2e_gate_activated.md (잔존 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)