### PR TITLE
fix(auth): 본인인증 Edge Function 설정에러 한글화 + 멱등성 롤백 retry 하드닝

### DIFF
--- a/uniqn-mobile/src/services/auth/__tests__/portOneIdentityService.test.ts
+++ b/uniqn-mobile/src/services/auth/__tests__/portOneIdentityService.test.ts
@@ -1,0 +1,62 @@
+/**
+ * callVerifyAndSavePortOneProfile 의 Edge Function 에러 매핑 회귀 테스트.
+ *
+ * 회원가입 주 경로(verify-and-save)는 그동안 PROFILE_ALREADY_COMPLETED 만 typed
+ * 에러로 변환하고, 그 외 IdP code 는 raw FunctionsHttpError 를 throw → "Edge Function
+ * returned a non-2xx status code" 영문 메시지가 UI 노출. A-1 이 서버에 code 필드를
+ * 추가했으므로, 클라이언트도 verify-identity 경로와 동일하게 code 를 한글 메시지로 변환해야 한다.
+ */
+import { ValidationError } from '@/errors';
+import { invokeEdgeFunction } from '@/lib/supabaseFunctions';
+import { callVerifyAndSavePortOneProfile } from '../portOneIdentityService';
+
+// jest.mock 는 babel-plugin-jest-hoist 로 import 위로 호이스팅된다.
+jest.mock('@/lib/supabaseFunctions', () => ({
+  invokeEdgeFunction: jest.fn(),
+}));
+
+const mockInvoke = invokeEdgeFunction as jest.Mock;
+
+const VALID_TOKEN = 'a'.repeat(64); // 64-hex caller binding token
+
+function makeHttpError(body: { code?: string; error?: string }) {
+  // Supabase FunctionsHttpError 형태: context 는 fetch Response (json() 보유)
+  return {
+    name: 'FunctionsHttpError',
+    message: 'Edge Function returned a non-2xx status code',
+    context: { json: async () => body },
+  };
+}
+
+describe('callVerifyAndSavePortOneProfile — Edge Function 에러 매핑', () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+  });
+
+  it('PORTONE_CONFIG_MISSING code → 영문 generic 이 아닌 한글 ValidationError 로 변환한다', async () => {
+    mockInvoke.mockResolvedValue({
+      data: null,
+      error: makeHttpError({
+        code: 'PORTONE_CONFIG_MISSING',
+        error: '본인인증 서비스에 일시적인 문제가 발생했어요. 잠시 후 다시 시도해주세요.',
+      }),
+    });
+
+    const promise = callVerifyAndSavePortOneProfile({
+      identityVerificationId: 'iv-test-1',
+      mode: 'signup',
+      expectedBindingToken: VALID_TOKEN,
+    } as Parameters<typeof callVerifyAndSavePortOneProfile>[0]);
+
+    await expect(promise).rejects.toBeInstanceOf(ValidationError);
+    await expect(promise).rejects.toMatchObject({
+      userMessage: expect.stringContaining('본인인증 서비스'),
+    });
+    // 영문 generic 이 사용자에게 노출되면 안 된다.
+    await expect(promise).rejects.not.toMatchObject({
+      userMessage: expect.stringContaining('non-2xx'),
+    });
+    // code 매핑은 즉시 변환 — 재시도 없이 1회만 호출.
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+});

--- a/uniqn-mobile/src/services/auth/portOneIdentityService.ts
+++ b/uniqn-mobile/src/services/auth/portOneIdentityService.ts
@@ -552,6 +552,16 @@ export async function callVerifyAndSavePortOneProfile(
       });
     }
 
+    // A-1 — verify-identity 경로와 동일하게 IdP code 를 한글 ValidationError 로 변환.
+    // (PORTONE_CONFIG_MISSING 등 서버 설정/검증 에러의 영문 generic 메시지 UI 노출 방지.)
+    if (parsed?.code) {
+      logger.info('verifyAndSavePortOneProfile edge error mapped to ValidationError', {
+        component: 'portOneIdentityService',
+        code: parsed.code,
+      });
+      throw mapIdpErrorCodeToAppError(parsed.code, parsed.error);
+    }
+
     if (!isRetryableError(error)) {
       throw error;
     }

