### PR TITLE
fix(e2e): review 계정 프로필 완료 플래그 마이그레이션 코드화 — CI 약관 리다이렉트 해소

### DIFF
--- a/uniqn-mobile/e2e/helpers/workspace-seed.ts
+++ b/uniqn-mobile/e2e/helpers/workspace-seed.ts
@@ -67,3 +67,35 @@ export async function ensureE2EWorkspace(
   }
   return data.id as string;
 }
+
+/**
+ * owner 의 **기본(현재) 워크스페이스** ID 를 반환 — 앱의 워크스페이스 선택과 일치.
+ *
+ * 앱은 `workspaceService.pickOwnedWorkspaceId` 에서 owned 워크스페이스를
+ * `created_at` 오름차순 정렬 후 가장 오래된 것을 현재 워크스페이스로 사용한다.
+ * /employer 리스트는 이 현재 워크스페이스로 필터링되므로, 리스트 가시성을
+ * 검증하는 테스트는 별도의 'E2E 테스트 워크스페이스' 가 아니라 이 기본
+ * 워크스페이스에 공고를 시드해야 한다.
+ *
+ * owned 워크스페이스가 하나도 없으면 `ensureE2EWorkspace` 로 생성 후 반환(폴백).
+ */
+export async function getDefaultWorkspaceId(
+  adminClient: SupabaseClient,
+  ownerId: string
+): Promise<string> {
+  const { data, error } = await adminClient
+    .from('workspaces')
+    .select('id')
+    .eq('owner_id', ownerId)
+    .order('created_at', { ascending: true })
+    .limit(1);
+
+  if (error) {
+    throw new Error(`default workspace SELECT 실패: ${error.message}`);
+  }
+  if (data && data.length > 0 && data[0]?.id) {
+    return data[0].id as string;
+  }
+  // owned 워크스페이스가 없으면 생성(폴백) — 앱도 동일하게 자동 생성한다.
+  return ensureE2EWorkspace(adminClient, ownerId);
+}

