### PR TITLE
fix(mobile): 스케줄 카드 중첩 button + work_log applicationId 합성키 수정

### DIFF
--- a/uniqn-mobile/app/(app)/(tabs)/schedule.tsx
+++ b/uniqn-mobile/app/(app)/(tabs)/schedule.tsx
@@ -671,8 +671,6 @@ export default function ScheduleScreen() {
                       key={item.id}
                       schedule={item}
                       onPress={() => handleOpenDetailSheet(item)}
-                      onCancelApplication={handleCancelApplication}
-                      onRequestCancellation={handleRequestCancellation}
                     />
                   );
                 })}
@@ -733,8 +731,6 @@ export default function ScheduleScreen() {
                       key={item.id}
                       schedule={item}
                       onPress={() => handleOpenDetailSheet(item)}
-                      onCancelApplication={handleCancelApplication}
-                      onRequestCancellation={handleRequestCancellation}
                     />
                   );
                 })}

--- a/uniqn-mobile/src/components/schedule/ScheduleCard.tsx
+++ b/uniqn-mobile/src/components/schedule/ScheduleCard.tsx
@@ -5,7 +5,7 @@
 import { SECONDARY_PALETTE } from '@/constants/colors';
 import React, { memo, useMemo } from 'react';
 import { View, Text, Pressable } from 'react-native';
