### PR TITLE
fix(auth): signUp 422 orphan 락아웃 self-heal + orphan dead code 제거

### DIFF
--- a/uniqn-mobile/src/repositories/interfaces/IUserRepository.ts
+++ b/uniqn-mobile/src/repositories/interfaces/IUserRepository.ts
@@ -155,17 +155,6 @@ export interface IUserRepository {
   // ==========================================================================
 
   /**
-   * 고아 계정 마킹 (삭제 실패 시 DB에 기록)
-   *
-   * @description Cloud Function Scheduler가 주기적으로 정리
-   * @param uid - 사용자 ID
-   * @param reason - 마킹 사유
-   * @param phone - 전화번호 (선택)
-   * @param platform - 플랫폼 정보
-   */
-  markAsOrphan(uid: string, reason: string, phone?: string, platform?: string): Promise<void>;
-
-  /**
    * 구인자 등록 (Transaction으로 원자적 처리)
    *
    * @description staff → employer 역할 전환

--- a/uniqn-mobile/src/repositories/supabase/UserRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/UserRepository.ts
@@ -33,14 +33,13 @@ const TABLES = {
   APPLICATIONS: 'applications',
   WORK_LOGS: 'work_logs',
   NOTIFICATIONS: 'notifications',
-  ORPHAN_ACCOUNTS: 'orphan_accounts',
   CONSENTS: 'consents',
 } as const;
 // PostgREST alias `identity:identity_data` — DB 컬럼은 identity_data 이지만
 // 응답 필드명은 identity 로 받아 `FirestoreUserProfile.identity` 매핑 유지.
 // 마이그레이션 20260507144735 에서 컬럼이 rename 됨 (PR #56).
 const USER_COLUMNS =
-  'id,birth_date,bubble_score,career,created_at,deletion_requested_at,deletion_scheduled_for,email,employer_agreements,employer_registered_at,experience_years,fcm_tokens,gender,identity:identity_data,identity_provider,identity_verified,identity_verified_at,is_active,is_orphan,marketing_agreed,name,nickname,note,phone,phone_verified,photo_url,photo_url_blurhash,privacy_agreed,profile_completed,region,role,social_provider,status,terms_agreed,updated_at' as const;
+  'id,birth_date,bubble_score,career,created_at,deletion_requested_at,deletion_scheduled_for,email,employer_agreements,employer_registered_at,experience_years,fcm_tokens,gender,identity:identity_data,identity_provider,identity_verified,identity_verified_at,is_active,marketing_agreed,name,nickname,note,phone,phone_verified,photo_url,photo_url_blurhash,privacy_agreed,profile_completed,region,role,social_provider,status,terms_agreed,updated_at' as const;
 
 // ============================================================================
 // Helpers
@@ -389,32 +388,6 @@ export class SupabaseUserRepository implements IUserRepository {
   // ==========================================================================
   // 특수 작업 (Transaction)
   // ==========================================================================
-
-  async markAsOrphan(
-    uid: string,
-    reason: string,
-    _phone?: string,
-    platform?: string
-  ): Promise<void> {
-    try {
-      const { error } = await supabase.from(TABLES.ORPHAN_ACCOUNTS).upsert({
-        id: uid,
-        reason,
-        platform: platform ?? null,
-        created_at: new Date().toISOString(),
-      });
-
-      if (error) {
-        logger.error('고아 계정 마킹 실패 (Supabase)', toError(error), { uid, reason });
-        return; // 마킹 실패는 throw하지 않음 (원래 동작 유지)
-      }
-
-      logger.warn('고아 계정 마킹 완료 (수동 정리 필요)', { uid, reason });
-    } catch (error) {
-      logger.error('고아 계정 마킹 실패', toError(error), { uid, reason });
-      // 마킹 실패는 throw하지 않음
-    }
-  }
 
   async registerAsEmployer(
     userId: string,

--- a/uniqn-mobile/src/services/auth/__tests__/authService.test.ts
+++ b/uniqn-mobile/src/services/auth/__tests__/authService.test.ts
@@ -1,13 +1,5 @@
-import {
-  getUserProfile,
-  login,
-  rollbackPhoneOnlyAccount,
-  signOut,
-  signUp,
-} from '../authCoreService';
-import { Platform } from 'react-native';
-
-import { userRepository } from '@/repositories';
+import { getUserProfile, login, signOut, signUp } from '../authCoreService';
+import { ERROR_CODES } from '@/errors';
 
 const mockSignInWithPassword = jest.fn();
 const mockSignUp = jest.fn();
@@ -47,7 +39,6 @@ jest.mock('@/shared/auth/protectedAuthFlow', () => ({
 jest.mock('@/repositories', () => ({
   userRepository: {
     getById: jest.fn(),
-    markAsOrphan: jest.fn(),
   },
 }));
 
@@ -124,7 +115,6 @@ jest.mock('../userProfileService', () => ({
   getUserProfile: jest.fn(),
 }));
 
-const mockUserRepository = userRepository as jest.Mocked<typeof userRepository>;
 const { getUserProfile: mockFetchUserProfile } = jest.requireMock('../userProfileService') as {
   getUserProfile: jest.Mock;
 };
@@ -137,7 +127,6 @@ describe('authCoreService', () => {
     jest.clearAllMocks();
     mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
     mockSignOut.mockResolvedValue({ error: null });
-    mockUserRepository.markAsOrphan.mockResolvedValue(undefined);
   });
 
   it('logs in with Supabase signInWithPassword', async () => {
@@ -223,6 +212,79 @@ describe('authCoreService', () => {
     expect(mockTrackSignup).toHaveBeenCalledWith('email');
   });
 
+  it('recovers when email already exists (orphan) by signing in and resuming profile save', async () => {
+    // 이메일 확인 OFF 환경: 중복 이메일은 하드 422 user_already_exists 로 옴
+    const existingUser = {
+      id: 'user-orphan',
+      email: 'dup@example.com',
+      user_metadata: {},
+      app_metadata: { providers: ['email'] },
+    };
+    const profile = {
+      uid: 'user-orphan',
+      email: 'dup@example.com',
+      name: 'Dup',
+      role: 'staff',
+      phoneVerified: true,
+      createdAt: new Date() as never,
+      updatedAt: new Date() as never,
+    };
+
+    mockSignUp.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { code: 'user_already_exists', status: 422, message: 'User already registered' },
+    });
+    // 기존 orphan 계정, 입력 비번 일치 → signIn 성공 후 프로필 저장 이어서 완료
+    mockSignInWithPassword.mockResolvedValue({
+      data: { user: existingUser, session: { access_token: 'token' } },
+      error: null,
+    });
+    mockCallVerify.mockResolvedValue(undefined);
+    mockFetchUserProfile.mockResolvedValue(profile);
+
+    const result = await signUp({
+      email: 'dup@example.com',
+      password: 'Password123!',
+      name: 'Dup',
+      identityVerificationId: 'imp_dup',
+      termsAgreed: true,
+      privacyAgreed: true,
+      thirdPartyAgreed: true,
+      marketingAgreed: false,
+    } as never);
+
+    expect(mockSignInWithPassword).toHaveBeenCalled();
+    expect(mockCallVerify).toHaveBeenCalled();
+    expect(result).toEqual({ user: existingUser, profile });
+  });
+
+  it('throws AUTH_EMAIL_ALREADY_EXISTS when email exists but password mismatches', async () => {
+    mockSignUp.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { code: 'user_already_exists', status: 422, message: 'User already registered' },
+    });
+    // 기존 계정이지만 비번 불일치 → 클라이언트 복구 불가, 로그인 안내
+    mockSignInWithPassword.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { message: 'Invalid login credentials', status: 400 },
+    });
+
+    await expect(
+      signUp({
+        email: 'dup@example.com',
+        password: 'WrongPass1!',
+        name: 'Dup',
+        identityVerificationId: 'imp_dup',
+        termsAgreed: true,
+        privacyAgreed: true,
+        thirdPartyAgreed: true,
+        marketingAgreed: false,
+      } as never)
+    ).rejects.toMatchObject({ code: ERROR_CODES.AUTH_EMAIL_ALREADY_EXISTS });
+
+    expect(mockCallVerify).not.toHaveBeenCalled();
+  });
+
   it('rejects signUp when identityVerificationId is missing', async () => {
     await expect(
       signUp({
@@ -266,30 +328,6 @@ describe('authCoreService', () => {
         marketingAgreed: false,
       } as never)
     ).rejects.toThrow();
-
-    expect(mockSignOut).toHaveBeenCalled();
-  });
-
-  it('rollback marks orphan and signs out without throwing', async () => {
-    await expect(
-      rollbackPhoneOnlyAccount('user-rollback', 'native_signup_rollback_failed', '01012345678')
-    ).resolves.toBeUndefined();
-
-    expect(mockUserRepository.markAsOrphan).toHaveBeenCalledWith(
-      'user-rollback',
-      'native_signup_rollback_failed',
-      '01012345678',
-      Platform.OS
-    );
-    expect(mockSignOut).toHaveBeenCalled();
-  });
-
-  it('rollback does not throw when markAsOrphan fails', async () => {
-    mockUserRepository.markAsOrphan.mockRejectedValue(new Error('mark failed'));
-
-    await expect(
-      rollbackPhoneOnlyAccount('user-rollback', 'native_signup_rollback_failed', '01012345678')
-    ).resolves.toBeUndefined();
 
     expect(mockSignOut).toHaveBeenCalled();
   });

--- a/uniqn-mobile/src/services/auth/authCoreService.ts
+++ b/uniqn-mobile/src/services/auth/authCoreService.ts
@@ -8,7 +8,6 @@
 import type { User as SupabaseUser } from '@supabase/supabase-js';
 import { Platform } from 'react-native';
 import { supabase } from '@/lib/supabase';
-import { userRepository } from '@/repositories';
 import { logger } from '@/utils/logger';
 import { clearCounterSyncCache } from '@/shared/cache/counterSyncCache';
 import { clearProtectedAuthFlow, protectAuthFlow } from '@/shared/auth/protectedAuthFlow';
@@ -265,28 +264,55 @@ export async function signUp(data: SignUpFormData): Promise<AuthResult> {
       },
     });
 
-    if (signUpError || !signUpData.user) {
+    // 이미 가입된 이메일 처리 (orphan 락아웃 근본 해결):
+    //  - 이메일 확인 OFF 환경: 중복 이메일은 하드 422 user_already_exists 에러로 옴
+    //  - 이메일 확인 ON 환경: 에러 없이 session=null(obfuscated)로 옴
+    // 두 경우 모두 dead-end("회원가입 실패") 대신 기존 계정으로 signIn 해서,
+    // 프로필 미완성(orphan)이면 본인인증 저장을 이어 완료(self-heal)하고,
+    // 완성됐으면 edge function이 PROFILE_ALREADY_COMPLETED → 로그인 안내로 분기.
+    const alreadyExists =
+      !!signUpError &&
+      ((signUpError as { code?: string }).code === 'user_already_exists' ||
+        (signUpError as { status?: number }).status === 422 ||
+        /already\s*(registered|exists)/i.test(signUpError.message ?? ''));
+
+    if (signUpError && !alreadyExists) {
       throw new AuthError(ERROR_CODES.AUTH_INVALID_CREDENTIALS, {
         userMessage: '회원가입에 실패했습니다. 다시 시도해주세요.',
-        originalError: signUpError ? new Error(signUpError.message) : undefined,
+        originalError: new Error(signUpError.message),
       });
     }
-
-    const user = signUpData.user;
-    protectAuthFlow(user.id, 'email_signup');
 
     // functions.invoke는 functions.headers.Authorization을 사용하는데,
     // SupabaseClient v2에서 onAuthStateChange가 functions.setAuth를 호출하지 않아
     // signUp 직후 항상 anon key로 요청됨 → 명시적으로 access token 전달 필요.
-    // signUpData.session이 null인 경우(이미 가입된 이메일 재시도 등)는 signIn으로 fallback.
-    let accessToken = signUpData.session?.access_token;
-    if (!accessToken) {
-      const { data: signInData } = await supabase.auth.signInWithPassword({
+    let user = signUpData?.user ?? null;
+    let accessToken = signUpData?.session?.access_token;
+
+    // user/세션이 없으면(이미 가입된 이메일) 기존 계정으로 로그인해 이어서 진행.
+    if (!user || !accessToken) {
+      const { data: signInData, error: signInError } = await supabase.auth.signInWithPassword({
         email: data.email,
         password: data.password,
       });
-      accessToken = signInData.session?.access_token;
+      if (signInError || !signInData.user || !signInData.session) {
+        // 기존 계정이지만 비밀번호 불일치 → 클라이언트에서 복구 불가, 로그인 안내.
+        throw new AuthError(ERROR_CODES.AUTH_EMAIL_ALREADY_EXISTS, {
+          userMessage: '이미 가입된 이메일이에요. 로그인하거나 비밀번호 찾기를 이용해주세요.',
+          originalError: signInError ? new Error(signInError.message) : undefined,
+        });
+      }
+      user = signInData.user;
+      accessToken = signInData.session.access_token;
     }
+
+    if (!user) {
+      // 도달 불가 — 위 분기에서 user 확정 (TS narrowing 보조).
+      throw new AuthError(ERROR_CODES.AUTH_INVALID_CREDENTIALS, {
+        userMessage: '회원가입에 실패했습니다. 다시 시도해주세요.',
+      });
+    }
+    protectAuthFlow(user.id, 'email_signup');
 
     try {
       // 2. Edge Function 호출: 서버사이드 PortOne 재조회 + DB 저장 + role 설정
@@ -319,21 +345,8 @@ export async function signUp(data: SignUpFormData): Promise<AuthResult> {
 
       return { user, profile };
     } catch (error) {
-      // 실패 시 계정 정리: orphan 마킹 → signOut.
-      // orphan 레코드는 같은 이메일/전화번호 재가입 진단·복구 단서.
-      try {
-        await markOrphanAccount(
-          user.id,
-          error instanceof Error ? error.message : 'signup failed',
-          data.verifiedPhone
-        );
-      } catch (markError) {
-        logger.warn('orphan 마킹 실패', {
-          component: 'authService',
-          uid: user.id,
-          error: markError instanceof Error ? markError.message : String(markError),
-        });
-      }
+      // 실패 시 세션 정리: signOut. orphan auth 계정은 다음 시도에서 signUp 422 →
+      // signIn 재개로 self-heal 되고, 7일 후 cleanup-orphan-accounts cron 이 정리한다.
       try {
         await supabase.auth.signOut();
       } catch {
@@ -533,45 +546,4 @@ export async function checkPhoneExists(phone: string): Promise<boolean> {
 export async function getLinkedPhoneNumber(): Promise<string | null> {
   const { data } = await supabase.auth.getUser();
   return data.user?.phone ?? null;
-}
-
-/**
- * 고아 계정 마킹 (가입 실패 시 Firestore에 기록)
- */
-export async function markOrphanAccount(
-  uid: string,
-  reason: string,
-  phone?: string
-): Promise<void> {
-  await userRepository.markAsOrphan(uid, reason, phone, Platform.OS);
-}
-
-/**
- * Phone-only 계정 롤백
- *
- * Supabase에서는 단일 SDK이므로 단순히 signOut만 수행.
- */
-export async function rollbackPhoneOnlyAccount(
-  uid: string,
-  reason: string,
-  phone?: string
-): Promise<void> {
-  logger.warn('phone-only rollback started', { uid, reason, component: 'authService' });
-
-  try {
-    await markOrphanAccount(uid, reason, phone);
-  } catch {
-    logger.error('CRITICAL: failed to mark orphan account', {
-      uid,
-      reason,
-      component: 'authService',
-    });
-  }
-
-  clearProtectedAuthFlow(uid);
-  try {
-    await supabase.auth.signOut();
-  } catch {
-    // Ignore sign-out cleanup failures.
-  }
 }

--- a/uniqn-mobile/src/services/auth/index.ts
+++ b/uniqn-mobile/src/services/auth/index.ts
@@ -40,9 +40,7 @@ export {
   checkEmailExists,
   checkNicknameExists,
   checkPhoneExists,
-  rollbackPhoneOnlyAccount,
   getLinkedPhoneNumber,
-  markOrphanAccount,
 } from './authCoreService';
 
 export {


### PR DESCRIPTION
## 문제 (라이브 로그로 확정)

회원가입 도중 auth 계정만 생기고 프로필 저장(`verify-and-save-portone-profile`)이 실패해 **orphan**(public.users 없는 auth 계정)이 되면, 이메일 확인 OFF 환경에서 재가입 시 `auth.signUp` 이 하드 **422 user_already_exists** 를 반환 → "회원가입에 실패했습니다" dead-end 로 **영구 락아웃**.

본인인증(`verify-portone-identity`)은 매번 통과하니 "본인인증은 되는데 가입만 안 됨"으로 보였음. 기존 signIn fallback 은 `session=null`(확인 ON) 케이스만 커버해 422 를 못 잡았던 게 근본 갭. (실측: 1분 내 제출도 실패 → 5분 만료설 기각)

## 변경

- **Fix A** — `signUp`: 422 `user_already_exists` 시 즉시 throw 대신 `signInWithPassword` 시도
  - 성공 + 프로필 미완성(orphan) → `verify-and-save-portone-profile` 이어서 완료 = **self-heal**
  - 성공 + 프로필 완성 → edge `PROFILE_ALREADY_COMPLETED` → 로그인 안내
  - 비번 불일치 → `AUTH_EMAIL_ALREADY_EXISTS`("이미 가입된 이메일이에요. 로그인하거나 비밀번호 찾기를 이용해주세요.")
- **dead code 제거** — `markAsOrphan`(없는 `orphan_accounts` 테이블 write·noop), `markOrphanAccount`, `rollbackPhoneOnlyAccount`, `ORPHAN_ACCOUNTS` 상수, USER_COLUMNS 의 `is_orphan`, IUserRepository decl, index export. signUp 실패 catch 는 `signOut` 만 유지(self-heal + 7일 cron 정리).

## 테스트

- `authService.test.ts`: orphan recovery / password mismatch **2건 추가**, rollback 2건 제거 → 10/10 pass
- `tsc --noEmit` clean, `eslint` clean

## 영향 / 비고

- 막혀 있던 사용자 3건(orphan)은 이미 수동 삭제 복구 완료(현재 orphan 0).
- 별건 미해결: 커스텀 SMTP `535` (비번 재설정 메일 실패) — Supabase Dashboard SMTP 설정 작업 필요(코드 아님).
- 모바일 반영은 머지 후 EAS OTA/빌드 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)