### PR TITLE
fix(apply): 시간 미정(TBA) 슬롯 지원 차단 + 모달 뒤 가려진 피드백 노출

### DIFF
--- a/uniqn-mobile/app/(app)/jobs/[id]/apply.tsx
+++ b/uniqn-mobile/app/(app)/jobs/[id]/apply.tsx
@@ -2,8 +2,8 @@
  * UNIQN Mobile - Job Apply Screen
  */
 
-import { useState, useCallback } from 'react';
-import { View, Text } from 'react-native';
+import { useState, useCallback, useRef } from 'react';
+import { Alert, View, Text } from 'react-native';
 import { useLocalSearchParams, router, Stack } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useQueryClient } from '@tanstack/react-query';
@@ -15,7 +15,7 @@ import { AlertTriangleIcon, CheckCircleIcon, InformationCircleIcon } from '@/com
 import { useJobDetail, useApplications, useHasAppliedToJob } from '@/hooks';
 import { resolveSessionUserId } from '@/hooks/internal/sessionUserId';
 import { getJobDetailQueryOptions } from '@/hooks/useJobDetail';
-import { useAuthStore, useToastStore } from '@/stores';
+import { useAuthStore } from '@/stores';
 import { STATUS } from '@/constants';
 import { getClosingStatus } from '@/utils/job-posting/dateUtils';
 import { isSupportedReleasePosting } from '@/utils/jobPostingVisibility';
