### PR TITLE
fix(mobile): 로그인 orphan 계정 잔존 세션 정리

### DIFF
--- a/uniqn-mobile/src/services/auth/__tests__/authService.test.ts
+++ b/uniqn-mobile/src/services/auth/__tests__/authService.test.ts
@@ -171,6 +171,29 @@ describe('authCoreService', () => {
     await expect(login({ email: 'test@example.com', password: 'wrong' })).rejects.toThrow();
   });
 
+  it('signs out lingering session when profile is missing (orphan login)', async () => {
+    // signInWithPassword 는 세션을 생성하지만 public.users 프로필이 없는 orphan 계정.
+    // signUp/Apple 경로처럼 잔존 세션을 정리해야 authStore 가 끌려가지 않는다.
+    const supabaseUser = {
+      id: 'user-orphan',
+      email: 'orphan@example.com',
+      user_metadata: {},
+      app_metadata: { providers: ['email'] },
+    };
+
+    mockSignInWithPassword.mockResolvedValue({
+      data: { user: supabaseUser, session: { access_token: 'token' } },
+      error: null,
+    });
+    mockFetchUserProfile.mockResolvedValue(null);
+
+    await expect(
+      login({ email: 'orphan@example.com', password: 'Password123!' })
+    ).rejects.toMatchObject({ code: ERROR_CODES.AUTH_USER_NOT_FOUND });
+
+    expect(mockSignOut).toHaveBeenCalled();
+  });
+
   it('signs up with Supabase auth and edge function', async () => {
     const supabaseUser = {
       id: 'user-1',

--- a/uniqn-mobile/src/services/auth/authCoreService.ts
+++ b/uniqn-mobile/src/services/auth/authCoreService.ts
@@ -91,8 +91,15 @@ export async function login(data: LoginFormData): Promise<AuthResult> {
     const profile = await getUserProfile(user.id);
 
     if (!profile) {
+      // 세션은 이미 생성됐지만 public.users 프로필이 없는 orphan 계정.
+      // 잔존 세션을 정리해 authStore 가 끌려가지 않게 한다 (signUp/Apple 경로와 일관).
+      try {
+        await supabase.auth.signOut();
+      } catch {
+        // cleanup failure 무시 — 원래 에러가 우선
+      }
       throw new AuthError(ERROR_CODES.AUTH_USER_NOT_FOUND, {
-        userMessage: '사용자 정보를 찾을 수 없습니다.',
+        userMessage: '가입이 완료되지 않은 계정이에요. 다시 회원가입을 진행해주세요.',
       });
     }
 


### PR DESCRIPTION
## Summary
프로필(`public.users`)이 없는 orphan 계정으로 로그인할 때, Supabase 세션은 생성됐지만 정리되지 않아 `authStore`가 끌려가던 문제를 수정합니다. signUp/Apple 로그인 경로와 동일하게 잔존 세션을 `signOut()`으로 정리합니다.

## Changes
- `authCoreService.ts > login()`: 프로필 없는 orphan 계정 로그인 시 `supabase.auth.signOut()` 호출 (cleanup 실패는 무시, 원래 에러 우선)
- 에러 메시지 한글화: "사용자 정보를 찾을 수 없습니다." → "가입이 완료되지 않은 계정이에요. 다시 회원가입을 진행해주세요."
- Red-Green 테스트 추가: orphan login 시 `signOut` 호출 검증

## Test plan
- [x] `npm run type-check` 통과 (0 errors)
- [x] `npm run lint` 통과 (0 errors)
- [x] `npm run format:check` 통과
- [x] `jest` 전체 통과 (4184/4184)
- [ ] orphan 계정 로그인 → 세션 정리 + 한글 에러 메시지 노출 수동 확인

## 배포
- JS-only 변경 → EAS Update(OTA) 대상. `--channel production` 푸시 예정 (SDK 55 빌드 한정 도달).

---
Generated with [Claude Code](https://claude.com/claude-code)