--- a/uniqn-mobile/supabase/functions/_shared/__tests__/idp-binding.test.ts
+++ b/uniqn-mobile/supabase/functions/_shared/__tests__/idp-binding.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for shared IdP helpers used by the PortOne Edge Functions.
+ *
+ * These helpers are intentionally Deno-free (no `Deno.*`, no `jsr:` imports at
+ * the module top level) so they run under the project's jest-expo harness.
+ */
+import { idpError, retryOnError } from '../idp-binding.ts';
+import { IDP_ERROR_CODES } from '../idp-errors.ts';
+
+describe('idpError', () => {
+  it('PORTONE_CONFIG_MISSING — code 필드를 포함한 500 응답을 반환한다', async () => {
+    const res = idpError('PORTONE_CONFIG_MISSING');
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as { error: string; code: string };
+    // 클라이언트 parseEdgeFunctionErrorBody 의 `parsed?.code` 게이트를 통과시키는 핵심 계약.
+    expect(body.code).toBe('PORTONE_CONFIG_MISSING');
+    expect(body.error).toBe(IDP_ERROR_CODES.PORTONE_CONFIG_MISSING.message);
+    // 영문 generic 메시지가 아니라 한글 사용자 메시지여야 한다.
+    expect(body.error).not.toContain('non-2xx');
+  });
+});
+
+describe('retryOnError', () => {
+  const noSleep = async () => {};
+
+  it('첫 시도 성공 시 1회만 호출하고 결과를 반환한다', async () => {
+    const op = jest.fn(async () => ({ error: null as null | { message: string } }));
+    const result = await retryOnError(op, { attempts: 3, delayMs: 1000, sleep: noSleep });
+
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(result.error).toBeNull();
+  });
+
+  it('error 가 사라질 때까지 재시도하고 성공 결과를 반환한다', async () => {
+    let calls = 0;
+    const op = jest.fn(async () => {
+      calls += 1;
+      return { error: calls < 3 ? { message: 'transient' } : null };
+    });
+
+    const result = await retryOnError(op, { attempts: 3, delayMs: 1000, sleep: noSleep });
+
+    expect(op).toHaveBeenCalledTimes(3);
+    expect(result.error).toBeNull();
+  });
+
+  it('attempts 회 모두 실패하면 마지막 error 를 그대로 반환한다 (throw 하지 않음)', async () => {
+    const op = jest.fn(async () => ({ error: { message: 'permanent' } }));
+
+    const result = await retryOnError(op, { attempts: 3, delayMs: 1000, sleep: noSleep });
+
+    expect(op).toHaveBeenCalledTimes(3);
+    expect(result.error).toEqual({ message: 'permanent' });
+  });
+
+  it('attempts 사이에 주입된 sleep 을 호출한다', async () => {
+    const sleep = jest.fn(async () => {});
+    const op = jest.fn(async () => ({ error: { message: 'x' } }));
+
+    await retryOnError(op, { attempts: 3, delayMs: 500, sleep });
+
+    // 3회 시도 → 시도 사이 2번 대기
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(500);
+  });
+});