@@ -94,9 +94,10 @@ export default function ApplyScreen() {
   const storeUserId = useAuthStore((state) => state.user?.uid);
   const isAuthInitialized = useAuthStore((state) => state.isInitialized);
   const userId = resolveSessionUserId(storeUserId, isAuthInitialized);
-  const { addToast } = useToastStore();
   const queryClient = useQueryClient();
   const [showForm, setShowForm] = useState(true);
+  // 제출 in-flight 가드 (더블탭 중복 제출 방지). submitApplication 의 throttle 을 대체.
+  const submitInFlightRef = useRef(false);
 
   const {
     job,
@@ -105,7 +106,7 @@ export default function ApplyScreen() {
     refresh: refreshJob,
   } = useJobDetail(id ?? '');
 
-  const { submitApplication, isSubmitting, hasApplied } = useApplications();
+  const { submitApplicationAsync, isSubmitting, hasApplied } = useApplications();
   const {
     data: hasAppliedDirect = false,
     isLoading: isCheckingExistingApplication,
@@ -126,58 +127,70 @@ export default function ApplyScreen() {
       preQuestionAnswers: PreQuestionAnswer[] | undefined,
       provisionConsent: { at: string; version: string }
     ) => {
-      if (!job) {
+      // 중복 제출 방지 — fetchQuery await 동안 isSubmitting 이 아직 false 라 버튼이 활성이므로
+      // 더블탭 시 두 번 제출될 수 있다(unique 인덱스가 데이터 중복은 막지만 2번째는 에러 Alert 노출).
+      if (!job || submitInFlightRef.current) {
         return;
       }
-
-      logger.info('지원서 제출 시작', {
-        jobId: job.id,
-        assignmentsCount: assignments.length,
-        hasPreQuestions: !!preQuestionAnswers,
-      });
+      submitInFlightRef.current = true;
 
       try {
-        const latestJob = await queryClient.fetchQuery<JobPosting | null>({
-          ...getJobDetailQueryOptions(job.id, userId ?? undefined),
-          staleTime: 0,
+        logger.info('지원서 제출 시작', {
+          jobId: job.id,
+          assignmentsCount: assignments.length,
+          hasPreQuestions: !!preQuestionAnswers,
         });
 
-        if (!latestJob) {
-          addToast({ type: 'error', message: '공고를 찾을 수 없습니다' });
-          return;
+        try {
+          const latestJob = await queryClient.fetchQuery<JobPosting | null>({
+            ...getJobDetailQueryOptions(job.id, userId ?? undefined),
+            staleTime: 0,
+          });
+
+          if (!latestJob) {
+            Alert.alert('오류', '공고를 찾을 수 없습니다');
+            return;
+          }
+
+          if (latestJob.status !== STATUS.JOB_POSTING.ACTIVE) {
+            Alert.alert('지원 불가', '지원이 마감된 공고입니다');
+            return;
+          }
+
+          const { total, filled } = getClosingStatus(latestJob);
+          if (total > 0 && filled >= total) {
+            Alert.alert('지원 불가', '모집 인원이 마감되었습니다');
+            return;
+          }
+        } catch (error) {
+          logger.warn('지원 전 최신 공고 검증 실패', { error });
         }
 
-        if (latestJob.status !== STATUS.JOB_POSTING.ACTIVE) {
-          addToast({ type: 'error', message: '지원이 마감된 공고입니다' });
-          return;
+        // mutateAsync + try/catch — 에러 메시지를 네이티브 Alert 로 노출한다.
+        // (전역 onError 토스트는 네이티브 SheetModal 뒤에 가려 안 보이므로)
+        try {
+          await submitApplicationAsync({
+            jobPostingId: job.id,
+            assignments,
+            message,
+            preQuestionAnswers,
+            provisionConsentAt: provisionConsent.at,
+            provisionConsentVersion: provisionConsent.version,
+          });
+          setShowForm(false);
+        } catch (error) {
+          logger.error('지원서 제출 실패', error instanceof Error ? error : undefined);
+          const errorMessage =
+            error instanceof Error
+              ? error.message
+              : '지원 중 오류가 발생했습니다. 다시 시도해 주세요.';
+          Alert.alert('지원 실패', errorMessage);
         }
-
-        const { total, filled } = getClosingStatus(latestJob);
-        if (total > 0 && filled >= total) {
-          addToast({ type: 'error', message: '모집 인원이 마감되었습니다' });
-          return;
-        }
-      } catch (error) {
-        logger.warn('지원 전 최신 공고 검증 실패', { error });
+      } finally {
+        submitInFlightRef.current = false;
       }
-
-      submitApplication(
-        {
-          jobPostingId: job.id,
-          assignments,
-          message,
-          preQuestionAnswers,
-          provisionConsentAt: provisionConsent.at,
-          provisionConsentVersion: provisionConsent.version,
-        },
-        {
-          onSuccess: () => {
-            setShowForm(false);
-          },
-        }
-      );
     },
-    [addToast, job, queryClient, submitApplication, userId]
+    [job, queryClient, submitApplicationAsync, userId]
   );
 
   const handleClose = useCallback(() => {

--- a/uniqn-mobile/src/components/jobs/ApplicationForm.tsx
+++ b/uniqn-mobile/src/components/jobs/ApplicationForm.tsx
@@ -1,6 +1,6 @@
 import { SECONDARY_PALETTE } from '@/constants/colors';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Pressable, Text, TextInput, View } from 'react-native';
+import { Alert, Pressable, Text, TextInput, View } from 'react-native';
 import { buildPostingFacts } from '@/domains/job-posting';
 import { findUnansweredRequired, initializePreQuestionAnswers } from '@/domains/application';
 import { THIRD_PARTY_CONSENT_VERSION_TAG } from '@/constants/legal';
@@ -8,7 +8,6 @@ import { FIXED_DATE_MARKER, FIXED_TIME_MARKER, type Assignment } from '@/types/a
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { SheetModal } from '@/components/ui/SheetModal';
-import { useModalStore } from '@/stores/modalStore';
 import type { JobPosting, PostingType, PreQuestionAnswer } from '@/types';
 import { AssignmentSelector } from './AssignmentSelector';
 import { PostingTypeBadge } from './PostingTypeBadge';
@@ -102,7 +101,6 @@ export function ApplicationForm({
   onClose,
 }: ApplicationFormProps) {
   const postingFacts = useMemo(() => buildPostingFacts(job), [job]);
-  const showConfirm = useModalStore((state) => state.showConfirm);
   const [message, setMessage] = useState('');
   const [selectedAssignments, setSelectedAssignments] = useState<Assignment[]>([]);
   const [selectedFixedRoleId, setSelectedFixedRoleId] = useState<string | null>(null);
@@ -224,12 +222,13 @@ export function ApplicationForm({
       return;
     }
 
-    showConfirm(
-      '작성을 그만할까요?',
-      '입력한 지원 내용은 저장되지 않고 바로 닫힙니다.',
-      handleClose
-    );
-  }, [handleClose, hasUnsavedChanges, isSubmitting, showConfirm]);
+    // 네이티브 Alert 사용 — modalStore 의 ConfirmModal 은 SheetModal(네이티브 RNModal) 뒤에
+    // 가려 안 보여서 사용자가 닫기 확인을 못 한다(= 화면에서 못 나가는 버그).
+    Alert.alert('작성을 그만할까요?', '입력한 지원 내용은 저장되지 않고 바로 닫힙니다.', [
+      { text: '계속 편집', style: 'cancel' },
+      { text: '닫기', style: 'destructive', onPress: handleClose },
+    ]);
+  }, [handleClose, hasUnsavedChanges, isSubmitting]);
 
   const footer = (
     <Button onPress={handleSubmit} disabled={!canSubmit} loading={isSubmitting} fullWidth>

--- a/uniqn-mobile/src/components/jobs/__tests__/ApplicationForm.test.tsx
+++ b/uniqn-mobile/src/components/jobs/__tests__/ApplicationForm.test.tsx
@@ -1,15 +1,7 @@
 import React from 'react';
+import { Alert } from 'react-native';
 import { fireEvent, render } from '@testing-library/react-native';
 import { ApplicationForm } from '../ApplicationForm';
-
-const mockShowConfirm = jest.fn();
-
-jest.mock('@/stores/modalStore', () => ({
-  useModalStore: (selector: (state: { showConfirm: typeof mockShowConfirm }) => unknown) =>
-    selector({
-      showConfirm: mockShowConfirm,
-    }),
-}));
 
 jest.mock('@/domains/job-posting', () => ({
   buildPostingFacts: () => ({
@@ -87,8 +79,16 @@ const job = {
 } as any;
 
 describe('ApplicationForm', () => {
+  let alertSpy: jest.SpyInstance;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    // Alert.alert 은 네이티브 호출 — 테스트에서는 spy 로 가로채 buttons 를 검사한다.
+    alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
   });
 
   it('closes immediately when there are no unsaved changes', () => {
@@ -107,10 +107,10 @@ describe('ApplicationForm', () => {
     fireEvent.press(getByTestId('sheet-request-close'));
 
     expect(onClose).toHaveBeenCalledTimes(1);
-    expect(mockShowConfirm).not.toHaveBeenCalled();
+    expect(alertSpy).not.toHaveBeenCalled();
   });
 
-  it('asks for confirmation before closing when the form is dirty', () => {
+  it('asks for confirmation (native Alert) before closing when the form is dirty', () => {
     const onClose = jest.fn();
 
     const { getByPlaceholderText, getByTestId } = render(
@@ -129,13 +129,21 @@ describe('ApplicationForm', () => {
     );
     fireEvent.press(getByTestId('sheet-request-close'));
 
-    expect(mockShowConfirm).toHaveBeenCalledTimes(1);
-    expect(mockShowConfirm).toHaveBeenCalledWith(
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    expect(alertSpy).toHaveBeenCalledWith(
       '작성을 그만할까요?',
       '입력한 지원 내용은 저장되지 않고 바로 닫힙니다.',
-      expect.any(Function)
+      expect.arrayContaining([
+        expect.objectContaining({ text: '계속 편집' }),
+        expect.objectContaining({ text: '닫기', onPress: expect.any(Function) }),
+      ])
     );
     expect(onClose).not.toHaveBeenCalled();
+
+    // '닫기' 버튼의 onPress 를 실행하면 실제로 닫힌다.
+    const buttons = alertSpy.mock.calls[0][2] as { text: string; onPress?: () => void }[];
+    buttons.find((b) => b.text === '닫기')?.onPress?.();
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   // T4 — P1 지원 시점 동의: 미체크 상태에서는 체크박스가 false 로 노출

--- a/uniqn-mobile/src/domains/application/__tests__/slotCapacity.test.ts
+++ b/uniqn-mobile/src/domains/application/__tests__/slotCapacity.test.ts
@@ -1,0 +1,76 @@
+import type { Assignment, JobPosting } from '@/types';
+import { TBA_TIME_MARKER } from '@/types/assignment';
+import { validateAssignmentSlotCapacity } from '../slotCapacity';
+
+/**
+ * 회귀 테스트 — 시간 미정(TBA) 슬롯 capacity 키 불일치
+ *
+ * 버그(2026-05-20): 시간 미정 dated 공고는 빈자리가 있어도 지원이 100% 차단되었다.
+ * 원인은 buildPostingSlotCapacityMap이 isTimeToBeAnnounced를 무시하고 `slot.startTime ?? ''`만
+ * 써서 capacity 키가 `date____role`인 반면, AssignmentSelector는 TBA 슬롯에 TBA_TIME_MARKER('미정')를
+ * 넣어 요청 키가 `date__미정__role`이 되어 영원히 매칭되지 않았던 것.
+ */
+
+function makeDatedPosting(timeSlot: {
+  startTime?: string;
+  isTimeToBeAnnounced?: boolean;
+  roleCount: number;
+  filled: number;
+}): JobPosting {
+  return {
+    schedule: {
+      kind: 'dated',
+      primaryDate: '2026-05-23',
+      allDates: ['2026-05-23'],
+      requirements: [
+        {
+          date: '2026-05-23',
+          isGrouped: false,
+          timeSlots: [
+            {
+              id: 'slot-1',
+              ...(timeSlot.startTime ? { startTime: timeSlot.startTime } : {}),
+              ...(timeSlot.isTimeToBeAnnounced ? { isTimeToBeAnnounced: true } : {}),
+              roles: [{ role: 'dealer', count: timeSlot.roleCount, filled: timeSlot.filled }],
+            },
+          ],
+        },
+      ],
+    },
+  } as unknown as JobPosting;
+}
+
+function makeAssignment(timeSlot: string): Assignment {
+  return {
+    roleIds: ['dealer'],
+    timeSlot,
+    dates: ['2026-05-23'],
+    isGrouped: false,
+    checkMethod: 'individual',
+  } as Assignment;
+}
+
+describe('validateAssignmentSlotCapacity — TBA(시간 미정) 슬롯', () => {
+  it('빈자리(0/1)가 있는 시간 미정 슬롯은 지원 가능해야 한다 (회귀)', () => {
+    const posting = makeDatedPosting({ isTimeToBeAnnounced: true, roleCount: 1, filled: 0 });
+    const result = validateAssignmentSlotCapacity(posting, [makeAssignment(TBA_TIME_MARKER)]);
+
+    expect(result.available).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('정원이 찬 시간 미정 슬롯(1/1)은 지원 불가여야 한다', () => {
+    const posting = makeDatedPosting({ isTimeToBeAnnounced: true, roleCount: 1, filled: 1 });
+    const result = validateAssignmentSlotCapacity(posting, [makeAssignment(TBA_TIME_MARKER)]);
+
+    expect(result.available).toBe(false);
+    expect(result.firstIssue?.remaining).toBe(0);
+  });
+
+  it('시간이 확정된 슬롯(09:00)은 종전대로 정상 매칭된다', () => {
+    const posting = makeDatedPosting({ startTime: '09:00', roleCount: 1, filled: 0 });
+    const result = validateAssignmentSlotCapacity(posting, [makeAssignment('09:00')]);
+
+    expect(result.available).toBe(true);
+  });
+});

--- a/uniqn-mobile/src/domains/application/slotCapacity.ts
+++ b/uniqn-mobile/src/domains/application/slotCapacity.ts
@@ -1,4 +1,5 @@
 import type { Assignment, JobPosting } from '@/types';
+import { TBA_TIME_MARKER } from '@/types/assignment';
 import { WorkLogCreator } from '@/domains/schedule';
 
 export interface SlotCapacityIssue {
@@ -38,7 +39,11 @@ export function buildPostingSlotCapacityMap(posting: JobPosting): Map<string, Sl
 
   posting.schedule.requirements.forEach((requirement) => {
     requirement.timeSlots.forEach((slot) => {
-      const slotStartTime = WorkLogCreator.extractStartTime(slot.startTime ?? '');
+      // AssignmentSelector.getSlotSelectionTime 과 동일한 해석을 사용해야 한다.
+      // 시간 미정(isTimeToBeAnnounced) 슬롯은 startTime 이 없으므로 TBA_TIME_MARKER 로 키를 만든다.
+      // (이 줄이 startTime 만 보면 요청측 키 `date__미정__role` 과 영원히 불일치 → 빈자리도 마감 처리됨)
+      const slotSelectionTime = slot.isTimeToBeAnnounced ? TBA_TIME_MARKER : (slot.startTime ?? '');
+      const slotStartTime = WorkLogCreator.extractStartTime(slotSelectionTime);
 
       slot.roles.forEach((role) => {
         const roleId = getRoleId(role);

--- a/uniqn-mobile/src/hooks/useApplications.ts
+++ b/uniqn-mobile/src/hooks/useApplications.ts
@@ -314,6 +314,9 @@ export function useApplications() {
     isRefreshing: isOnline ? myApplicationsQuery.isRefetching : false,
     error: isOnline ? myApplicationsQuery.error : null,
     submitApplication: useThrottledCallback(submitV2Mutation.mutate, 1000),
+    // mutateAsync — 호출부에서 await + try/catch 로 에러를 직접 표면화할 때 사용.
+    // (네이티브 모달 위 토스트가 가려지는 문제 회피: 호출부에서 Alert.alert 로 노출)
+    submitApplicationAsync: submitV2Mutation.mutateAsync,
     isSubmitting: submitV2Mutation.isPending,
     cancelApplication: cancelMutation.mutate,
     isCancelling: cancelMutation.isPending,


### PR DESCRIPTION
## 문제
모바일에서 **시간 미정(미정) 날짜형 공고**에 지원하면 빈자리가 있어도 "지원하기"를 눌러도 잠깐 로딩 후 아무 반응 없고, 그 화면에서 나갈 수도 없었음.

## 근본 원인 (웹 dev 재현으로 확정)
`ValidationError: 선택한 날짜 또는 역할의 모집이 마감되었습니다.` (E3001, validation, severity low)

- **TBA 슬롯 capacity 키 불일치**: `buildPostingSlotCapacityMap`이 `isTimeToBeAnnounced`를 무시하고 `slot.startTime ?? ''`만 사용 → capacity 키 `date____role`. 반면 `AssignmentSelector.getSlotSelectionTime`은 TBA 슬롯에 `TBA_TIME_MARKER('미정')`를 넣어 요청 키가 `date__미정__role`. 영원히 매칭 실패 → 빈자리(0/1)에도 "모집 마감". **모든 시간 미정 dated 공고가 지원 100% 차단됨.**
- **에러가 완전히 은폐됨**: validation 에러는 `telemetryChannel: none`이라 Sentry 미전송 + 토스트는 네이티브 `SheetModal`(RN Modal) 뒤에 가려 안 보임. 그래서 "아무것도 안 됨"으로 보였고 원격 로그/Sentry로도 관측 불가였음.

## 수정
- **slotCapacity.ts (P0, 핵심)**: map 빌더가 셀렉터와 동일하게 TBA 슬롯은 `TBA_TIME_MARKER`로 키 생성 → 키 일치
- **apply.tsx**: `submitApplicationAsync`(mutateAsync) + try/catch + `Alert.alert`로 제출 에러를 모달 위에 노출. `submitInFlightRef` 가드로 더블탭 중복 제출 방지(throttle 대체)
- **ApplicationForm.tsx**: 닫기 확인을 `showConfirm`(모달 뒤 안 보임) → 네이티브 `Alert.alert`로 교체 (화면에서 못 나가던 문제 해소)
- **useApplications.ts**: `submitApplicationAsync` 노출

## 검증
- 회귀 테스트 신규 (`slotCapacity.test.ts`): TBA 빈자리 가능 / 정원초과 불가 / 시간확정 정상 — **red→green 확인**
- 영향 스위트 268 테스트 통과 (application 도메인 + jobs + useApplications hook)
- `tsc --noEmit` 0 / eslint 0
- review-staff 계정으로 실제 공고(인천 루원시티 텍사스 5/23 미정 딜러 0/1) 웹 dev 재현 → 에러 캡처 → 수정 확인
- DB 검증: UNIQUE(job_posting_id, applicant_id) 인덱스로 더블탭 데이터 중복 불가 확인

## 영향 범위
시간 미정 dated 공고에 지원하려는 모든 스태프. 고정/시간확정 공고는 영향 없음(그래서 그동안 안 드러남).

🤖 Generated with [Claude Code](https://claude.com/claude-code)