### PR TITLE
fix(useAuthGuard): root URL '/' redirect skip when in-app group segment present

### DIFF
--- a/uniqn-mobile/src/hooks/__tests__/useAuthGuard.test.ts
+++ b/uniqn-mobile/src/hooks/__tests__/useAuthGuard.test.ts
@@ -338,6 +338,48 @@ describe('useAuthGuard', () => {
     });
   });
 
+  // PR #120 회귀 가드: HomeTabBar 의 router.push('/(app)/(tabs)') 가
+  // expo-router web 에서 URL '/' 로 group erasure 되는데, ROUTE_CONFIGS 에 없는
+  // '(tabs)' 만 segments 에 남으면 routeGroup=null 로 root 분기 진입.
+  // 이전엔 redirect 가 발동해 staff 가 (tabs) 에 도달 불가.
+  // group segment 가 하나라도 있으면 의도된 in-app 네비게이션이므로 redirect 건너뛴다.
+  it('does not redirect authenticated users to home when navigating into a tabs group at root URL', async () => {
+    mockPathname = '/';
+    mockSegments = ['(tabs)'];
+    mockAuthState.user = { uid: 'staff-1', email: 'staff@example.com', phoneNumber: null };
+    mockAuthState.profile = {
+      role: 'staff',
+      socialProvider: null,
+      phoneVerified: true,
+      profileCompleted: true,
+    };
+
+    renderHook(() => useAuthGuard());
+
+    await waitFor(() => {
+      // hook ran (effect synchronously dispatched)
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+  });
+
+  it('still redirects authenticated users to home on a true root entry with empty segments', async () => {
+    mockPathname = '/';
+    mockSegments = [];
+    mockAuthState.user = { uid: 'staff-1', email: 'staff@example.com', phoneNumber: null };
+    mockAuthState.profile = {
+      role: 'staff',
+      socialProvider: null,
+      phoneVerified: true,
+      profileCompleted: true,
+    };
+
+    renderHook(() => useAuthGuard());
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/(app)/home');
+    });
+  });
+
   it('normalizes phone-only sessions off the social signup flow', async () => {
     mockPathname = '/signup';
     mockSegments = ['(auth)', 'signup'];

--- a/uniqn-mobile/src/hooks/useAuthGuard.ts
+++ b/uniqn-mobile/src/hooks/useAuthGuard.ts
@@ -212,8 +212,18 @@ export function useAuthGuard(): void {
     if (!routeGroup) {
       const isRouterRootPath = pathname === '/' || pathname === '/index';
       const isBrowserRootPath = browserPathname === '/' || browserPathname === '/index';
+      // expo-router 의 route group erasure 로 URL '/' 이지만 segments 에 in-app
+      // 그룹 식별자(예: '(tabs)')가 남은 상태가 존재. 이 때 root redirect 가
+      // 발동하면 사용자가 (tabs) 진입 시 즉시 home 으로 튕긴다.
+      // 예: HomeTabBar 의 router.push('/(app)/(tabs)') → URL '/' 로 erase,
+      // segments=['(tabs)']. ROUTE_CONFIGS 에 '(tabs)' 없으므로 routeGroup=null,
+      // 이전엔 root branch 진입 → /home replace. 그룹 segment 가 하나라도 있으면
+      // 의도된 in-app 네비게이션으로 간주하고 redirect 건너뛴다.
+      const hasGroupSegments = segments.some(
+        (seg): seg is string => typeof seg === 'string' && seg.startsWith('(') && seg.endsWith(')')
+      );
 
-      if (isRouterRootPath && isBrowserRootPath && isAuthenticated) {
+      if (isRouterRootPath && isBrowserRootPath && isAuthenticated && !hasGroupSegments) {
         logger.debug('Authenticated user entered root route', {
           component: 'useAuthGuard',
           pathname,


### PR DESCRIPTION
## Summary

- `useAuthGuard` 의 root '/' redirect 분기가 `segments` 에 `(...)` 그룹 식별자가 하나라도 있으면 건너뛰도록 가드 추가
- HomeTabBar 의 `router.push('/(app)/(tabs)')` 가 expo-router web 에서 URL `/` 로 group erasure 되는 회귀(PR #120 1차 CI fail) 의 production-side fix
- jest 회귀 가드 2건 추가

## 근본 원인

`router.push('/(app)/(tabs)')` 호출 시 expo-router 가 URL '/' 로 erase. `segments` 는 `['(tabs)']` (또는 유사) 형태로 남는데, `ROUTE_CONFIGS` 에 '(tabs)' 가 없어 `extractRouteGroup` 이 null 반환. 이전 코드는 `!routeGroup && pathname==='/' && isAuthenticated` 만 검사해 root redirect 발동 → 사용자가 즉시 `/home` 으로 튕김.

PR #120 CI artifact:
```
/tmp/pr120-results/p2-standard-jobs-home-구인구직-홈-헤더와-검색바가-표시된다-chromium/error-context.md
```
HomeTabBar click 후에도 페이지 스냅샷이 `/home` 상태 그대로.

## 변경

`uniqn-mobile/src/hooks/useAuthGuard.ts:212-225`

```ts
const hasGroupSegments = segments.some(
  (seg): seg is string => typeof seg === 'string' && seg.startsWith('(') && seg.endsWith(')')
);

if (isRouterRootPath && isBrowserRootPath && isAuthenticated && !hasGroupSegments) {
  // redirect 발동 (true root entry 만)
}
```

- `segments=['(tabs)']` → `hasGroupSegments=true` → redirect skip (신규)
- `segments=['(app)','(tabs)']` → `routeGroup='(app)'` → 기존 (app) 분기 처리 (변경 없음)
- `segments=[]` → `hasGroupSegments=false` → redirect 발동 (initial entry, 기존 동작 유지)

## 후속 PR

이 PR 머지 후:
1. `e2e/tests/p2-standard/jobs-home.spec.ts:19` describe.skip → describe (11 tests)
2. `e2e/tests/p1-important/home-logo-no-stack-accumulation.spec.ts:73` test.skip → test (1 test)
3. `e2e/tests/p1-important/home-navigation-staff.spec.ts:49` test.skip → test (1 test)

총 13 tests 재활성화 예정.

## Test plan

- [x] `npx jest src/hooks/__tests__/useAuthGuard.test.ts` — 18/18 통과 (기존 16 + 신규 2)
- [x] `npx tsc --noEmit` — exit 0
- [x] `npx eslint` — clean
- [x] `npx prettier --check` — clean
- [ ] e2e workflow 통과 — CI 대기
- [ ] 머지 후 후속 PR 에서 Cat 1 entry route 13 tests unskip 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)