### PR TITLE
fix(workspace): 신규 employer default workspace 자동 생성 — 공고 등록 차단 해소

### DIFF
--- a/uniqn-mobile/src/services/workspace/__tests__/workspaceService.test.ts
+++ b/uniqn-mobile/src/services/workspace/__tests__/workspaceService.test.ts
@@ -1,0 +1,117 @@
+import { workspaceService } from '@/services/workspace/workspaceService';
+import { BusinessError, ERROR_CODES } from '@/errors';
+import type { Workspace } from '@/types/workspace';
+
+const mockFindAllByMember = jest.fn();
+const mockCreate = jest.fn();
+
+jest.mock('@/repositories', () => ({
+  workspaceRepository: {
+    findAllByMember: (...args: unknown[]) => mockFindAllByMember(...args),
+    create: (...args: unknown[]) => mockCreate(...args),
+  },
+  workspaceMemberRepository: {
+    findByWorkspaceWithUser: jest.fn(),
+    removeViaRpc: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(() => ({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    })),
+  },
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    appError: jest.fn(),
+  },
+}));
+
+function workspace(overrides: Partial<Workspace> = {}): Workspace {
+  return {
+    id: 'ws-1',
+    name: '내 워크스페이스',
+    ownerId: 'employer-1',
+    memberCount: 1,
+    createdAt: '2026-05-01T00:00:00.000Z',
+    updatedAt: '2026-05-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('workspaceService.getDefaultWorkspaceIdForOwner', () => {
+  beforeEach(() => {
+    mockFindAllByMember.mockReset();
+    mockCreate.mockReset();
+  });
+
+  it('owner 워크스페이스가 있으면 가장 오래된 것 반환 (fast path)', async () => {
+    mockFindAllByMember.mockResolvedValueOnce([
+      workspace({ id: 'ws-new', createdAt: '2026-05-10T00:00:00.000Z' }),
+      workspace({ id: 'ws-old', createdAt: '2026-05-01T00:00:00.000Z' }),
+    ]);
+
+    const id = await workspaceService.getDefaultWorkspaceIdForOwner('employer-1');
+
+    expect(id).toBe('ws-old');
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('owner 워크스페이스 0개 → 자동 생성 후 재조회로 복구 (2026-05-19 hotfix)', async () => {
+    mockFindAllByMember
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([workspace({ id: 'ws-auto' })]);
+    mockCreate.mockResolvedValueOnce(workspace({ id: 'ws-auto' }));
+
+    const id = await workspaceService.getDefaultWorkspaceIdForOwner('employer-1');
+
+    expect(id).toBe('ws-auto');
+    expect(mockCreate).toHaveBeenCalledWith('내 워크스페이스');
+    expect(mockFindAllByMember).toHaveBeenCalledTimes(2);
+  });
+
+  it('owner 워크스페이스 0개 + 자동 생성 실패 → BusinessError throw', async () => {
+    mockFindAllByMember.mockResolvedValueOnce([]);
+    mockCreate.mockRejectedValueOnce(new Error('CAP_REACHED'));
+
+    await expect(workspaceService.getDefaultWorkspaceIdForOwner('employer-1')).rejects.toThrow(
+      BusinessError
+    );
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('자동 생성은 성공했지만 재조회도 0개 → BusinessError throw', async () => {
+    mockFindAllByMember.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    mockCreate.mockResolvedValueOnce(workspace({ id: 'ws-orphan' }));
+
+    await expect(
+      workspaceService.getDefaultWorkspaceIdForOwner('employer-1')
+    ).rejects.toMatchObject({
+      code: ERROR_CODES.BUSINESS_INVALID_STATE,
+    });
+  });
+
+  it('다른 사람이 owner 인 워크스페이스만 있으면 (멤버 only) → 자동 생성 시도', async () => {
+    mockFindAllByMember
+      .mockResolvedValueOnce([workspace({ ownerId: 'other-employer' })])
+      .mockResolvedValueOnce([
+        workspace({ ownerId: 'other-employer' }),
+        workspace({ id: 'ws-auto', ownerId: 'employer-1' }),
+      ]);
+    mockCreate.mockResolvedValueOnce(workspace({ id: 'ws-auto' }));
+
+    const id = await workspaceService.getDefaultWorkspaceIdForOwner('employer-1');
+
+    expect(id).toBe('ws-auto');
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/uniqn-mobile/src/services/workspace/workspaceService.ts
+++ b/uniqn-mobile/src/services/workspace/workspaceService.ts
@@ -75,24 +75,46 @@ export const workspaceService = {
    * 무료 공고 생성 (`jobManagementService.createJobPosting`) 경로에서
    * `workspace_id NOT NULL` 제약 (M3) 충족용. M5 wallet RPC 와 동일 정책 (created_at ASC).
    *
-   * backfill 후 모든 active employer 는 워크스페이스 1+ 보유 가정.
-   * 0개인 경우 BUSINESS_INVALID_STATE — 사용자에게 재시도 안내.
+   * 2026-05-19 hotfix: 신규 employer (backfill 2026-05-07 이후 가입) + staff→employer 역할 변경자는
+   * default workspace 부재 가능. 0개 발견 시 자동 생성 + 재조회 (안전망).
+   * 영구 해결은 handle_new_user trigger 의 employer 자동 workspace 생성 (마이그레이션 20260519).
    *
-   * @throws BusinessError E6 워크스페이스 없음
+   * @throws BusinessError E6 워크스페이스 없음 (자동 생성도 실패한 경우)
    */
   async getDefaultWorkspaceIdForOwner(ownerId: string): Promise<string> {
+    const ownedId = await this.pickOwnedWorkspaceId(ownerId);
+    if (ownedId) return ownedId;
+
+    logger.warn('default workspace not found — auto-creating', { ownerId });
+    try {
+      await workspaceRepository.create('내 워크스페이스');
+    } catch (createError) {
+      logger.error('default workspace auto-create 실패', {
+        ownerId,
+        error: String(createError),
+      });
+      throw new BusinessError(ERROR_CODES.BUSINESS_INVALID_STATE, {
+        userMessage: '워크스페이스를 찾을 수 없어요. 잠시 후 다시 시도해주세요.',
+        metadata: { ownerId, autoCreateFailed: true },
+      });
+    }
+
+    const retryId = await this.pickOwnedWorkspaceId(ownerId);
+    if (retryId) return retryId;
+
+    logger.error('default workspace not found after auto-create', { ownerId });
+    throw new BusinessError(ERROR_CODES.BUSINESS_INVALID_STATE, {
+      userMessage: '워크스페이스를 찾을 수 없어요. 잠시 후 다시 시도해주세요.',
+      metadata: { ownerId, retryAfterCreate: true },
+    });
+  },
+
+  async pickOwnedWorkspaceId(ownerId: string): Promise<string | null> {
     const workspaces = await workspaceRepository.findAllByMember(ownerId);
     const owned = workspaces
       .filter((w) => w.ownerId === ownerId)
       .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
-    if (owned.length === 0) {
-      logger.warn('default workspace not found', { ownerId });
-      throw new BusinessError(ERROR_CODES.BUSINESS_INVALID_STATE, {
-        userMessage: '워크스페이스를 찾을 수 없어요. 잠시 후 다시 시도해주세요.',
-        metadata: { ownerId },
-      });
-    }
-    return owned[0]!.id;
+    return owned[0]?.id ?? null;
   },
 
   /**

--- a/uniqn-mobile/supabase/migrations/20260519223300_handle_new_user_employer_default_workspace.sql
+++ b/uniqn-mobile/supabase/migrations/20260519223300_handle_new_user_employer_default_workspace.sql
@@ -1,0 +1,68 @@
+-- handle_new_user 트리거 확장 — employer 가입 시 default workspace 자동 생성
+--
+-- 문제: 2026-05-07 backfill 마이그레이션은 일회성이라 그 이후 가입한 employer 는
+-- default workspace 가 없음. 공고 등록 시 jobManagementService.createJobPosting →
+-- workspaceService.getDefaultWorkspaceIdForOwner 가 0개 발견하고
+-- "워크스페이스를 찾을 수 없어요" 에러 throw → 신규 가입자는 공고 등록 차단.
+--
+-- 해결: handle_new_user 안에서 role='employer' 일 때 자동으로 workspace INSERT.
+-- 워크스페이스 이름은 backfill 마이그레이션과 동일한 COALESCE 패턴 (LEFT 40자 안전).
+-- workspace INSERT 가 실패해도 회원가입 자체는 성공하도록 EXCEPTION 블록으로 격리
+-- (실패 시 클라이언트 fallback workspaceService.getDefaultWorkspaceIdForOwner 가
+-- 자동 생성으로 복구).
+--
+-- 호환: SECURITY DEFINER 라 RLS workspaces_insert_employer_with_cap 우회.
+-- staff/admin/staff→employer 역할 변경은 다음 별도 trigger 또는 클라이언트 fallback 처리.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_provider text;
+  v_role public.user_role;
+  v_workspace_name text;
+BEGIN
+  v_provider := NEW.raw_app_meta_data ->> 'provider';
+  v_role := COALESCE((NEW.raw_app_meta_data ->> 'role')::public.user_role, 'staff');
+
+  INSERT INTO public.users (id, email, name, role, social_provider)
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.email, ''),
+    COALESCE(NEW.raw_user_meta_data ->> 'name', ''),
+    v_role,
+    CASE
+      WHEN v_provider IN ('apple', 'google', 'kakao', 'naver') THEN v_provider
+      ELSE NULL
+    END
+  );
+
+  -- employer 자동 default workspace 생성 (2026-05-07 backfill 후속)
+  IF v_role = 'employer' THEN
+    BEGIN
+      v_workspace_name := COALESCE(
+        NULLIF(LEFT(NEW.raw_user_meta_data ->> 'name', 40), ''),
+        NULLIF(LEFT(SPLIT_PART(COALESCE(NEW.email, ''), '@', 1), 40), ''),
+        '내'
+      ) || ' 워크스페이스';
+
+      INSERT INTO public.workspaces (name, owner_id)
+      VALUES (v_workspace_name, NEW.id);
+    EXCEPTION WHEN OTHERS THEN
+      -- workspace 생성 실패는 회원가입 자체를 막지 않음.
+      -- 클라이언트 fallback (workspaceService.getDefaultWorkspaceIdForOwner)
+      -- 이 첫 공고 등록 시점에 재생성 시도.
+      RAISE WARNING 'handle_new_user: workspace 자동 생성 실패 (user_id=%, error=%)',
+        NEW.id, SQLERRM;
+    END;
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.handle_new_user() IS
+  '신규 가입자 public.users INSERT + employer 일 경우 default workspace 자동 생성 (2026-05-19 hotfix). workspace 실패는 회원가입 차단하지 않음 (클라이언트 fallback 안전망).';


### PR DESCRIPTION
## Summary

- **Bug**: 2026-05-07 backfill 마이그레이션 이후 가입한 신규 employer 가 공고 등록 시도 시 "워크스페이스를 찾을 수 없어요. 잠시 후 다시 시도해주세요." 에러로 차단됨. 막힌 사용자 1명 (최원석) 보고 후 발견
- **Root cause**: `handle_new_user` 트리거가 `public.users` INSERT 만 수행하고 employer default workspace 는 만들지 않음. backfill 은 일회성이라 그 이후 가입자는 계속 0개 상태로 남음. `workspaceService.getDefaultWorkspaceIdForOwner` 가 owner workspace 0개 발견 시 `BusinessError(BUSINESS_INVALID_STATE)` throw → `createJobPosting` 차단
- **Fix**: 양쪽 다 — DB trigger 확장 (영구 해결) + 클라이언트 fallback (안전망)

## 변경 내역

### 1. DB trigger 확장 (영구 해결)

`uniqn-mobile/supabase/migrations/20260519223300_handle_new_user_employer_default_workspace.sql`

- `handle_new_user` 안에서 `v_role = 'employer'` 일 때 `public.workspaces` 자동 INSERT
- 이름 결정: \`COALESCE(LEFT(name,40), LEFT(email_local,40), '내') || ' 워크스페이스'\`
- `EXCEPTION WHEN OTHERS` 블록 — workspace INSERT 실패해도 회원가입 자체는 통과 (클라이언트 fallback 안전망에 위임)
- `SECURITY DEFINER` 라 `workspaces_insert_employer_with_cap` RLS 우회

### 2. 클라이언트 fallback (안전망)

`uniqn-mobile/src/services/workspace/workspaceService.ts`

- `getDefaultWorkspaceIdForOwner` 가 owner workspace 0개 발견 시 `workspaceRepository.create('내 워크스페이스')` 자동 호출 후 재조회
- staff → employer **역할 변경** 케이스 (trigger 가 fire 안 하는 시나리오) 커버
- `pickOwnedWorkspaceId` private helper 추출 (fast path + retry 공통)

### 3. 회귀 테스트

`uniqn-mobile/src/services/workspace/__tests__/workspaceService.test.ts` (신규 5건)

- ✅ owner workspace 있으면 가장 오래된 것 반환 (fast path, create 호출 0회)
- ✅ owner 0개 → 자동 생성 후 재조회로 복구
- ✅ owner 0개 + 자동 생성 실패 → BusinessError throw
- ✅ 자동 생성 성공했지만 재조회도 0개 → BusinessError throw
- ✅ 다른 사람이 owner 인 workspace 만 있으면 (멤버 only) → 자동 생성 시도

Red-Green 검증: fix 제거 시 3건 fail → 복원 시 5건 pass

## Prod 적용 상태

- ✅ DB trigger 마이그레이션 **이미 prod 적용 완료** (Supabase MCP `apply_migration`)
- ✅ 막힌 사용자 1명 (`4de7cc0e-...` / 최원석) workspace 수동 INSERT 완료
- ✅ 검증: `employers without workspace = 0`

이 PR 머지는 클라이언트 fallback 코드 + 회귀 테스트 + 마이그레이션 파일 (소스 트리 동기화) 반영용. **prod hot path 는 이미 회복된 상태**.

## Test plan

- [x] `npx tsc --noEmit` → EXIT=0
- [x] `npx jest src/services/workspace/__tests__/workspaceService.test.ts` → 5/5 pass
- [x] workspace + jobManagement 18 testsuites / 153 tests pass (회귀 없음)
- [x] pre-commit hook (lint --fix + prettier --write) 통과
- [x] pre-push quality gate (`npm run quality` = type-check + lint + format:check) 통과
- [ ] CI 통과 확인
- [ ] EAS update 로 모바일 클라이언트 fallback 배포 (별도 진행)
- [ ] Cloudflare Pages 재배포 (웹) — `node scripts/deploy-cloudflare.js --force`

## 관련 메모리

- `pitfall_employer_signup_no_default_workspace.md` (신규)

🤖 Generated with [Claude Code](https://claude.com/claude-code)