--- a/uniqn-mobile/supabase/functions/_shared/idp-binding.ts
+++ b/uniqn-mobile/supabase/functions/_shared/idp-binding.ts
@@ -27,6 +27,30 @@ export function idpError(code: IdpErrorCode, detail?: string): Response {
   });
 }
 
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Supabase 쿼리처럼 `{ error }` 를 반환(throw 하지 않음)하는 작업을 재시도한다.
+ *
+ * 멱등성 롤백 DELETE 같이 "일시 장애로 실패하면 dangling row 가 후속 재시도를
+ * 영구 차단하는" 작업을 위한 best-effort 하드닝. 마지막 결과를 그대로 반환하므로
+ * 호출자가 최종 error 를 직접 처리한다 (A7 dangling-row 가시성 유지).
+ */
+export async function retryOnError<T extends { error: unknown }>(
+  // PostgREST 쿼리 빌더는 Promise 가 아닌 PromiseLike(thenable) 이므로 PromiseLike 로 받는다.
+  op: () => PromiseLike<T>,
+  opts: { attempts: number; delayMs: number; sleep?: (ms: number) => Promise<void> }
+): Promise<T> {
+  const sleep = opts.sleep ?? defaultSleep;
+  let result = await op();
+  for (let attempt = 1; attempt < opts.attempts && result.error; attempt += 1) {
+    await sleep(opts.delayMs);
+    result = await op();
+  }
+  return result;
+}
+
 export function isVerificationRecent(
   verifiedAt: string | undefined,
   maxAgeMs = 5 * 60 * 1000

--- a/uniqn-mobile/supabase/functions/_shared/idp-errors.ts
+++ b/uniqn-mobile/supabase/functions/_shared/idp-errors.ts
@@ -23,6 +23,10 @@ export const IDP_ERROR_CODES = {
   IV_DUPLICATE_NICKNAME: { status: 409, message: '이미 사용 중인 닉네임입니다' },
   AUTH_REQUIRED: { status: 401, message: '인증이 필요합니다' },
   AUTH_FAILED: { status: 401, message: '인증 실패' },
+  PORTONE_CONFIG_MISSING: {
+    status: 500,
+    message: '본인인증 서비스에 일시적인 문제가 발생했어요. 잠시 후 다시 시도해주세요.',
+  },
   PORTONE_FETCH_FAILED: { status: 400, message: '본인인증 정보 조회 실패' },
   PORTONE_NOT_VERIFIED: { status: 400, message: '본인인증이 완료되지 않았습니다' },
   PORTONE_INCOMPLETE: { status: 400, message: '본인인증 데이터가 불완전합니다' },

--- a/uniqn-mobile/supabase/functions/verify-and-save-portone-profile/index.ts
+++ b/uniqn-mobile/supabase/functions/verify-and-save-portone-profile/index.ts
@@ -9,6 +9,7 @@ import {
   logDiDiagnostic,
   normalizeBirthDate,
   normalizeGender,
+  retryOnError,
   toE164,
   validateAge,
 } from '../_shared/idp-binding.ts';
@@ -108,7 +109,8 @@ Deno.serve(async (req: Request) => {
     }
 
     const portoneSecret = Deno.env.get('PORTONE_API_SECRET');
-    if (!portoneSecret) return jsonResponse({ error: 'PortOne 설정 오류' }, 500);
+    // code 필드 포함 — 클라 parseEdgeFunctionErrorBody 게이트를 통과해 한글 메시지로 변환.
+    if (!portoneSecret) return idpError('PORTONE_CONFIG_MISSING');
 
     const portoneRes = await fetch(
       `https://api.portone.io/identity-verifications/${encodeURIComponent(identityVerificationId)}`,
@@ -299,10 +301,15 @@ Deno.serve(async (req: Request) => {
     if (upsertError) {
       // C6 fix — rollback DELETE 결과 명시적 처리. 실패 시 dangling row가
       // 다음 재시도를 영구 차단하므로 logger.error로 visible하게 알림.
-      const { error: rollbackError } = await supabase
-        .from('processed_identity_verifications')
-        .delete()
-        .eq('verification_id', identityVerificationId);
+      // A-2 하드닝 — 일시 장애로 1회 DELETE 가 실패해도 dangling row 가 남지 않도록 3회 재시도.
+      const { error: rollbackError } = await retryOnError(
+        () =>
+          supabase
+            .from('processed_identity_verifications')
+            .delete()
+            .eq('verification_id', identityVerificationId),
+        { attempts: 3, delayMs: 1000 }
+      );
       if (rollbackError) {
         // A7: dangling row 발생 — 사용자에게도 명시 에러 코드 반환해 고객센터 안내 가능
         console.error('[CRITICAL] idempotency rollback failed — dangling row may block retry', {

--- a/uniqn-mobile/supabase/functions/verify-portone-identity/index.ts
+++ b/uniqn-mobile/supabase/functions/verify-portone-identity/index.ts
@@ -102,7 +102,8 @@ Deno.serve(async (req: Request) => {
 
     const portoneSecret = Deno.env.get('PORTONE_API_SECRET');
     if (!portoneSecret) {
-      return jsonResponse({ error: 'PortOne 설정 오류' }, 500);
+      // code 필드 포함 — 클라 parseEdgeFunctionErrorBody 게이트를 통과해 한글 메시지로 변환.
+      return idpError('PORTONE_CONFIG_MISSING');
     }
 
     const portoneRes = await fetch(


### PR DESCRIPTION
## 배경
회원가입·로그인·본인인증 흐름 오류 취약점 분석에서 확인된 **저위험·고가치 하드닝 2건**. 자동 탐색이 올린 다른 "Critical" 다수는 이미 수정됐거나(JWT autoRefresh, 멱등성 C6) 이론적 과장(authRedirect NULL — 컬럼 `DEFAULT false`)으로 검증돼 제외.

## 변경
### A-1 — Edge Function 설정에러 영문 generic 노출 차단 🟠
- `_shared/idp-errors.ts`: `PORTONE_CONFIG_MISSING` 코드 추가(500 + 한글 메시지)
- `verify-portone-identity` / `verify-and-save-portone-profile`: `jsonResponse({error},500)` → `idpError('PORTONE_CONFIG_MISSING')` (응답에 `code` 필드 포함)
- `portOneIdentityService.ts`: **저장 경로(회원가입 주 경로)** catch에 verify 경로와 동일한 IdP code→한글 ValidationError 매핑 추가
  - 이게 없으면 서버 `code` 추가가 회원가입 흐름에서 무력 (기존엔 `PROFILE_ALREADY_COMPLETED`만 매핑)

**효과**: `PORTONE_API_SECRET` 미주입 등 설정 에러 시 `"Edge Function returned a non-2xx status code"` 영문 노출 → 한글 메시지로 변환.

### A-2 — 멱등성 롤백 dangling row 영구차단 완화 ⚠️
- `_shared/idp-binding.ts`: 순수·테스트 가능한 `retryOnError` 헬퍼 추출 (`PromiseLike<T>` 시그니처로 PostgREST 빌더 호환)
- `verify-and-save-portone-profile`: 롤백 DELETE에 3회 retry(1초 backoff) 적용
  - 기존 C6 fix(가시 로그 + `IDEMPOTENCY_ROLLBACK_FAILED`)는 유지, 그 위에 일시 장애 retry만 추가

## 테스트 (RED→GREEN 확인)
- `supabase/functions/_shared/__tests__/idp-binding.test.ts` — retryOnError 4 + idpError 1 = **5 신규**
- `src/services/auth/__tests__/portOneIdentityService.test.ts` — code 매핑 **1 신규**

| 검증 | 결과 |
|------|------|
| auth + shared 스위트 | 9 suites, **111 tests, 0 fail** |
| `tsc --noEmit` | exit 0 |
| eslint (변경 파일) | 0 errors |
| prettier | 통과 |

> `supabase/functions`는 tsconfig·eslint·format 게이트에서 제외(Deno)되므로 Deno 코드는 `PromiseLike<T>` 타이핑으로 Deno 컴파일러 안전성 확보. 런타임 검증은 배포 후.

## 배포 영향
- Edge Function 변경: master 머지 시 **Deploy Edge Functions 워크플로우 자동 배포**
- 클라이언트(`portOneIdentityService.ts`) 변경: 기존 앱 사용자 반영엔 **EAS OTA/새 빌드** 필요

## 후속 (별도 세션)
- B-1: Apple 로그인 낙관적 minimal profile 반환 (`socialLoginService.ts:460-504`) — 신중한 설계 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)