-import { CardStripe, Badge, FocusablePressable } from '@/components/ui';
+import { CardStripe, Badge } from '@/components/ui';
 import {
   CalendarIcon,
   ClockIcon,
@@ -38,29 +38,18 @@ import {
 import { STATUS } from '@/constants';
 import { APPLICATION_STATUS_LABELS } from '@/shared/status';
 import { WorkTimeDisplay } from '@/shared/time';
-import { useModalStore } from '@/stores/modalStore';
 import type { ScheduleEvent } from '@/types';
 
 export interface ScheduleCardProps {
   schedule: ScheduleEvent;
   onPress?: () => void;
-  /** applied 상태에서 "지원 취소" 액션 (applicationId 필요) */
-  onCancelApplication?: (applicationId: string) => void;
-  /** confirmed 상태에서 "취소 요청" 액션 (applicationId 필요) */
-  onRequestCancellation?: (applicationId: string) => void;
 }
 
-export const ScheduleCard = memo(function ScheduleCard({
-  schedule,
-  onPress,
-  onCancelApplication,
-  onRequestCancellation,
-}: ScheduleCardProps) {
+export const ScheduleCard = memo(function ScheduleCard({ schedule, onPress }: ScheduleCardProps) {
   const status = statusConfig[schedule.type];
   const attendance = attendanceConfig[schedule.status];
   const ownerName = schedule.postingProjection?.ownerName;
   const hasPendingCancellation = Boolean(schedule.isCancellationPending);
-  const showConfirm = useModalStore((s) => s.showConfirm);
 
   const projectedSalary = useMemo(
     () =>
@@ -262,43 +251,6 @@ export const ScheduleCard = memo(function ScheduleCard({
               </View>
             </View>
           )}
-
-          {/* 인라인 액션 버튼 — applied/confirmed 상태에서 직접 취소 가능 */}
-          {schedule.applicationId &&
-            !hasPendingCancellation &&
-            !isCancelled &&
-            ((schedule.type === STATUS.SCHEDULE.APPLIED && onCancelApplication) ||
-              (schedule.type === STATUS.SCHEDULE.CONFIRMED && onRequestCancellation)) && (
-              <View className="mt-3 flex-row justify-end">
-                <FocusablePressable
-                  onPress={(event) => {
-                    event.stopPropagation();
-                    if (!schedule.applicationId) return;
-                    const id = schedule.applicationId;
-                    if (schedule.type === STATUS.SCHEDULE.APPLIED) {
-                      showConfirm(
-                        '지원 취소',
-                        '정말 지원을 취소하시겠습니까?\n취소 후에는 다시 지원해야 합니다.',
-                        () => onCancelApplication?.(id)
-                      );
-                    } else if (schedule.type === STATUS.SCHEDULE.CONFIRMED) {
-                      onRequestCancellation?.(id);
-                    }
-                  }}
-                  hitSlop={10}
-                  focusRingRadius={6}
-                  className="rounded-md border border-secondary-200 px-3 py-1.5 min-h-[36px] active:bg-secondary-50 dark:border-surface-overlay dark:active:bg-surface-overlay"
-                  accessibilityRole="button"
-                  accessibilityLabel={
-                    schedule.type === STATUS.SCHEDULE.APPLIED ? '지원 취소' : '취소 요청'
-                  }
-                >
-                  <Text className="text-xs font-sans-medium text-content-secondary dark:text-secondary-300">
-                    {schedule.type === STATUS.SCHEDULE.APPLIED ? '지원 취소' : '취소 요청'}
-                  </Text>
-                </FocusablePressable>
-              </View>
-            )}
 
           {hasPendingCancellation && (
             <View className="mt-3 rounded-lg bg-warning-50 px-3 py-2 dark:bg-warning-900/20">

--- a/uniqn-mobile/src/components/schedule/__tests__/ScheduleCard.test.tsx
+++ b/uniqn-mobile/src/components/schedule/__tests__/ScheduleCard.test.tsx
@@ -38,6 +38,23 @@ describe('ScheduleCard', () => {
     expect(getByText('취소 요청 검토 중입니다.')).toBeTruthy();
   });
 
+  // 카드 안에 인라인 "지원 취소" 버튼을 두면 카드 전체 Pressable(웹 <button>)
+  // 안에 또 다른 Pressable(<button>)이 중첩되어 hydration 에러가 난다.
+  // 취소 기능은 ScheduleDetailModal 로 일원화했으므로 카드에는 없어야 한다.
+  it('does not render an inline cancel action inside the card', () => {
+    const schedule = {
+      ...createMockScheduleEvent({
+        type: 'applied',
+        applicationId: 'app-1',
+      }),
+    } as unknown as ScheduleEvent;
+
+    const { queryByText } = render(<ScheduleCard schedule={schedule} onPress={() => {}} />);
+
+    expect(queryByText('지원 취소')).toBeNull();
+    expect(queryByText('취소 요청')).toBeNull();
+  });
+
   it('drops the pending-cancellation notice once approval resolves to cancelled', () => {
     const schedule = createMockScheduleEvent({
       type: 'cancelled',

--- a/uniqn-mobile/src/domains/schedule/ScheduleConverter.ts
+++ b/uniqn-mobile/src/domains/schedule/ScheduleConverter.ts
@@ -119,7 +119,10 @@ export class ScheduleConverter {
       sourceCollection: 'workLogs',
       sourceId: workLog.id,
       workLogId: workLog.id,
-      applicationId: `${jobPostingId}_${workLog.staffId}`,
+      // 실제 지원서 ID (applications.id). 취소/상세 조회가 이 값으로 UUID 조회하므로
+      // 합성키(`${jobPostingId}_${staffId}`)를 쓰면 invalid uuid(22P02)로 터진다.
+      // 레거시/수동 work_log로 applicationId가 없으면 undefined → 취소 버튼 숨김 + 그룹화 제외(안전).
+      applicationId: workLog.applicationId ?? undefined,
       customSalaryInfo: workLog.customSalaryInfo,
       customAllowances: workLog.customAllowances,
       customTaxSettings: workLog.customTaxSettings,

--- a/uniqn-mobile/src/domains/schedule/__tests__/ScheduleConverter.test.ts
+++ b/uniqn-mobile/src/domains/schedule/__tests__/ScheduleConverter.test.ts
@@ -171,6 +171,25 @@ describe('ScheduleConverter.workLogToScheduleEvent', () => {
     expect(event.endTime).toBeNull();
   });
 
+  it('uses the real applications.id as applicationId (not a synthetic composite key)', () => {
+    const postingContext = createSchedulePostingContext(createPosting());
+    const event = ScheduleConverter.workLogToScheduleEvent(
+      createWorkLog({ applicationId: 'f9960cc9-7cf0-45ce-abe1-1e1b336213f7' }),
+      postingContext
+    );
+
+    // 취소/상세 조회가 이 값으로 applications.id = eq(...) UUID 조회를 한다.
+    // 합성키(`${jobPostingId}_${staffId}`)면 invalid uuid(22P02)로 400이 난다.
+    expect(event.applicationId).toBe('f9960cc9-7cf0-45ce-abe1-1e1b336213f7');
+  });
+
+  it('leaves applicationId undefined when the workLog has no source application', () => {
+    const postingContext = createSchedulePostingContext(createPosting());
+    const event = ScheduleConverter.workLogToScheduleEvent(createWorkLog(), postingContext);
+
+    expect(event.applicationId).toBeUndefined();
+  });
+
   it('preserves assignmentGroupId from the canonical workLog contract', () => {
     const postingContext = createSchedulePostingContext(createPosting());
     const event = ScheduleConverter.workLogToScheduleEvent(

--- a/uniqn-mobile/src/schemas/workLog.schema.ts
+++ b/uniqn-mobile/src/schemas/workLog.schema.ts
@@ -134,6 +134,7 @@ export const workLogDocumentSchema = z
     id: z.string(),
     staffId: z.string(),
     jobPostingId: z.string(),
+    applicationId: z.string().nullable().optional(),
     date: z.string().nullable(),
 
     // 스태프 정보

--- a/uniqn-mobile/src/types/schedule.ts
+++ b/uniqn-mobile/src/types/schedule.ts
@@ -412,6 +412,8 @@ export interface WorkLog extends FirebaseDocument {
   staffId: string;
   /** 공고 ID */
   jobPostingId: string;
+  /** 원본 지원서 ID (applications.id) — 확정 시 work_log 생성 경로에서 채워짐. 수동/레거시 work_log는 null */
+  applicationId?: string | null;
   assignmentGroupId?: string | null;
   hasTimeModificationLogs?: boolean;
   date: string;


### PR DESCRIPTION
## 요약
실기기/웹에서 발견된 스케줄 탭 버그 2건을 근본 수정. employer-intro 기능 스택에 섞여 있던 것을 cherry-pick으로 분리.

## 버그 1 — 웹 중첩 `<button>` hydration 에러
- `ScheduleCard`의 카드 전체 Pressable(`accessibilityRole="button"`) 안에 인라인 "지원 취소" FocusablePressable(역시 button)이 중첩 → react-native-web가 둘 다 `<button>`으로 렌더 → `<button>` in `<button>` hydration 에러.
- 취소 기능은 `ScheduleDetailModal`에 자체 확인 다이얼로그까지 완비 → 카드 인라인 버튼은 중복. **제거로 근본 해결**(우회 아님).
- 미사용 props/`useModalStore`/`FocusablePressable` import 정리.

## 버그 2 — `invalid input syntax for type uuid` (22P02), 취소 요청 크래시
- work_log 기반(confirmed/completed) 스케줄의 `applicationId`를 합성키 `${jobPostingId}_${staffId}`로 생성 → 취소 요청/딥링크 상세가 이 값으로 `applications.id` UUID 조회 시 400 (E4002).
- 실제로 `work_logs.application_id` 컬럼이 존재하고 zod `.passthrough()`로 런타임엔 살아있었으나 `WorkLog` 타입 미선언이라 합성키를 썼던 것.
- `WorkLog` 타입 + `workLogDocumentSchema`에 `applicationId` 추가, `ScheduleConverter`가 실제 `application_id` 사용. 없으면 `undefined` → 취소 버튼 숨김 + 그룹화 제외(안전).

## 테스트
- `ScheduleConverter`: Red-Green 검증 (합성키→FAIL / 실제 UUID·undefined→PASS)
- `ScheduleCard`: 인라인 취소 액션 부재 가드
- 로컬: `tsc --noEmit` 0 errors · eslint(변경파일) 0 · jest(schedule/converter/schema/grouping) 41 pass

## 배포 주의
모바일 실기기 반영은 **EAS 빌드/OTA 필요** — 머지만으론 기존 빌드 사용자에게 안 감 (특히 버그 2는 실기기 확인된 크래시).

🤖 Generated with [Claude Code](https://claude.com/claude-code)