### PR TITLE
fix(e2e): CI 러너 리소스 경합 완화 — workers 4→2 + expect timeout 15s

### DIFF
--- a/uniqn-mobile/e2e/playwright.config.ts
+++ b/uniqn-mobile/e2e/playwright.config.ts
@@ -28,7 +28,10 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: isCI,
   retries: isCI ? 2 : 0,
-  workers: isCI ? 4 : 1,
+  // ubuntu-latest 는 2 vCPU. workers:4 + 로컬 Supabase + 웹서버가 CPU 초과구독되면
+  // 인증후 페이지 로드가 expect timeout 을 넘겨 광범위 실패 → retries 3배 증폭 →
+  // 45분 job cap 초과 cancelled. 2 로 낮춰 경합 완화 (8.5→~15분이나 안정적).
+  workers: isCI ? 2 : 1,
   outputDir: testResultsDir,
   reporter: isCI
     ? [['list'], ['html', { open: 'never', outputFolder: htmlReportDir }], ['github']]
@@ -38,7 +41,8 @@ export default defineConfig({
   globalTeardown: require.resolve('./global-teardown'),
 
   timeout: 60_000,
-  expect: { timeout: 10_000 },
+  // CI 러너 부하 시 페이지 로드 여유 확보 (10s → 15s). 근본은 workers 축소.
+  expect: { timeout: 15_000 },
 
   use: {
     baseURL: E2E_CONFIG.runtime.baseUrl,


### PR DESCRIPTION
## Summary
e2e가 코드 변경 없이 비결정적으로 8.5분 success / 45.8분 timeout-cancelled 를 오가던 근본 원인을 수정합니다. ubuntu-latest(2 vCPU)에 playwright workers:4 + 로컬 Supabase + Expo 웹서버가 CPU 초과구독되어, 러너가 느린 회차에 인증후 페이지 로드가 expect timeout(10s)을 넘기고 retries:2 가 실패를 3배 증폭해 45분 job cap(`e2e.yml:26`)을 초과 → cancelled.

## 근거 (조사)
- **동일 브랜치/코드가 success + failure + cancelled 모두 생성** → 코드 아닌 러너 성능 의존
- global-setup `[storageState]` 4계정 생성 성공 → 로그인/인증 정상
- 실패가 `auth-logout-session`·`e2e-user-journeys` 의 "로그인 →" 전 카테고리 균일 → 인증후 로드 단계
- 정상 회차는 8.5분에 전체 통과

## Changes
- `e2e/playwright.config.ts`: `workers: isCI ? 4 → 2` (2 vCPU 매칭, 경합 완화)
- `e2e/playwright.config.ts`: `expect.timeout: 10s → 15s` (러너 부하 시 로드 여유)

## Test plan
- [ ] 이 PR의 e2e가 45분 cap 내 안정적으로 완료 (정상 ~15분 예상)
- [ ] 후속 수 회 실행에서 cancelled 재발 없음 확인 (비결정성 특성상 1회 통과로는 미증명)

## Note
근본 직접 수정. 정상 회차 wall-clock 이 8.5→~15분으로 늘지만 45분 cap 한참 아래라 안정성↑. 더 견고한 대안(suite shard)은 별도 검토 가능.

---
Generated with [Claude Code](https://claude.com/claude-code)