### PR TITLE
perf(db): wallets/wallet_ledger RLS auth.jwt() initplan 최적화

### DIFF
--- a/uniqn-mobile/supabase/migrations/20260523180012_optimize_wallet_rls_initplan.sql
+++ b/uniqn-mobile/supabase/migrations/20260523180012_optimize_wallet_rls_initplan.sql
@@ -1,0 +1,14 @@
+-- Perf: wrap auth.jwt() in (select ...) so RLS evaluates it once per query (initplan)
+-- instead of once per row. Semantics unchanged. Supabase advisor lint 0003_auth_rls_initplan.
+--
+-- Flagged policies (auth.jwt() re-evaluated per row):
+--   - public.wallet_ledger.ledger_admin_select (USING)
+--   - public.wallets.wallet_admin_all (USING + WITH CHECK)
+-- The *_self_select policies already use (select auth.uid()) and are not affected.
+
+alter policy ledger_admin_select on public.wallet_ledger
+  using ((((select auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text) = 'admin'::text);
+
+alter policy wallet_admin_all on public.wallets
+  using ((((select auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text) = 'admin'::text)
+  with check ((((select auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text) = 'admin'::text);


### PR DESCRIPTION
## 요약

Supabase advisor lint `0003_auth_rls_initplan` 2건 해소. `auth.jwt()` 를 `(select auth.jwt())` 로 래핑해 RLS 가 행마다 재평가하던 것을 쿼리당 1회(initplan)로 축소.

- `wallet_ledger.ledger_admin_select` (USING)
- `wallets.wallet_admin_all` (USING + WITH CHECK)
- `*_self_select` 정책은 이미 `(select auth.uid())` 라 영향 없음

## 검증

- 의미 불변(admin 체크 동일), 회귀 위험 없음
- **prod 적용 완료**(MCP migration `20260523180012`), advisor 재실행 결과 `auth_rls_initplan` 2건→0건 확인
- 이 PR 은 로컬 마이그레이션 파일을 repo 에 코드화(prod/repo 동기화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)