### PR TITLE
fix(auth): Apple 로그인 프로필 DB 쓰기 미확인 optimistic 경로 가시화 (B-1)

### DIFF
--- a/uniqn-mobile/src/services/auth/__tests__/socialLoginService.test.ts
+++ b/uniqn-mobile/src/services/auth/__tests__/socialLoginService.test.ts
@@ -20,6 +20,8 @@ const mockGetMMKVInstance = jest.fn();
 const mockLeaveBreadcrumb = jest.fn();
 const mockProtectAuthFlow = jest.fn();
 const mockClearProtectedAuthFlow = jest.fn();
+const mockLoggerInfo = jest.fn();
+const mockLoggerWarn = jest.fn();
 
 const mockMmkv = {
   set: jest.fn(),
@@ -81,8 +83,8 @@ jest.mock('@/repositories', () => ({
 
 jest.mock('@/utils/logger', () => ({
   logger: {
-    info: jest.fn(),
-    warn: jest.fn(),
+    info: (...args: unknown[]) => mockLoggerInfo(...args),
+    warn: (...args: unknown[]) => mockLoggerWarn(...args),
     error: jest.fn(),
     debug: jest.fn(),
   },
@@ -359,6 +361,53 @@ describe('socialLoginService signInWithApple', () => {
     );
     expect(result.profile.socialProvider).toBe('apple');
     expect(result.profile.phoneVerified).toBe(false);
+  });
+
+  // B-1 관측성: 프로필 DB 쓰기를 끝내 확인 못한 채 optimistic 반환하는 경로는
+  // 확인된 경로와 구분되는 logger.warn 을 남겨 실제 빈도를 측정할 수 있어야 한다.
+  it('warns that the profile write was unconfirmed when creation keeps timing out', async () => {
+    jest.useFakeTimers();
+
+    const timeoutError = new NetworkError(ERROR_CODES.NETWORK_TIMEOUT, {
+      userMessage: 'Apple 로그인 후 프로필 생성이 지연되고 있습니다.',
+    });
+
+    mockWithTimeout
+      .mockImplementationOnce((promise: Promise<unknown>) => promise) // signInWithIdToken
+      .mockImplementationOnce(() => Promise.resolve(null)) // lookup → null
+      .mockImplementationOnce(() => Promise.reject(timeoutError)) // create 1차 타임아웃
+      .mockImplementationOnce(() => Promise.resolve(null)) // verify1 attempt1
+      .mockImplementationOnce(() => Promise.resolve(null)) // verify1 attempt2
+      .mockImplementationOnce(() => Promise.reject(timeoutError)) // create 2차 타임아웃
+      .mockImplementationOnce(() => Promise.resolve(null)) // verify2 attempt1
+      .mockImplementationOnce(() => Promise.resolve(null)); // verify2 attempt2
+
+    const { signInWithApple } = loadModule();
+
+    const signInPromise = signInWithApple();
+    await Promise.resolve();
+    await Promise.resolve();
+    await jest.runAllTimersAsync();
+    await signInPromise;
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('미확인'),
+      expect.objectContaining({ uid: 'mock-user-id' })
+    );
+  });
+
+  it('does not warn when the new-user profile write is confirmed on first try', async () => {
+    mockGetUserProfile.mockResolvedValue(null);
+
+    const { signInWithApple } = loadModule();
+
+    await signInWithApple();
+
+    // 1차 createOrMerge 가 성공한 확인된 경로 → 미확인 warn 이 없어야 한다.
+    expect(mockLoggerWarn).not.toHaveBeenCalledWith(
+      expect.stringContaining('미확인'),
+      expect.anything()
+    );
   });
 
   it('rethrows a cancel event without signing out', async () => {

--- a/uniqn-mobile/src/services/auth/socialLoginService.ts
+++ b/uniqn-mobile/src/services/auth/socialLoginService.ts
@@ -445,8 +445,12 @@ export async function signInWithApple(): Promise<AuthResult> {
         return false;
       };
 
+      // 프로필 DB 쓰기가 실제로 확인됐는지 추적. 끝내 확인 못한 채 optimistic 반환하는
+      // 경로는 social signup 단계의 권위적 upsert 에 위임하되, 빈도 측정을 위해 구분 로깅한다.
+      let profileWriteConfirmed = false;
       try {
         await createProfileDocument(1);
+        profileWriteConfirmed = true;
       } catch (createError) {
         const createErrorCode = (createError as { code?: string })?.code ?? '';
         const isRetryableCreateError =
@@ -458,10 +462,13 @@ export async function signInWithApple(): Promise<AuthResult> {
         }
 
         const profileCreatedAfterFirstTimeout = await verifyProfileCreationSettled(1);
-        if (!profileCreatedAfterFirstTimeout) {
+        if (profileCreatedAfterFirstTimeout) {
+          profileWriteConfirmed = true;
+        } else {
           await sleep(APPLE_PROFILE_WRITE_RETRY_DELAY_MS);
           try {
             await createProfileDocument(2);
+            profileWriteConfirmed = true;
           } catch (retryCreateError) {
             const retryCode = (retryCreateError as { code?: string })?.code ?? '';
             const isRetryableRetry =
@@ -470,7 +477,9 @@ export async function signInWithApple(): Promise<AuthResult> {
 
             if (isRetryableRetry) {
               const settled = await verifyProfileCreationSettled(2);
-              if (!settled) {
+              if (settled) {
+                profileWriteConfirmed = true;
+              } else {
                 protectAuthFlow(user.id, 'social_signup', SOCIAL_SIGNUP_FLOW_PROTECTION_TTL_MS);
                 preserveProtectedAuthFlow = true;
               }
@@ -495,12 +504,26 @@ export async function signInWithApple(): Promise<AuthResult> {
         updatedAt: now,
       };
 
-      logger.info('Apple 신규 사용자 최소 프로필 생성', { uid: user.id });
-      leaveAppleLoginBreadcrumb('apple_login_flow', {
-        flowId,
-        status: 'success',
-        resultType: 'new_minimal_profile',
-      });
+      if (profileWriteConfirmed) {
+        logger.info('Apple 신규 사용자 최소 프로필 생성', { uid: user.id });
+        leaveAppleLoginBreadcrumb('apple_login_flow', {
+          flowId,
+          status: 'success',
+          resultType: 'new_minimal_profile',
+        });
+      } else {
+        // DB 쓰기 미확인 — social signup 단계의 upsert 가 권위적 source 이므로 흐름은 진행하되,
+        // 실제 발생 빈도를 측정해 근본 대응 여부를 판단하기 위해 visible warn + 구분 breadcrumb.
+        logger.warn(
+          'Apple 신규 프로필 DB 쓰기 미확인 — social signup upsert 에 위임 (optimistic 진행)',
+          { uid: user.id, flowId }
+        );
+        leaveAppleLoginBreadcrumb('apple_login_flow', {
+          flowId,
+          status: 'success',
+          resultType: 'new_minimal_profile_unconfirmed',
+        });
+      }
       return { user, profile: minimalProfile };
     }
 


### PR DESCRIPTION
## 배경
회원가입·로그인·본인인증 오류 분석에서 "Apple 로그인 낙관적 success 반환"(B-1)으로 플래그된 항목. PR #129(A-1/A-2)에 이어 단독 처리.

## 조사 결론 — 기능 버그 아님, 의도된 fallback
`socialLoginService.ts:448-505` 의 신규 Apple 유저 프로필 생성 경로를 라인 단위로 검증한 결과:

- **`createOrMerge`는 멱등** — `supabase.from(USERS).upsert({ id, ... })` (`UserRepository.ts:220`). attempt2 재호출이 안전(중복/unique violation 없음). → 재시도-비멱등 로그인 실패 버그 **없음**.
- **minimal profile은 best-effort pre-seed** — 권위적 write는 `socialSignup`(`signup?mode=social`) 단계의 `completeSocialProfile` → `verify-and-save-portone-profile` upsert에서 일어남. 신규 Apple 유저는 `phoneVerified=false`로 socialSignup 라우팅(`login.tsx:186`) → **self-heal**.
- 기존 테스트 `'falls back to the social signup flow when profile creation keeps timing out'`이 이 fallback을 **의도된 동작으로 이미 검증** 중.

따라서 "낙관 반환 제거"는 정상 신규 가입 흐름을 깨고 UX를 악화시키는 **위험한 변경**이라 채택하지 않음.

## 진짜 결함 = 관측성
DB 쓰기를 끝내 확인 못한 채 optimistic 반환하는 경로가 **확인된 경로와 동일하게** `success` / `resultType: 'new_minimal_profile'`로 로깅돼 **실제 실패 빈도를 은폐**.

## 변경 (behavior 불변, self-heal 보존)
- `profileWriteConfirmed` 플래그로 create 성공/verify settled 여부 추적
- 미확인 경로만 `logger.warn` + breadcrumb `resultType: 'new_minimal_profile_unconfirmed'`로 구분
- 라우팅/반환값/protectAuthFlow 동작은 그대로 — Sentry로 실제 빈도 측정 후 근본 대응 판단 (`feedback_temp_defense_then_root_cause` 철학)

## 테스트 (RED→GREEN)
- `warns that the profile write was unconfirmed when creation keeps timing out` (신규)
- `does not warn when the new-user profile write is confirmed on first try` (신규, 오탐 가드)

| 검증 | 결과 |
|------|------|
| auth 스위트 | 7 suites, **107 tests, 0 fail** |
| `tsc --noEmit` | exit 0 |
| eslint / prettier | 0 errors / 통과 |

## 후속 (데이터 기반)
Sentry에서 `new_minimal_profile_unconfirmed` 빈도가 유의미하면 → 근본 대응(verify 견고화 또는 create 동기화) 검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)