### PR TITLE
test(e2e): collaborator 2 tests 재시도 (PR #120 follow-up)

### DIFF
--- a/uniqn-mobile/e2e/tests/p1-important/collaborator-self-leave.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/collaborator-self-leave.spec.ts
@@ -92,10 +92,13 @@ test.describe('Collaborator Self Leave', () => {
     }
   });
 
-  // PR #120 follow-up: 재시도. PR #114 iter 1 "RangeError" 진단 부정확. employer-
-  // collaborator-add 와 동일 path 라 함께 진단. collaborator-shared-postings 는
-  // 같은 qa-collaborator 로 통과하므로 auth path 는 정상 — 페이지 자체 이슈.
-  test('collaborator 가 "나가기" 버튼 클릭 후 공유받은 공고에서 사라진다', async ({ page }) => {
+  // CI #121 재시도 fail: employer-collaborator-add.spec.ts 와 동일 패턴 — 1.2 min
+  // hang + RangeError. collaborator-shared-postings 는 같은 qa-collaborator 로 통과
+  // 하므로 auth/storage 정상. `/my-postings/{id}/collaborators` 페이지 자체 이슈.
+  // 자세한 진단 노트는 employer-collaborator-add.spec.ts 참고.
+  test.skip('collaborator 가 "나가기" 버튼 클릭 후 공유받은 공고에서 사라진다', async ({
+    page,
+  }) => {
     // 1) 협업자 관리 페이지 (collaborator 시점 — owner 아님)
     await page.goto(`/my-postings/${jobPostingId}/collaborators`);
     await waitForReady(page);

--- a/uniqn-mobile/e2e/tests/p1-important/collaborator-self-leave.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/collaborator-self-leave.spec.ts
@@ -92,11 +92,10 @@ test.describe('Collaborator Self Leave', () => {
     }
   });
 
-  // CI #114 iter 1 fail: URL group prefix 제거 후에도 22.7s hang + RangeError.
-  // employer-collaborator-add.spec 와 동일 패턴 — useJobDetail/JPC RLS 추정.
-  test.skip('collaborator 가 "나가기" 버튼 클릭 후 공유받은 공고에서 사라진다', async ({
-    page,
-  }) => {
+  // PR #120 follow-up: 재시도. PR #114 iter 1 "RangeError" 진단 부정확. employer-
+  // collaborator-add 와 동일 path 라 함께 진단. collaborator-shared-postings 는
+  // 같은 qa-collaborator 로 통과하므로 auth path 는 정상 — 페이지 자체 이슈.
+  test('collaborator 가 "나가기" 버튼 클릭 후 공유받은 공고에서 사라진다', async ({ page }) => {
     // 1) 협업자 관리 페이지 (collaborator 시점 — owner 아님)
     await page.goto(`/my-postings/${jobPostingId}/collaborators`);
     await waitForReady(page);

--- a/uniqn-mobile/e2e/tests/p1-important/employer-collaborator-add.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/employer-collaborator-add.spec.ts
@@ -86,10 +86,24 @@ test.describe('Employer Collaborator Add', () => {
     }
   });
 
-  // PR #120 follow-up: useAuthGuard root redirect 가 jobs-home fail 의 원인이었으나
-  // 협업자 페이지는 /(employer) group route 라 해당 영향 없음. CI #114 iter 1 의
-  // "RangeError" 진단은 부정확했으므로 재시도해서 실제 fail 원인 확인.
-  test('employer 가 collaborator 를 추가하면 "현재 협업자" 섹션에 표시된다', async ({ page }) => {
+  // CI #121 (run 26002529355) 재시도 fail: `/my-postings/{id}/collaborators` 페이지가
+  // 1.2 min hang + `RangeError: apiRequestContext._wrapApiCall: Invalid string length`.
+  // "협업자 추가" 텍스트 `Received: undefined` — 페이지가 owner view 미렌더.
+  //
+  // shared-postings (같은 qa-collaborator) 는 통과하므로 auth/storage 정상. 이 페이지
+  // 자체 (`app/(employer)/my-postings/[id]/collaborators.tsx`) 의:
+  //  - useJobDetail / useJobPostingCollaborators realtime subscription
+  //  - 또는 isOwner 분기 (jobPosting.ownerId === currentUserId)
+  // 가 infinite render loop 또는 massive console 가능성. RangeError 는 Playwright
+  // 내부 logger 가 그 결과로 limit hit.
+  //
+  // **production-side 진단 필요** (별도 PR):
+  //  1. createRealtimeSubscription 의 무한 retry 검증
+  //  2. isOwner 분기 — auth state 가 정상 currentUserId 반환하는지
+  //  3. page 가 Stack.Screen presentation='modal' 로 web 에서 rendering 문제 있는지
+  test.skip('employer 가 collaborator 를 추가하면 "현재 협업자" 섹션에 표시된다', async ({
+    page,
+  }) => {
     await page.goto(`/my-postings/${jobPostingId}/collaborators`);
     await waitForReady(page);
 

--- a/uniqn-mobile/e2e/tests/p1-important/employer-collaborator-add.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/employer-collaborator-add.spec.ts
@@ -86,12 +86,10 @@ test.describe('Employer Collaborator Add', () => {
     }
   });
 
-  // CI #114 iter 1 fail: URL group prefix 제거 후에도 1.2 min hang + RangeError.
-  // 페이지가 로드되나 '협업자 추가' 헤더가 render 되지 않음 (isOwner=false 또는 useJobDetail RLS 차단 추정).
-  // 별도 follow-up PR 에서 useJobPostingCollaborators RPC + RLS 검증 필요.
-  test.skip('employer 가 collaborator 를 추가하면 "현재 협업자" 섹션에 표시된다', async ({
-    page,
-  }) => {
+  // PR #120 follow-up: useAuthGuard root redirect 가 jobs-home fail 의 원인이었으나
+  // 협업자 페이지는 /(employer) group route 라 해당 영향 없음. CI #114 iter 1 의
+  // "RangeError" 진단은 부정확했으므로 재시도해서 실제 fail 원인 확인.
+  test('employer 가 collaborator 를 추가하면 "현재 협업자" 섹션에 표시된다', async ({ page }) => {
     await page.goto(`/my-postings/${jobPostingId}/collaborators`);
     await waitForReady(page);
 


### PR DESCRIPTION
## Summary

PR #114 iter 1 의 "RangeError + 1.2 min hang" 진단은 PR #120 분석으로 부정확했음이
밝혀짐 (RangeError 는 단일 원인이 아니라 4가지 별개 원인의 우연한 동시 발생).
협업자 페이지는 /(employer) group route 라 useAuthGuard root redirect 영향 없음.

## Tests 재활성화

1. \`employer-collaborator-add.spec.ts:92\` (chromium-employer) — qa-employer 시점
2. \`collaborator-self-leave.spec.ts:97\` (chromium-collaborator) — qa-collaborator 시점

같은 path \`/my-postings/{id}/collaborators\` 사용. \`collaborator-shared-postings\` 는
같은 qa-collaborator 로 PASSING — auth/storage state 정상.

## 가설

- 가설 A: useJobDetail 데이터 늦게 도착 → isOwner=false 분기 → "협업자 추가" 미렌더
- 가설 B: jobPosting.ownerId 매핑 mismatch (toCamelCase 검증됨, 가능성 낮음)
- 가설 C: useJobPostingCollaborators RLS 차단으로 페이지 hang

CI artifact 페이지 스냅샷으로 실제 상태 확인 후 진단.

## Test plan

- [ ] e2e workflow 통과 (1) 또는 (2) 명확한 fail 메시지 + 페이지 스냅샷 수집
- [ ] 통과 시: 회복 2 tests, master 머지
- [ ] Fail 시: artifact 분석으로 실제 원인 식별, 추가 fix 또는 re-skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)