### PR TITLE
fix(mobile): 오프라인 배너 시스템 상태바 침범 수정

### DIFF
--- a/uniqn-mobile/src/components/ui/OfflineBanner.tsx
+++ b/uniqn-mobile/src/components/ui/OfflineBanner.tsx
@@ -7,6 +7,7 @@
 
 import React, { useCallback } from 'react';
 import { View, Text, Pressable, ActivityIndicator } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { STATUS_COLORS } from '@/constants/colors';
 import { WifiOff, RefreshCw } from '../icons';
 import { useNetworkStatus } from '@/hooks/useNetworkStatus';
@@ -49,6 +50,7 @@ export const OfflineBanner: React.FC<OfflineBannerProps> = React.memo(
   }) => {
     const { isOffline, isChecking, checkConnection } = useNetworkStatus();
     const [isRetrying, setIsRetrying] = React.useState(false);
+    const insets = useSafeAreaInsets();
 
     const handleRetry = useCallback(async () => {
       setIsRetrying(true);
@@ -67,7 +69,8 @@ export const OfflineBanner: React.FC<OfflineBannerProps> = React.memo(
     if (variant === 'toast') {
       return (
         <View
-          className="absolute top-12 left-4 right-4 z-50"
+          className="absolute left-4 right-4 z-50"
+          style={{ top: insets.top + 8 }}
           accessibilityRole="alert"
           accessibilityLiveRegion="assertive"
         >
@@ -145,7 +148,8 @@ export const OfflineBanner: React.FC<OfflineBannerProps> = React.memo(
     // 기본 배너 스타일
     return (
       <View
-        className="bg-error-600 dark:bg-error-700 px-4 py-3"
+        className="bg-error-600 dark:bg-error-700 px-4 pb-3"
+        style={{ paddingTop: insets.top + 12 }}
         accessibilityRole="alert"
         accessibilityLiveRegion="assertive"
       >


### PR DESCRIPTION
## 요약
오프라인 연결 끊김 배너가 기기 시스템 상태바(시계·배터리·노치)와 겹치는 문제 수정.

## 변경 내용
- `OfflineBanner` banner/toast variant에 `useSafeAreaInsets()` 적용
- **banner**: `py-3` → `pb-3` + `paddingTop: insets.top + 12` — 빨간 배경은 노치까지 채우되 텍스트·재시도 버튼은 상태바 아래에서 시작
- **toast**: 하드코딩 `top-12`(48px) → `top: insets.top + 8` — 노치 큰 기기 안전
- impeccable 디자인 §25 "시스템 status bar 침범 금지" 준수

## 영향 범위
- 프로덕션 사용처는 `app/_layout.tsx:176` `variant="banner"` 한 곳
- 웹(RN Web): `insets.top=0` → `paddingTop=12`로 기존과 동일, 무회귀

## 검증
- ✅ type-check 0 errors / lint 0 errors / format:check 통과 (pre-push 게이트)
- ⚠️ 모바일 반영은 EAS OTA 또는 새 빌드 필요 (머지만으론 프로덕션 앱 미반영)

🤖 Generated with [Claude Code](https://claude.com/claude-code)