--- a/uniqn-mobile/e2e/tests/p0-critical/e2e-user-journeys.spec.ts
+++ b/uniqn-mobile/e2e/tests/p0-critical/e2e-user-journeys.spec.ts
@@ -198,24 +198,27 @@ test.describe('E2E 유저 저니', () => {
     await waitForAppReady(page);
 
     // 2. HomeTabBar 의 프로필 탭 click → (tabs)/profile
+    // 탭 버튼 click 은 앱 초기화 race 로 no-op 될 수 있어(클릭 시점에 라우터 미준비),
+    // navigation 확정(프로필 수정 버튼 가시)까지 click+assert 를 재시도한다.
     const profileTabButton = page.getByRole('button', { name: '프로필 탭으로 이동' });
     await expect(profileTabButton).toBeVisible({ timeout: 10_000 });
-    await profileTabButton.click();
-    await page.waitForLoadState('domcontentloaded');
-
-    // 프로필 관련 콘텐츠가 보여야 함
-    await expect(page.getByRole('button', { name: /프로필 수정/ })).toBeVisible({
-      timeout: 10_000,
-    });
+    await expect(async () => {
+      await profileTabButton.click();
+      await expect(page.getByRole('button', { name: /프로필 수정/ })).toBeVisible({
+        timeout: 5_000,
+      });
+    }).toPass({ timeout: 25_000 });
 
     // 3. "설정센터" menu item click → /(app)/settings 진입
     // MenuItem 의 Pressable 내부 Text "설정센터" 클릭이 outer Pressable 의 sibling
     // div (e.g. ChevronRightIcon container) 에 intercept 됨. dispatchEvent 로 우회.
+    // 고정 timeout 대신 URL 전이(/settings)를 명시적으로 대기하며 재시도.
     const settingsMenuItem = page.getByText('설정센터');
     await expect(settingsMenuItem).toBeVisible({ timeout: 5_000 });
-    await settingsMenuItem.dispatchEvent('click');
-    await page.waitForLoadState('domcontentloaded');
-    await page.waitForTimeout(800);
+    await expect(async () => {
+      await settingsMenuItem.dispatchEvent('click');
+      await page.waitForURL(/\/settings/, { timeout: 5_000 });
+    }).toPass({ timeout: 20_000 });
 
     // settings 페이지 URL 확인 (StackHeader title 은 heading role 없어서 text 매칭 신뢰도 낮음)
     expect(page.url()).toContain('/settings');

--- a/uniqn-mobile/e2e/tests/p1-important/employer-posting-crud.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/employer-posting-crud.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Locator, type Page } from '@playwright/test';
 import { getAdminClient } from '../../helpers/supabase-admin';
-import { ensureE2EWorkspace } from '../../helpers/workspace-seed';
+import { getDefaultWorkspaceId } from '../../helpers/workspace-seed';
 import { TEST_ACCOUNTS } from '../../fixtures/test-accounts';
 
 async function waitForReady(page: Page): Promise<void> {
@@ -21,7 +21,9 @@ async function seedJobPosting(
   if (!admin) throw new Error('E2E_SUPABASE_SERVICE_ROLE_KEY 필요 — job_postings 시드 불가');
 
   const workDate = new Date(Date.now() + 10 * 86_400_000).toISOString().slice(0, 10);
-  const workspaceId = await ensureE2EWorkspace(admin, TEST_ACCOUNTS.employer.uid);
+  // 앱이 현재 워크스페이스로 보여주는 기본(가장 오래된 owned) 워크스페이스에 시드해야
+  // /employer 리스트에 노출된다. 별도 'E2E 테스트 워크스페이스' 에 넣으면 0건으로 보임.
+  const workspaceId = await getDefaultWorkspaceId(admin, TEST_ACCOUNTS.employer.uid);
 
   const { data, error } = await admin
     .from('job_postings')

--- a/uniqn-mobile/supabase/migrations/20260523123418_harden_review_account_profile_flags.sql
+++ b/uniqn-mobile/supabase/migrations/20260523123418_harden_review_account_profile_flags.sql
@@ -1,0 +1,49 @@
+-- 20260523123418_harden_review_account_profile_flags.sql
+-- 심사/E2E 계정 4종(review-staff/employer/admin/collaborator)의 프로필 완료 플래그를 보정.
+--
+-- 배경:
+--   20260419131630_seed_app_review_accounts.sql 와 20260520205822_seed_review_collaborator_account.sql
+--   는 public.users 에 id/email/name/role/phone 만 채우고
+--   phone_verified / identity_verified / profile_completed 는 설정하지 않는다.
+--   세 컬럼의 DB 기본값은 false 이므로, 마이그레이션만으로 생성된 row 는 "미완성 프로필" 이 된다.
+--   authRedirect.getAuthenticatedEntryRoute() 의 안전망 게이트
+--   (phoneVerified !== true && identityVerified === false) 가 발동해 로그인 직후
+--   /(auth)/signup 으로 리다이렉트되고, (app)/(employer) e2e 가 전면 실패한다.
+--
+--   프로덕션에서는 staff/employer/admin 3계정만 수동 UPDATE(2026-05-07)로 보정되어 있고
+--   review-collaborator(2026-05-20 시드)는 false/false/false 로 남아 있다. 또한 이 보정이
+--   마이그레이션에 없어 fresh 스택/재시드 시 4계정 전부 미완성으로 회귀하는 잠재 부채가 있다.
+--
+-- 이 마이그레이션은 그 보정을 멱등하게 코드화한다:
+--   - fresh 스택: 4계정 모두 완전한 프로필로 완성.
+--   - 프로덕션: 이미 완전한 3계정은 WHERE 가드로 no-op, collaborator 1행만 보정.
+--   role 은 건드리지 않으므로 role-escalation 가드와 무관하다.
+--
+-- ROLLBACK (수동, 필요 시):
+--   UPDATE public.users
+--     SET phone_verified=false, identity_verified=false, identity_verified_at=NULL,
+--         identity_provider=NULL, profile_completed=false
+--   WHERE id = 'e5555555-5555-4555-a555-555555555555';
+
+UPDATE public.users
+  SET
+    phone_verified = true,
+    identity_verified = true,
+    identity_verified_at = COALESCE(identity_verified_at, NOW()),
+    identity_provider = COALESCE(identity_provider, 'portone_inicis'),
+    profile_completed = true,
+    updated_at = NOW()
+  WHERE id IN (
+    'a1111111-1111-4111-a111-111111111111', -- review-staff
+    'b2222222-2222-4222-b222-222222222222', -- review-employer
+    'c3333333-3333-4333-c333-333333333333', -- review-admin
+    'e5555555-5555-4555-a555-555555555555'  -- review-collaborator
+  )
+  -- 이미 완전한 row 는 건드리지 않아 프로덕션 데이터 변형/타임스탬프 덮어쓰기 방지
+  AND (
+    phone_verified IS DISTINCT FROM true
+    OR identity_verified IS DISTINCT FROM true
+    OR profile_completed IS DISTINCT FROM true
+    OR identity_verified_at IS NULL
+    OR identity_provider IS NULL
+  );

--- a/uniqn-mobile/supabase/migrations/20260523203721_seed_review_collaborator_public_user.sql
+++ b/uniqn-mobile/supabase/migrations/20260523203721_seed_review_collaborator_public_user.sql
@@ -1,0 +1,26 @@
+-- E2E review-collaborator(e5555555) 의 public.users 행을 멱등 시드.
+--
+-- 배경: 20260520205822_seed_review_collaborator_account.sql 는 auth.users 만 INSERT 하고
+--   public.users 생성을 handle_new_user 트리거에 의존한다. 그러나 CI(supabase start) 의
+--   로컬 스택에서는 handle_new_user 가 직접 auth.users INSERT 에 발동하지 않아(known: PR #90)
+--   collaborator 의 public.users 행이 생성되지 않는다. 결과적으로 auth.users 만 있고
+--   public.users 가 없는 orphan 상태 → 앱 auth 초기화가 signOut → 로그인 화면 →
+--   collaborator e2e(공유받은 공고 등) 전면 실패.
+--   프로덕션에서는 트리거가 정상 발동해 행이 이미 존재하므로 ON CONFLICT 로 no-op.
+--
+-- 값은 prod 의 실제 collaborator 행과 동일(완전한 프로필 플래그 포함)하게 맞춰
+--   authRedirect 게이트(phone_verified/identity_verified)에 의한 약관 리다이렉트도 방지.
+-- prevent_role_escalation 은 BEFORE UPDATE OF role 이라 INSERT 에는 영향 없음.
+
+INSERT INTO public.users (
+  id, email, name, role, phone,
+  phone_verified, identity_verified, identity_verified_at, identity_provider, profile_completed
+) VALUES (
+  'e5555555-5555-4555-a555-555555555555',
+  'review-collaborator@uniqn.app',
+  '심사용 협업자',
+  'employer',
+  '+821055550005',
+  true, true, NOW(), 'portone_inicis', true
+)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## 근본 원인 (trace 증거 기반)

CI E2E가 비결정적으로 45분 캡에 cancelled 되던 진짜 원인은 **러너 경합이 아니라 시드 계정 미완성**이었음.

- 시드된 review 계정 4종(staff/employer/admin/collaborator)이 `phone_verified/identity_verified/profile_completed = false`(DB 기본값)
- `src/shared/navigation/authRedirect.ts:104` 게이트 `if (phoneVerified !== true && identityVerified === false)` 가 로그인 직후 `/(auth)/signup`(약관동의)로 리다이렉트
- → 모든 인증 테스트의 화면이 안 떠서 인라인 10s expect timeout → `retries:2` 3배 증폭 → 45분 job cap → cancelled

**스모킹건**: 실패 run(26339561974)의 `e2e-test-results` 아티팩트에서 실패 테스트 **12/12 전부 실패 시점 페이지 스냅샷이 '약관동의/회원가입' 화면**(스케줄/설정/대시보드 아님). staff·admin·journey 가리지 않고 결정적.

## 왜 master/다른 PR에서 재현됐나 (마이그레이션 drift)

이 보정 마이그레이션 `20260523123418_harden_review_account_profile_flags.sql` 는 `fix/login-orphan-signout` 브랜치에만 존재. **master 엔 파일 부재**. prod 레지스트리엔 적용돼 있으나(`20260523123448`) repo 에 없어서, CI 가 `supabase start`로 repo 마이그레이션만 적용 → 미완성 계정 시드 → 약관 리다이렉트.

## 변경

- `fix/login-orphan-signout`에 작성된 harden 마이그레이션 파일을 master 경로로 가져옴 (재작성 아님, 동일 파일)
- **멱등**: 이미 완전한 row 는 `WHERE` 가드로 no-op
- **prod 무변경**: prod 는 이미 적용 상태. 이 PR 은 repo/CI drift 만 해소
- role 미변경 → role-escalation 가드 무관

## 검증

이 PR 의 **E2E가 green 이면 곧 근본원인 증명** (완성 계정 시딩 → 인증 화면 렌더 → 통과, 정상 ~8.5분). B1(#132 workers/timeout)·shard 는 이 문제와 무관하므로 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)