### PR TITLE
test(e2e): Cat 1 entry route 잔존 13 tests 재활성화 (PR #122 fix)

### DIFF
--- a/uniqn-mobile/e2e/tests/p1-important/home-logo-no-stack-accumulation.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/home-logo-no-stack-accumulation.spec.ts
@@ -66,11 +66,8 @@ test.describe('홈 로고 탭 스택 누적 방지', () => {
     expect(finalHistoryLength - initialHistoryLength).toBeLessThanOrEqual(2);
   });
 
-  // CI #120 fail: /home → "구인구직 탭으로 이동" click 후에도 페이지가 /(tabs) 로
-  // 이동 안 함 (artifact 페이지 스냅샷 /home 그대로). useAuthGuard 의 root '/' →
-  // resolvedAuthenticatedRoute (=/home) replace 가 의심됨. 별도 production-side fix
-  // 필요 (E2E opt-out 또는 useAuthGuard 의 root redirect 조건 재검토).
-  test.skip('탭에서 홈 로고 5번 탭 후 history 가 비정상 증가하지 않는다', async ({ page }) => {
+  // PR #122 (useAuthGuard root redirect group segment guard) 머지로 (tabs) 진입 정상화.
+  test('탭에서 홈 로고 5번 탭 후 history 가 비정상 증가하지 않는다', async ({ page }) => {
     await page.goto('/');
     await waitForAppInit(page);
     await dismissOnboarding(page);

--- a/uniqn-mobile/e2e/tests/p1-important/home-navigation-staff.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/home-navigation-staff.spec.ts
@@ -42,11 +42,8 @@ test.describe('홈 네비게이션 — Staff', () => {
     await expect(page.getByText('내 지원 현황').first()).toBeVisible({ timeout: 10_000 });
   });
 
-  // CI #120 fail: /home → "구인구직 탭으로 이동" click 후 페이지가 /(tabs) 로
-  // 이동 안 함 (artifact 페이지 스냅샷 /home 그대로). useAuthGuard 의 root '/' →
-  // resolvedAuthenticatedRoute (=/home) replace 가 의심됨. 별도 production-side fix
-  // 필요 (E2E opt-out 또는 useAuthGuard 의 root redirect 조건 재검토).
-  test.skip('홈 → 탭 진입 → UNIQN 로고 탭으로 홈 복귀', async ({ page }) => {
+  // PR #122 (useAuthGuard root redirect group segment guard) 머지로 (tabs) 진입 정상화.
+  test('홈 → 탭 진입 → UNIQN 로고 탭으로 홈 복귀', async ({ page }) => {
     await page.goto('/');
     await waitForAppInit(page);
     await dismissOnboarding(page);

--- a/uniqn-mobile/e2e/tests/p2-standard/jobs-home.spec.ts
+++ b/uniqn-mobile/e2e/tests/p2-standard/jobs-home.spec.ts
@@ -7,16 +7,9 @@ import { HomePage } from '../../pages/app/tabs/home.page';
 
 // storageState는 chromium 프로젝트에서 staff.json으로 자동 설정됨
 
-// CI #120 fail: HomePage.goto() 의 HomeTabBar/CTA click 모두 (tabs) 로 navigation
-// 안 됨 — artifact 페이지 스냅샷이 /home 그대로. useAuthGuard.ts:213-225 의
-// `if (isRouterRootPath && isBrowserRootPath && isAuthenticated)` 분기가 root URL
-// '/' 진입을 항상 resolvedAuthenticatedRoute(=/home for staff) 로 replace.
-// HomeTabBar 의 router.push('/(app)/(tabs)') 가 URL `/` 로 해석되면서 same redirect 발동.
-// Fix 옵션 (별도 PR):
-//   1. useAuthGuard root redirect 에 segments 검사 추가 (이미 (app)/(tabs) 인 경우 skip)
-//   2. featureFlags.home_dashboard_enabled 에 E2E opt-out 추가
-//   3. NextWorkWidget empty-state CTA 와 HomeTabBar 의 '구인구직' route 를 deep-link 화
-test.describe.skip('구인구직 홈', () => {
+// PR #122 (useAuthGuard root redirect group segment guard) 머지로 회귀 해결.
+// segments=['(tabs)'] 같이 in-app group identifier 가 있으면 root redirect skip.
+test.describe('구인구직 홈', () => {
   let homePage: HomePage;
 
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Summary

PR #122 (useAuthGuard root redirect group segment guard) 머지 후 잔존 13 tests 재활성화.

PR #120 1차 CI fail 원인 (`useAuthGuard.ts:213-225` segments=['(tabs)'] 검사 부재) 가 a8dbcecef 에서 해결됐으므로 HomeTabBar click 후 (tabs) navigation 이 정상 동작.

## 대상 (13 tests)

| 파일 | 위치 | tests |
|------|------|-------|
| `p2-standard/jobs-home.spec.ts` | L19 | describe.skip → describe (11 tests) |
| `p1-important/home-logo-no-stack-accumulation.spec.ts` | L73 | test.skip → test (1) |
| `p1-important/home-navigation-staff.spec.ts` | L49 | test.skip → test (1) |

## 검증

- 단위: HomePage page object 의 HomeTabBar fallback 은 PR #120 에서 이미 준비됨 (재활용)
- 회귀 가드: PR #122 가 추가한 unit test 2건 (segments=['(tabs)'] skip / segments=[] redirect) 로 미래 fix 회귀 방지

## Test plan

- [x] 3 파일 unskip + skip 사유 주석 → PR #122 머지 사유 주석으로 치환
- [ ] E2E 13 tests 통과 — CI 대기
- [ ] 머지 후 master e2e gate 0 fail 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)