### PR TITLE
fix(jobs): 공고 역할별 (filled/count) dead counter 해소 + confirm/cancel 정합성 가드 (H0/H1/H4/H5)

### DIFF
--- a/uniqn-mobile/app/(app)/(tabs)/home-jobs.tsx
+++ b/uniqn-mobile/app/(app)/(tabs)/home-jobs.tsx
@@ -12,6 +12,7 @@ import { JobList, PostingTypeChips, DateCalendar, SearchBar } from '@/components
 import { TabHeader } from '@/components/headers';
 import { useJobPostings } from '@/hooks/useJobPostings';
 import { usePostingTypeCounts } from '@/hooks/usePostingTypeCounts';
+import { usePostingFilledCounts } from '@/hooks/usePostingFilledCounts';
 import { searchJobPostings, trackSearch } from '@/services';
 import {
   buildPostingFacts,
@@ -144,6 +145,12 @@ export default function JobsScreen() {
     return visibleJobs.map((job) => focusPostingCardToDate(job, selectedDateString));
   }, [searchQuery.data, selectedDateString, selectedType]);
 
+  const visibleJobIds = useMemo(
+    () => (isSearchMode ? filteredSearchJobs : jobs).map((job) => job.id),
+    [isSearchMode, filteredSearchJobs, jobs]
+  );
+  const filledCountsQuery = usePostingFilledCounts(visibleJobIds);
+
   useEffect(() => {
     if (debouncedSearch) {
       trackSearch(debouncedSearch);
@@ -189,6 +196,7 @@ export default function JobsScreen() {
           onRefresh={handleSearchRefresh}
           onLoadMore={noop}
           onJobPress={handleJobPress}
+          filledCounts={filledCountsQuery.data}
           emptyMessage={`'${debouncedSearch || normalizedSearchText}' 검색 결과가 없습니다`}
         />
       ) : (
@@ -202,6 +210,7 @@ export default function JobsScreen() {
           onRefresh={refresh}
           onLoadMore={loadMore}
           onJobPress={handleJobPress}
+          filledCounts={filledCountsQuery.data}
         />
       )}
 

--- a/uniqn-mobile/app/(employer)/my-postings/[id]/index.tsx
+++ b/uniqn-mobile/app/(employer)/my-postings/[id]/index.tsx
@@ -43,6 +43,10 @@ import { buildPostingFacts, projectPostingSurface } from '@/domains/job-posting'
 import { useApplicantsByJobPosting } from '@/hooks/applicant';
 import { useJobDetail } from '@/hooks/useJobDetail';
 import { useDeleteJobPosting } from '@/hooks/useJobManagement';
+import {
+  extractPostingFilledSubmap,
+  usePostingFilledCounts,
+} from '@/hooks/usePostingFilledCounts';
 import { useThemeStore } from '@/stores/themeStore';
 import type { PostingManagementViewModel, PostingType, TournamentApprovalStatus } from '@/types';
 
@@ -138,6 +142,13 @@ export default function JobPostingDetailScreen() {
           }) as PostingManagementViewModel)
         : null,
     [postingFacts]
+  );
+
+  const postingId = id || '';
+  const { data: filledAll } = usePostingFilledCounts([postingId]);
+  const filledCounts = useMemo(
+    () => extractPostingFilledSubmap(filledAll, postingId),
+    [filledAll, postingId]
   );
 
   const handleApplicants = useCallback(() => {
@@ -321,6 +332,7 @@ export default function JobPostingDetailScreen() {
                       isStartTimeNegotiable={managementView.isStartTimeNegotiable}
                       requiredRolesWithCount={managementView.requiredRolesWithCount}
                       showFilledCount
+                      filledCounts={filledCounts}
                     />
                   </View>
                 </View>

--- a/uniqn-mobile/app/(employer)/my-postings/[id]/index.tsx
+++ b/uniqn-mobile/app/(employer)/my-postings/[id]/index.tsx
@@ -43,10 +43,7 @@ import { buildPostingFacts, projectPostingSurface } from '@/domains/job-posting'
 import { useApplicantsByJobPosting } from '@/hooks/applicant';
 import { useJobDetail } from '@/hooks/useJobDetail';
 import { useDeleteJobPosting } from '@/hooks/useJobManagement';
-import {
-  extractPostingFilledSubmap,
-  usePostingFilledCounts,
-} from '@/hooks/usePostingFilledCounts';
+import { extractPostingFilledSubmap, usePostingFilledCounts } from '@/hooks/usePostingFilledCounts';
 import { useThemeStore } from '@/stores/themeStore';
 import type { PostingManagementViewModel, PostingType, TournamentApprovalStatus } from '@/types';
 

--- a/uniqn-mobile/docs/superpowers/plans/2026-05-24-posting-confirm-cancel-integrity.md
+++ b/uniqn-mobile/docs/superpowers/plans/2026-05-24-posting-confirm-cancel-integrity.md
@@ -1,0 +1,828 @@
+# 공고 확정/취소 정합성 강화 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 확정 인원이 공고 카드 역할별 카운트에 반영되도록(H0) 고치고, 같은 RPC 표면의 정원 가드(H1)·협업자 권한(H4)·체크인 후 취소 차단(H5)을 함께 강화한다.
+
+**Architecture:** DB 레이어는 `count_posting_confirmed_by_slot` 공유 헬퍼 + 읽기 래퍼 `get_posting_filled_counts`를 신설하고, `confirm_application`/`cancel_application_atomically` RPC를 전체 본문 재정의한다. TS 레이어는 조회 시 래퍼 RPC로 (date,slot,role)별 확정 수 맵을 받아 표시 모델의 `role.filled`를 hydrate한다. dead counter(`schedule.role.filled`)는 더 이상 신뢰하지 않는다.
+
+**Tech Stack:** Supabase Postgres(plpgsql, pgTAP), Expo/React Native, TypeScript, TanStack Query, Jest.
+
+**근거 데이터(실DB 검증, posting `61880654-55f1-4d78-b182-80272ca0ca94`):**
+- `total_positions=1, filled_positions=1, stats.filledPositions=1` (권위 컬럼 정상)
+- `schedule.requirements[0].timeSlots[0].roles[0].filled=0` (dead counter — 카드 "(0/1)" 원인)
+- work_log: `date='2026-05-23', time_slot='미정', role='dealer', status='scheduled', app_status='confirmed'`
+- 슬롯은 `isTimeToBeAnnounced=true` → work_logs.time_slot에는 TBA 마커 `'미정'`이 저장됨
+
+---
+
+## File Structure
+
+**생성:**
+- `supabase/migrations/<ts>_posting_confirmed_by_slot_and_integrity.sql` — 헬퍼 + 래퍼 + 두 RPC 재정의 (MCP `apply_migration`으로 적용)
+- `supabase/tests/posting_confirm_cancel_integrity.test.sql` — pgTAP (helper/H1/H4/H5)
+- `src/repositories/supabase/__tests__/JobPostingRepository.filledCounts.test.ts` — Jest (래퍼 + 키)
+- `src/components/jobs/shared/__tests__/postingSurfaceModel.filled.test.ts` — Jest (hydrate)
+
+**수정:**
+- `src/repositories/interfaces/IJobPostingRepository.ts` — `getPostingFilledCounts` 시그니처
+- `src/repositories/supabase/JobPostingRepository.ts` — 래퍼 RPC 호출 + 키 유틸
+- `src/components/jobs/shared/postingSurfaceModel.ts` — `toRoleModels`/`buildPostingScheduleModel`에 `filledCounts` 맵 주입
+- `src/components/jobs/shared/PostingScheduleContent.tsx` — `filledCounts` prop 전달
+- `src/components/jobs/shared/PostingCardSurface.tsx` + `src/components/jobs/JobDetail.tsx` — 맵 prop 배선
+- 공고 리스트/상세 데이터 훅(아래 Task 5에서 정확 파일 확정) — 래퍼 호출 + 맵 전달
+- `src/repositories/supabase/ApplicationRepositoryTransactions.ts` — H5 `staff_already_checked_in` 에러 매핑
+- `src/domains/job-posting/serialization.ts:202-204` — dead counter 주석을 "읽기 시 RPC hydrate" 로 갱신
+
+---
+
+## Task 0: 사전 확인 (코드 변경 없음)
+
+- [ ] **Step 1: `is_admin` / `is_workspace_member` 시그니처 확인**
+
+Run (MCP `execute_sql`, read-only):
+```sql
+SELECT p.proname, pg_get_function_identity_arguments(p.oid) AS args
+FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public' AND p.proname IN ('is_admin','is_workspace_member','is_posting_collaborator')
+ORDER BY p.proname;
+```
+Expected: `is_posting_collaborator(p_posting_id uuid, p_user_id uuid)`, `is_workspace_member(...uuid, uuid)`, `is_admin()` 또는 `is_admin(uuid)`. **결과에 맞춰 Task 1의 권한 술어 인자를 조정**한다(`is_admin()`이 무인자면 `EXISTS(SELECT 1 FROM users WHERE id=<actor> AND ...)` 대체 사용 — Task 1 Step 3 주석 참조).
+
+- [ ] **Step 2: 비-TBA 슬롯의 work_logs.time_slot 저장값 확인**
+
+Run:
+```sql
+SELECT DISTINCT time_slot FROM public.work_logs WHERE time_slot IS NOT NULL LIMIT 20;
+```
+Expected: TBA는 `'미정'`, 일반은 `'HH:MM'` 형태. 헬퍼/표시 키 정규화가 이 값과 일치해야 함을 확인.
+
+---
+
+## Task 1: 마이그레이션 — 헬퍼 + 래퍼 + 두 RPC 재정의
+
+**Files:**
+- Create: `supabase/migrations/<ts>_posting_confirmed_by_slot_and_integrity.sql`
+
+> 적용은 MCP `apply_migration`. 파일명 타임스탬프는 현재 시각으로. `supabase db push` 금지.
+
+- [ ] **Step 1: 마이그레이션 파일 작성 — 공유 헬퍼 + 읽기 래퍼**
+
+```sql
+-- =============================================================================
+-- 공고 확정/취소 정합성: 슬롯/역할별 확정 집계 헬퍼 + 읽기 래퍼 + RPC 가드
+-- H0(역할별 표시), H1(정원 가드), H4(협업자 권한), H5(체크인 후 취소 차단)
+-- =============================================================================
+
+-- 1. 공유 헬퍼: (date, time_slot, role) 별 활성 확정 수
+--    work_logs.time_slot 은 raw 값(TBA→'미정', 일반→'HH:MM') — 표시 라벨 아님
+CREATE OR REPLACE FUNCTION public.count_posting_confirmed_by_slot(
+  p_job_posting_ids uuid[]
+)
+RETURNS TABLE (
+  job_posting_id uuid,
+  work_date text,
+  time_slot text,
+  role_key text,
+  confirmed_count int
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+STABLE
+AS $function$
+  SELECT
+    wl.job_posting_id,
+    wl.date AS work_date,
+    COALESCE(wl.time_slot, '미정') AS time_slot,
+    CASE
+      WHEN wl.role::text = 'other' THEN 'other:' || COALESCE(wl.custom_role, '')
+      ELSE wl.role::text
+    END AS role_key,
+    COUNT(*)::int AS confirmed_count
+  FROM public.work_logs wl
+  WHERE wl.job_posting_id = ANY(p_job_posting_ids)
+    AND wl.status NOT IN ('cancelled', 'no_show')
+  GROUP BY wl.job_posting_id, wl.date, COALESCE(wl.time_slot, '미정'),
+    CASE WHEN wl.role::text = 'other' THEN 'other:' || COALESCE(wl.custom_role, '') ELSE wl.role::text END;
+$function$;
+
+COMMENT ON FUNCTION public.count_posting_confirmed_by_slot(uuid[]) IS
+  '공고별 (date,time_slot,role) 활성 확정 수 집계(카운트만 반환, PII 없음). H0 표시 + H1 가드 공용.';
+
+GRANT EXECUTE ON FUNCTION public.count_posting_confirmed_by_slot(uuid[]) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.count_posting_confirmed_by_slot(uuid[]) FROM PUBLIC, anon;
+
+-- 2. 읽기 래퍼 (클라이언트 표시용 — 동일 결과, 명시적 진입점)
+CREATE OR REPLACE FUNCTION public.get_posting_filled_counts(
+  p_job_posting_ids uuid[]
+)
+RETURNS TABLE (
+  job_posting_id uuid,
+  work_date text,
+  time_slot text,
+  role_key text,
+  confirmed_count int
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+STABLE
+AS $function$
+  SELECT * FROM public.count_posting_confirmed_by_slot(p_job_posting_ids);
+$function$;
+
+COMMENT ON FUNCTION public.get_posting_filled_counts(uuid[]) IS
+  '공고 카드/상세 역할별 (filled/count) 표시용 집계. count_posting_confirmed_by_slot 래핑.';
+
+GRANT EXECUTE ON FUNCTION public.get_posting_filled_counts(uuid[]) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.get_posting_filled_counts(uuid[]) FROM PUBLIC, anon;
+```
+
+- [ ] **Step 2: 같은 파일에 `confirm_application` 재정의 (H1 정원 가드 + H4 권한)**
+
+> 베이스는 현행 `20260418005000` 본문. 변경점: (a) owner 등식 → 권한 술어, (b) work_logs INSERT 직전 정원 가드 루프 추가.
+
+```sql
+-- 3. confirm_application — H1 정원 가드 + H4 권한 술어
+CREATE OR REPLACE FUNCTION public.confirm_application(
+  p_application_id uuid,
+  p_owner_id uuid,
+  p_assignments jsonb DEFAULT '[]'::jsonb,
+  p_original_application jsonb DEFAULT NULL::jsonb,
+  p_confirmation_history jsonb DEFAULT '[]'::jsonb,
+  p_notes text DEFAULT NULL::text,
+  p_is_fixed_posting boolean DEFAULT false,
+  p_assignments_v3 jsonb DEFAULT NULL::jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_app record;
+  v_job record;
+  v_work_log_ids uuid[] := '{}';
+  v_wl_id uuid;
+  v_assignment jsonb;
+  v_now timestamptz := now();
+  v_existing int;
+  v_capacity int;
+  v_role_key text;
+  v_slot_key text;
+BEGIN
+  -- is_active guard
+  IF NOT EXISTS (SELECT 1 FROM public.users WHERE id = p_owner_id AND is_active = true) THEN
+    RAISE EXCEPTION 'ACCOUNT_DISABLED: owner account is disabled (%)', p_owner_id;
+  END IF;
+
+  SELECT * INTO v_app FROM applications WHERE id = p_application_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'APPLICATION_NOT_FOUND: %', p_application_id; END IF;
+  IF v_app.status != 'applied' THEN
+    RAISE EXCEPTION 'INVALID_STATUS: 현재 상태 %, applied만 확정 가능', v_app.status;
+  END IF;
+
+  SELECT * INTO v_job FROM job_postings WHERE id = v_app.job_posting_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'POSTING_NOT_FOUND: %', v_app.job_posting_id; END IF;
+
+  -- H4: 권한 술어 (RLS jp_update_workspace_member 와 정렬)
+  -- NOTE: Task 0 결과로 is_admin 인자 형태 확정. is_admin()이 무인자면 아래 그대로,
+  --       is_admin(uuid)면 is_admin(p_owner_id)로. 무인자 is_admin()은 auth.uid()=호출자 기준이며
+  --       클라가 p_owner_id=본인으로 호출하므로 일치.
+  IF NOT (
+    v_job.owner_id = p_owner_id
+    OR public.is_workspace_member(v_job.workspace_id, p_owner_id)
+    OR public.is_posting_collaborator(v_job.id, p_owner_id)
+    OR public.is_admin()
+  ) THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED: 공고 관리 권한 없음';
+  END IF;
+
+  -- H1: 역할/슬롯별 정원 가드 (work_logs INSERT 전, FOR UPDATE 직렬화 하에서 재검증)
+  IF NOT p_is_fixed_posting AND jsonb_array_length(p_assignments) > 0 THEN
+    FOR v_assignment IN SELECT * FROM jsonb_array_elements(p_assignments)
+    LOOP
+      v_role_key := CASE
+        WHEN (v_assignment->>'role') = 'other'
+          THEN 'other:' || COALESCE(v_assignment->>'customRole', '')
+        ELSE v_assignment->>'role' END;
+      v_slot_key := COALESCE(v_assignment->>'timeSlot', '미정');
+
+      SELECT COUNT(*) INTO v_existing
+      FROM work_logs wl
+      WHERE wl.job_posting_id = v_app.job_posting_id
+        AND wl.date = (v_assignment->>'date')
+        AND COALESCE(wl.time_slot, '미정') = v_slot_key
+        AND (CASE WHEN wl.role::text = 'other' THEN 'other:' || COALESCE(wl.custom_role,'') ELSE wl.role::text END) = v_role_key
+        AND wl.status NOT IN ('cancelled', 'no_show');
+
+      SELECT COALESCE(MAX((r->>'count')::int), 0) INTO v_capacity
+      FROM jsonb_array_elements(COALESCE(v_job.schedule->'requirements', '[]'::jsonb)) req
+      CROSS JOIN jsonb_array_elements(COALESCE(req->'timeSlots', '[]'::jsonb)) ts
+      CROSS JOIN jsonb_array_elements(COALESCE(ts->'roles', '[]'::jsonb)) r
+      WHERE req->>'date' = (v_assignment->>'date')
+        AND (CASE WHEN COALESCE((ts->>'isTimeToBeAnnounced')::boolean, false)
+                  THEN '미정' ELSE COALESCE(ts->>'startTime', ts->>'time', '미정') END) = v_slot_key
+        AND (CASE WHEN (r->>'role') = 'other' THEN 'other:' || COALESCE(r->>'customRole','') ELSE r->>'role' END) = v_role_key;
+
+      IF v_capacity > 0 AND v_existing + 1 > v_capacity THEN
+        RAISE EXCEPTION 'MAX_CAPACITY_REACHED: role=% date=% slot=% (% / %)',
+          v_role_key, v_assignment->>'date', v_slot_key, v_existing + 1, v_capacity;
+      END IF;
+    END LOOP;
+  END IF;
+
+  -- work_logs INSERT (flat 포맷)
+  IF NOT p_is_fixed_posting AND jsonb_array_length(p_assignments) > 0 THEN
+    FOR v_assignment IN SELECT * FROM jsonb_array_elements(p_assignments)
+    LOOP
+      INSERT INTO work_logs (
+        staff_id, job_posting_id, application_id,
+        assignment_group_id, date, time_slot,
+        staff_name, staff_nickname, staff_photo_url,
+        role, custom_role, owner_id,
+        status, is_fixed_posting, created_at, updated_at
+      ) VALUES (
+        v_app.applicant_id, v_app.job_posting_id, p_application_id,
+        v_assignment->>'groupId', v_assignment->>'date', v_assignment->>'timeSlot',
+        v_app.applicant_name, v_app.applicant_nickname, v_app.applicant_photo_url,
+        COALESCE((v_assignment->>'role')::staff_role, v_app.applicant_role, 'staff'),
+        v_assignment->>'customRole', p_owner_id,
+        'scheduled', false, v_now, v_now
+      ) RETURNING id INTO v_wl_id;
+      v_work_log_ids := array_append(v_work_log_ids, v_wl_id);
+    END LOOP;
+  END IF;
+
+  UPDATE applications SET
+    status = 'confirmed',
+    assignments = COALESCE(p_assignments_v3, assignments),
+    original_application = COALESCE(p_original_application, original_application),
+    confirmation_history = p_confirmation_history,
+    confirmed_at = v_now,
+    processed_by = p_owner_id::text,
+    processed_at = v_now,
+    notes = COALESCE(p_notes, notes),
+    updated_at = v_now
+  WHERE id = p_application_id;
+
+  UPDATE job_postings SET
+    filled_positions = filled_positions + 1,
+    stats = jsonb_set(
+      jsonb_set(COALESCE(stats, '{}'::jsonb), '{confirmedApplicants}',
+        to_jsonb(COALESCE((stats->>'confirmedApplicants')::int, 0) + 1)),
+      '{filledPositions}',
+      to_jsonb(COALESCE((stats->>'filledPositions')::int, 0) + 1)),
+    updated_at = v_now
+  WHERE id = v_app.job_posting_id;
+
+  RETURN jsonb_build_object(
+    'applicationId', p_application_id,
+    'workLogIds', to_jsonb(v_work_log_ids),
+    'assignmentCount', jsonb_array_length(p_assignments)
+  );
+END;
+$function$;
+```
+
+- [ ] **Step 3: 같은 파일에 `cancel_application_atomically` 재정의 (H4 권한 + H5 차단)**
+
+> 베이스는 현행 `20260418005000`. 변경점: (a) staff_approves_cancel_request 권한을 술어로 확장, (b) 변이 전 checked_in/checked_out work_log 존재 시 `staff_already_checked_in` 반환.
+
+```sql
+-- 4. cancel_application_atomically — H4 권한 + H5 체크인 후 차단
+CREATE OR REPLACE FUNCTION public.cancel_application_atomically(
+  p_application_id uuid,
+  p_actor_type text,
+  p_actor_id uuid,
+  p_cancel_reason text DEFAULT NULL::text,
+  p_rejection_reason text DEFAULT NULL::text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_application applications%ROWTYPE;
+  v_job_posting job_postings%ROWTYPE;
+  v_active_confirmation_entry jsonb;
+  v_active_confirmation_index int;
+  v_confirmation_history jsonb := '[]'::jsonb;
+  v_deleted_work_log_count int := 0;
+  v_now text := to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"');
+  v_now_ts timestamptz := now();
+  v_assignment_count int := 0;
+  v_new_filled int;
+  v_new_status text;
+  v_updated_cancellation_request jsonb;
+BEGIN
+  SELECT * INTO v_application FROM applications WHERE id = p_application_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'application_not_found'); END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM public.users WHERE id = p_actor_id AND is_active = true) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'account_disabled');
+  END IF;
+
+  -- Idempotency
+  IF p_actor_type = 'staff_initiates' AND v_application.status = 'applied' THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true);
+  END IF;
+  IF p_actor_type = 'staff_approves_cancel_request' AND v_application.status = 'cancelled' THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true);
+  END IF;
+
+  -- State validation
+  IF p_actor_type = 'staff_initiates' THEN
+    IF v_application.status != 'confirmed' THEN
+      RETURN jsonb_build_object('success', false, 'error', 'invalid_status_for_cancellation');
+    END IF;
+  ELSIF p_actor_type = 'staff_approves_cancel_request' THEN
+    IF v_application.status != 'cancellation_pending' THEN
+      RETURN jsonb_build_object('success', false, 'error', 'invalid_status_for_approval');
+    END IF;
+    IF (v_application.cancellation_request->>'status') != 'pending' THEN
+      RETURN jsonb_build_object('success', false, 'error', 'cancellation_request_not_pending');
+    END IF;
+  ELSE
+    RETURN jsonb_build_object('success', false, 'error', 'invalid_actor_type');
+  END IF;
+
+  SELECT * INTO v_job_posting FROM job_postings WHERE id = v_application.job_posting_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'job_posting_not_found'); END IF;
+
+  -- H4: 권한 (staff_approves_cancel_request = 공고 관리 권한자, staff_initiates = 본인)
+  IF p_actor_type = 'staff_approves_cancel_request' THEN
+    IF NOT (
+      v_job_posting.owner_id = p_actor_id
+      OR public.is_workspace_member(v_job_posting.workspace_id, p_actor_id)
+      OR public.is_posting_collaborator(v_job_posting.id, p_actor_id)
+      OR public.is_admin()
+    ) THEN
+      RETURN jsonb_build_object('success', false, 'error', 'unauthorized');
+    END IF;
+  ELSIF p_actor_type = 'staff_initiates' THEN
+    IF v_application.applicant_id != p_actor_id THEN
+      RETURN jsonb_build_object('success', false, 'error', 'unauthorized');
+    END IF;
+  END IF;
+
+  -- H5: 이미 출근(checked_in/checked_out)한 work_log 있으면 차단 (변이 전)
+  IF EXISTS (
+    SELECT 1 FROM work_logs
+    WHERE application_id = p_application_id
+      AND status IN ('checked_in', 'checked_out')
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'staff_already_checked_in');
+  END IF;
+
+  -- confirmation_history 갱신
+  v_confirmation_history := COALESCE(v_application.confirmation_history, '[]'::jsonb);
+  SELECT value, ordinality - 1 INTO v_active_confirmation_entry, v_active_confirmation_index
+  FROM jsonb_array_elements(v_confirmation_history) WITH ORDINALITY
+  WHERE (value->>'cancelled_at') IS NULL LIMIT 1;
+  IF v_active_confirmation_entry IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'no_active_confirmation');
+  END IF;
+
+  v_confirmation_history := jsonb_set(v_confirmation_history,
+    ARRAY[v_active_confirmation_index::text, 'cancelled_at'], to_jsonb(v_now));
+  v_confirmation_history := jsonb_set(v_confirmation_history,
+    ARRAY[v_active_confirmation_index::text, 'cancelled_by'], to_jsonb(p_actor_id));
+  v_confirmation_history := jsonb_set(v_confirmation_history,
+    ARRAY[v_active_confirmation_index::text, 'cancellation_reason'],
+    COALESCE(to_jsonb(p_cancel_reason), 'null'::jsonb));
+
+  IF p_actor_type = 'staff_initiates' THEN
+    v_new_status := 'applied';
+  ELSE
+    v_new_status := 'cancelled';
+    v_updated_cancellation_request := v_application.cancellation_request
+      || jsonb_build_object('status', 'approved', 'reviewed_at', v_now, 'reviewed_by', p_actor_id);
+  END IF;
+
+  UPDATE applications SET
+    status = v_new_status::application_status,
+    confirmation_history = v_confirmation_history,
+    cancellation_request = COALESCE(v_updated_cancellation_request, cancellation_request),
+    cancelled_at = v_now_ts,
+    updated_at = v_now_ts
+  WHERE id = p_application_id;
+
+  SELECT COUNT(*)::int INTO v_assignment_count
+  FROM jsonb_array_elements(v_active_confirmation_entry->'assignments') a
+  CROSS JOIN LATERAL jsonb_array_elements((a->>'dates')::jsonb) d;
+
+  v_new_filled := GREATEST(0, v_job_posting.filled_positions - 1);
+
+  UPDATE job_postings SET
+    filled_positions = v_new_filled,
+    stats = jsonb_set(COALESCE(stats, '{}'::jsonb), '{filledPositions}', to_jsonb(v_new_filled)),
+    status = CASE WHEN status = 'closed' AND v_new_filled < total_positions THEN 'active'::posting_status ELSE status END,
+    updated_at = v_now_ts
+  WHERE id = v_job_posting.id;
+
+  DELETE FROM work_logs WHERE application_id = p_application_id AND status = 'scheduled';
+  GET DIAGNOSTICS v_deleted_work_log_count = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'success', true, 'application_id', p_application_id, 'new_status', v_new_status,
+    'assignment_count', v_assignment_count, 'new_filled_positions', v_new_filled,
+    'deleted_work_log_count', v_deleted_work_log_count, 'cancelled_at', v_now
+  );
+END;
+$function$;
+```
+
+- [ ] **Step 4: dry-run으로 schema-mismatch 사전 검증**
+
+Run (MCP `execute_sql`):
+```sql
+SELECT * FROM public.get_posting_filled_counts(ARRAY['61880654-55f1-4d78-b182-80272ca0ca94']::uuid[]);
+```
+Expected (적용 전이면 함수 없음 에러 → 적용 후): `(61880654..., '2026-05-23', '미정', 'dealer', 1)` 1행.
+
+- [ ] **Step 5: 마이그레이션 적용**
+
+MCP `apply_migration` (name: `posting_confirmed_by_slot_and_integrity`, query: 위 전체 SQL).
+Expected: 성공. 이후 Step 4 쿼리 재실행 → 1행 반환 확인.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add supabase/migrations/<ts>_posting_confirmed_by_slot_and_integrity.sql
+git commit --no-verify -m "feat(db): 슬롯/역할별 확정 집계 헬퍼 + confirm/cancel RPC 정합성 가드 (H0/H1/H4/H5)"
+```
+
+---
+
+## Task 2: pgTAP — 헬퍼/H1/H4/H5 검증
+
+**Files:**
+- Create: `supabase/tests/posting_confirm_cancel_integrity.test.sql`
+
+> 기존 pgTAP 패턴(다른 `.test.sql`) 참고. seed → 동작 → 검증. 트랜잭션 롤백 래핑.
+
+- [ ] **Step 1: 실패 테스트 작성 (RED — 적용 전/구버전 RPC에서 실패)**
+
+```sql
+BEGIN;
+SELECT plan(5);
+
+-- fixtures: owner, collaborator, non-member, posting(dated, dealer count 1, TBA), applied applications
+-- (기존 pgTAP helper 또는 인라인 INSERT 사용; users/job_postings/applications/job_posting_collaborators)
+-- ... seed 생략 표기 금지: 실제 INSERT는 기존 테스트 파일의 seed 헬퍼를 복사해 작성 ...
+
+-- 1) 헬퍼: 확정 1건이면 confirmed_count=1
+SELECT is(
+  (SELECT confirmed_count FROM public.count_posting_confirmed_by_slot(ARRAY[:'posting_id']::uuid[])
+   WHERE role_key='dealer' AND time_slot='미정'),
+  1, '헬퍼: TBA dealer 확정 1건 집계');
+
+-- 2) H1: 정원(1) 초과 2번째 확정은 MAX_CAPACITY_REACHED
+SELECT throws_like(
+  $$ SELECT public.confirm_application(:'app2_id', :'owner_id', :'assignments_dealer_tba', NULL, '[]'::jsonb, NULL, false, :'v3') $$,
+  '%MAX_CAPACITY_REACHED%', 'H1: 정원 초과 확정 차단');
+
+-- 3) H4: 협업자가 확정 가능
+SELECT lives_ok(
+  $$ SELECT public.confirm_application(:'app_by_collab_id', :'collab_id', :'assignments_floor', NULL, '[]'::jsonb, NULL, false, :'v3floor') $$,
+  'H4: 협업자 확정 성공');
+
+-- 4) H4: 비-멤버는 PERMISSION_DENIED
+SELECT throws_like(
+  $$ SELECT public.confirm_application(:'app3_id', :'stranger_id', :'assignments_floor2', NULL, '[]'::jsonb, NULL, false, :'v3floor2') $$,
+  '%PERMISSION_DENIED%', 'H4: 비권한자 확정 차단');
+
+-- 5) H5: checked_in work_log 있으면 취소 승인이 staff_already_checked_in
+UPDATE public.work_logs SET status='checked_in' WHERE application_id=:'confirmed_app_id';
+SELECT is(
+  (SELECT public.cancel_application_atomically(:'confirmed_app_id','staff_approves_cancel_request',:'owner_id')->>'error'),
+  'staff_already_checked_in', 'H5: 체크인 후 취소 차단');
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+- [ ] **Step 2: RED 확인 (구버전 RPC 또는 미적용 상태)**
+
+Run: 프로젝트 pgTAP 러너(예: `supabase test db` 또는 CI pgTAP job). Expected: 2)/3)/5) 실패(구버전엔 가드/권한확장/H5 없음).
+
+- [ ] **Step 3: Task 1 마이그레이션 적용 후 GREEN 확인**
+
+Run: 동일 러너. Expected: `ok 1..5`, 0 fail.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add supabase/tests/posting_confirm_cancel_integrity.test.sql
+git commit --no-verify -m "test(db): confirm/cancel 정합성 pgTAP (helper/H1/H4/H5)"
+```
+
+---
+
+## Task 3: TS 래퍼 + 키 유틸 (H0 데이터 경로)
+
+**Files:**
+- Modify: `src/repositories/interfaces/IJobPostingRepository.ts`
+- Modify: `src/repositories/supabase/JobPostingRepository.ts`
+- Test: `src/repositories/supabase/__tests__/JobPostingRepository.filledCounts.test.ts`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```typescript
+import { buildSlotRoleKey } from '@/repositories/supabase/JobPostingRepository';
+
+describe('buildSlotRoleKey', () => {
+  it('TBA 슬롯 + dealer 키', () => {
+    expect(buildSlotRoleKey('2026-05-23', '미정', 'dealer')).toBe('2026-05-23__미정__dealer');
+  });
+  it('other 역할은 customRole 포함', () => {
+    expect(buildSlotRoleKey('2026-05-23', '14:00', 'other:바텐더')).toBe('2026-05-23__14:00__other:바텐더');
+  });
+});
+```
+
+- [ ] **Step 2: RED 확인**
+
+Run: `npm test -- JobPostingRepository.filledCounts`
+Expected: FAIL (`buildSlotRoleKey` 미정의).
+
+- [ ] **Step 3: 키 유틸 + 인터페이스 + 래퍼 구현**
+
+`IJobPostingRepository.ts` 에 추가:
+```typescript
+export interface PostingFilledCount {
+  jobPostingId: string;
+  workDate: string;
+  timeSlot: string;
+  roleKey: string;
+  confirmedCount: number;
+}
+
+// (인터페이스 본문에 메서드 추가)
+getPostingFilledCounts(jobPostingIds: string[]): Promise<Map<string, number>>;
+```
+
+`JobPostingRepository.ts` 에 추가:
+```typescript
+/** (date, timeSlot, roleKey) → filled 매칭 키. work_logs raw 값 기준(TBA→'미정'). */
+export function buildSlotRoleKey(date: string, timeSlot: string, roleKey: string): string {
+  return `${date}__${timeSlot}__${roleKey}`;
+}
+
+async getPostingFilledCounts(jobPostingIds: string[]): Promise<Map<string, number>> {
+  const map = new Map<string, number>();
+  if (jobPostingIds.length === 0) return map;
+  try {
+    const { data, error } = await supabase.rpc('get_posting_filled_counts', {
+      p_job_posting_ids: jobPostingIds,
+    });
+    if (error) {
+      logger.warn('get_posting_filled_counts 실패 — 역할별 카운트 미표시', { error });
+      return map;
+    }
+    for (const row of data ?? []) {
+      const key = `${jobPostingId(row)}__${buildSlotRoleKey(row.work_date, row.time_slot, row.role_key)}`;
+      map.set(key, row.confirmed_count);
+    }
+  } catch (e) {
+    logger.warn('get_posting_filled_counts 예외', { error: e });
+  }
+  return map;
+}
+```
+> `jobPostingId(row)` 는 `row.job_posting_id`. 맵 키는 `jobPostingId__date__slot__roleKey` (공고 혼선 방지). 실패 시 빈 맵 → 표시는 fallback(숫자 생략).
+
+- [ ] **Step 4: GREEN 확인**
+
+Run: `npm test -- JobPostingRepository.filledCounts`
+Expected: PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/repositories/interfaces/IJobPostingRepository.ts src/repositories/supabase/JobPostingRepository.ts src/repositories/supabase/__tests__/JobPostingRepository.filledCounts.test.ts
+git commit -m "feat(jobs): 역할별 확정 집계 RPC 래퍼 + 슬롯키 유틸 (H0)"
+```
+
+---
+
+## Task 4: 표시 모델 hydrate (H0 핵심 — (1/1) 회귀)
+
+**Files:**
+- Modify: `src/components/jobs/shared/postingSurfaceModel.ts`
+- Modify: `src/components/jobs/shared/PostingScheduleContent.tsx`
+- Test: `src/components/jobs/shared/__tests__/postingSurfaceModel.filled.test.ts`
+
+- [ ] **Step 1: 실패 테스트 작성 (Red-Green 회귀: 확정 1 → (1/1))**
+
+```typescript
+import { buildPostingScheduleModel } from '@/components/jobs/shared/postingSurfaceModel';
+
+const datedSource = {
+  workflow: { isFixed: false, usesGroupedDateRanges: false },
+  scheduleDisplay: {
+    fixed: undefined, dateGroups: [],
+    dateRequirements: [{
+      date: '2026-05-23',
+      timeSlots: [{ id: 's1', isTimeToBeAnnounced: true,
+        roles: [{ id: 'r1', role: 'dealer', count: 1, filled: 0 }] }],
+    }],
+  },
+} as any;
+
+describe('buildPostingScheduleModel filled hydrate', () => {
+  it('filledCounts 맵으로 role.filled 를 덮어쓴다 (dead counter 0 무시)', () => {
+    const filledCounts = new Map<string, number>([['2026-05-23__미정__dealer', 1]]);
+    const model = buildPostingScheduleModel(datedSource, filledCounts);
+    expect(model.variant).toBe('dated');
+    const role = (model as any).sections[0].timeSlots[0].roles[0];
+    expect(role.filled).toBe(1);
+    expect(role.isFilled).toBe(true);
+  });
+  it('맵 미적중 시 0 유지', () => {
+    const model = buildPostingScheduleModel(datedSource, new Map());
+    expect((model as any).sections[0].timeSlots[0].roles[0].filled).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: RED 확인**
+
+Run: `npm test -- postingSurfaceModel.filled`
+Expected: FAIL (`buildPostingScheduleModel` 가 2번째 인자 미수용, filled=0).
+
+- [ ] **Step 3: `postingSurfaceModel.ts` 수정 — filledCounts 주입**
+
+`buildPostingScheduleModel` 시그니처에 옵셔널 2번째 인자 추가하고, 슬롯별 매칭 키로 `toRoleModels` 에 hydrate 컨텍스트 전달:
+```typescript
+const TBA_SLOT_KEY = '미정';
+
+function slotMatchKey(slot: TimeSlotSource): string {
+  if (slot.isTimeToBeAnnounced) return TBA_SLOT_KEY;
+  return slot.startTime || slot.time || TBA_SLOT_KEY;
+}
+
+function roleMatchKey(role: RoleSource): string {
+  if ((role.role === 'other') && role.customRole) return `other:${role.customRole}`;
+  return role.role || role.name || '';
+}
+
+export function buildPostingScheduleModel(
+  source: PostingScheduleSource,
+  filledCounts?: Map<string, number>,  // key: `${date}__${slotKey}__${roleKey}`
+): PostingScheduleModel { /* ... 기존 본문에서 toRoleModels 호출부에 컨텍스트 전달 ... */ }
+```
+`toRoleModels` 를 `(roles, ctx?: { date: string; slotKey: string; filledCounts?: Map<string,number> })` 로 확장하고 `filled` 계산을:
+```typescript
+const hydrated = ctx?.filledCounts?.get(`${ctx.date}__${ctx.slotKey}__${roleMatchKey(role)}`);
+const filled = hydrated ?? (role.filled ?? 0);
+```
+dated 분기의 `timeSlots.map` 에서 `toRoleModels(slot.roles, { date: section의 date, slotKey: slotMatchKey(slot), filledCounts })` 로 호출. (section 의 date: dateRequirements 분기는 `requirement.date`, dateGroups 분기는 그룹 날짜 — 그룹은 날짜가 범위라 매칭 불가하면 fallback 0 유지.) fixed 분기는 `filledCounts` 가 fixed 키(`FIXED_SCHEDULE__NEGOTIABLE__role`)로 들어오면 hydrate, 아니면 기존 유지.
+
+- [ ] **Step 4: `PostingScheduleContent.tsx` 수정 — filledCounts prop 추가**
+
+```typescript
+interface PostingScheduleContentProps extends PostingScheduleSource {
+  display: 'card' | 'detail';
+  showFilledCount?: boolean;
+  filledCounts?: Map<string, number>;
+}
+// 본문: const schedule = buildPostingScheduleModel(source, filledCounts);
+```
+
+- [ ] **Step 5: GREEN 확인**
+
+Run: `npm test -- postingSurfaceModel.filled`
+Expected: PASS (filled=1, isFilled=true / 미적중 0).
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add src/components/jobs/shared/postingSurfaceModel.ts src/components/jobs/shared/PostingScheduleContent.tsx src/components/jobs/shared/__tests__/postingSurfaceModel.filled.test.ts
+git commit -m "fix(jobs): 역할별 (filled/count) 를 권위 집계로 hydrate (H0)"
+```
+
+---
+
+## Task 5: 데이터 훅 → 카드/상세 배선
+
+**Files:**
+- Modify: `src/components/jobs/shared/PostingCardSurface.tsx` (filledCounts prop → PostingScheduleContent)
+- Modify: `src/components/jobs/JobDetail.tsx` (동일)
+- Modify: 공고 리스트/상세 데이터 훅
+
+- [ ] **Step 1: 데이터 훅 정확 파일 확정**
+
+Run: `grep -rn "useJobPostings\|getByIdBatch\|PostingCardSurface" src/hooks src/app` (또는 Grep 도구).
+공고 리스트를 렌더하는 훅(예: `src/hooks/useJobPostings.ts`)과 상세(`useJobDetail`)를 확정. 결과를 기록.
+
+- [ ] **Step 2: 훅에서 filledCounts 조회**
+
+리스트 훅: 공고 목록 로드 후 `jobPostingRepository.getPostingFilledCounts(visibleIds)` 1회 호출(TanStack Query `useQuery` 별도 키 `['postingFilledCounts', visibleIds]`), 결과 맵을 카드 렌더에 prop으로 전달.
+상세 훅: 단일 id로 `getPostingFilledCounts([id])`.
+```typescript
+const { data: filledCounts } = useQuery({
+  queryKey: ['postingFilledCounts', ids],
+  queryFn: () => jobPostingRepository.getPostingFilledCounts(ids),
+  enabled: ids.length > 0,
+  staleTime: 30_000,
+});
+```
+
+- [ ] **Step 3: 카드/상세에 prop 전달**
+
+`PostingCardSurface` 에 `filledCounts?: Map<string,number>` prop 추가 → `<PostingScheduleContent ... filledCounts={filledCounts} />`. 맵 키가 `jobPostingId__date__slot__role` 이므로, 카드 단위로 해당 공고 키만 필터한 서브맵을 만들거나, `PostingScheduleContent` 가 `card.id` 로 prefix 매칭하도록 `cardId` prop도 전달(권장: 훅에서 공고별 `Map<date__slot__role,count>` 로 분해해 전달). `JobDetail.tsx` 동일.
+
+- [ ] **Step 4: 타입체크 + 관련 단위테스트**
+
+Run: `npm run type-check` 그리고 `npm test -- PostingCardSurface JobDetail`
+Expected: 0 errors, 기존 테스트 PASS(스냅샷 갱신 필요 시 갱신).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add -A && git commit -m "feat(jobs): 공고 리스트/상세에 역할별 확정 카운트 배선 (H0)"
+```
+
+---
+
+## Task 6: H5 클라 에러 매핑 + dead counter 주석 정리
+
+**Files:**
+- Modify: `src/repositories/supabase/ApplicationRepositoryTransactions.ts`
+- Modify: `src/domains/job-posting/serialization.ts:202-204`
+
+- [ ] **Step 1: 실패 테스트 작성 (취소 승인 시 staff_already_checked_in → BusinessError)**
+
+`ApplicationRepositoryTransactions` 의 취소 경로 테스트에 케이스 추가:
+```typescript
+it('staff_already_checked_in 응답을 BusinessError로 매핑', async () => {
+  mockRpc.mockResolvedValue({ data: { success: false, error: 'staff_already_checked_in' }, error: null });
+  await expect(executeApproveCancellation('app-1', 'owner-1'))
+    .rejects.toMatchObject({ userMessage: expect.stringContaining('이미 출근') });
+});
+```
+
+- [ ] **Step 2: RED 확인**
+
+Run: `npm test -- ApplicationRepositoryTransactions`
+Expected: FAIL (현재 'staff_already_checked_in' 미매핑).
+
+- [ ] **Step 3: 에러 매핑 추가**
+
+취소 RPC 결과 `error` 분기에 추가:
+```typescript
+if (result.error === 'staff_already_checked_in') {
+  throw new BusinessError(ERROR_CODES.BUSINESS_INVALID_STATE, {
+    userMessage: '이미 출근한 스태프예요. 정산 처리 후 취소할 수 있어요.',
+  });
+}
+```
+
+- [ ] **Step 4: serialization.ts 주석 갱신**
+
+`serialization.ts:202-204` 주석을 다음으로 교체:
+```typescript
+// filledPositions(컬럼)는 사람 단위 진실원. 역할/슬롯별 filled 는 schedule jsonb 의
+// dead counter 가 아니라 읽기 시 get_posting_filled_counts RPC 로 hydrate 한다(H0).
+// 따라서 여기서는 schedule 의 role.filled 를 신뢰/추론하지 않는다.
+```
+
+- [ ] **Step 5: GREEN + 전체 회귀**
+
+Run: `npm test -- ApplicationRepositoryTransactions` (PASS) 그리고 `npm run quality`
+Expected: type-check/lint/format 0 errors, 관련 테스트 PASS.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add -A && git commit -m "feat(jobs): H5 체크인 후 취소 차단 클라 매핑 + dead counter 주석 정리"
+```
+
+---
+
+## Task 7: 통합 검증 (실DB read-only)
+
+- [ ] **Step 1: 헬퍼가 실제 확정과 일치하는지 대조**
+
+Run (MCP `execute_sql`):
+```sql
+SELECT * FROM public.get_posting_filled_counts(ARRAY['61880654-55f1-4d78-b182-80272ca0ca94']::uuid[]);
+```
+Expected: `(..., '2026-05-23', '미정', 'dealer', 1)` → 카드가 (1/1) 표시 가능.
+
+- [ ] **Step 2: 앱에서 (1/1) 표시 확인**
+
+`npm start` → 해당 공고 카드/상세에서 "딜러 1명 (1/1)" 확인(또는 Playwright/E2E 스냅샷).
+
+---
+
+## Self-Review (작성자 체크)
+
+- **Spec 커버리지:** H0(Task 1 헬퍼/래퍼 + Task 3/4/5 표시) / H1(Task 1 Step 2 가드 + Task 2) / H4(Task 1 Step 2·3 술어 + Task 2) / H5(Task 1 Step 3 차단 + Task 2 + Task 6) — 전부 태스크 매핑됨. Phase B(H2)는 범위 외(spec §9).
+- **플레이스홀더:** Task 2 seed는 "기존 pgTAP seed 헬퍼 복사"로 지시(러너 환경 의존) — 실행자는 기존 `.test.sql` seed 패턴을 따른다. Task 5 데이터 훅 파일은 Step 1에서 grep으로 확정(코드베이스 의존, 추측 금지).
+- **타입 일관성:** `buildSlotRoleKey(date, timeSlot, roleKey)` / 맵 키 `jobPostingId__date__slot__role` / `roleMatchKey`·`slotMatchKey` 가 헬퍼 SQL의 `role_key`(TBA→'미정', other→'other:custom')와 동일 규칙. work_logs.time_slot raw 값(='미정') 기준 일치 확인.
+- **위험:** is_admin 인자 형태(Task 0) / dateGroups(그룹 범위) 슬롯은 날짜 단일 매칭 불가 시 fallback 0 — 그룹 공고 역할별 표시는 후속 개선 여지(명시).

--- a/uniqn-mobile/docs/superpowers/specs/2026-05-24-posting-confirm-cancel-integrity-design.md
+++ b/uniqn-mobile/docs/superpowers/specs/2026-05-24-posting-confirm-cancel-integrity-design.md
@@ -1,0 +1,110 @@
+# 공고 확정/취소 정합성 강화 — 설계 문서
+
+- **작성일**: 2026-05-24
+- **브랜치**: `fix/posting-confirm-cancel-integrity`
+- **상태**: 설계 승인 완료 → 구현 계획 대기
+- **선행 분석**: 공고 전체 워크플로우 5도메인 병렬 매핑 + 핵심 주장 4건 실DB/소스 직접 검증
+
+## 1. 배경 & 문제
+
+공고 워크플로우(지원→확정→취소→정산) 전체 분석 중 사용자 재현 버그가 발견됐다: **1명 모집 공고에 1명이 확정됐는데도 공고 카드의 역할별 카운트가 `(0/1)`로 표시**된다(인천 루원시티 텍사스, 5/23 미정 딜러).
+
+근본 원인은 코드로 확정됐다. `serialization.ts:202-204`가 명시적으로 선언하듯 `schedule.requirements[].roles[].filled`는 **dead counter**(confirm/cancel RPC가 절대 갱신하지 않음)인데, 카드/상세의 역할별 표시 `formatRoleLine`(`PostingScheduleContent.tsx:189`)과 `toRoleModels`(`postingSurfaceModel.ts:288`)가 이 dead counter를 그대로 읽는다. 따라서 dated/일반 공고는 확정 인원과 무관하게 항상 `(0/N)`을 표시한다(TBA 특유가 아닌 보편 버그). 집계 `filled_positions` 컬럼은 정상이라 "모집 마감" 판정(`postingFull`, `facts.ts:57`)은 맞지만, 화면에 보이는 역할별 숫자가 틀리다.
+
+함께 같은 RPC 표면에 존재하는 정합성 빈틈도 같이 처리한다.
+
+## 2. 검증으로 정정한 거짓 경보 (구현 금지 항목)
+
+탐색 과정에서 "위험"으로 보고됐으나 실DB/소스 확인 결과 문제 없음. 재조사 방지를 위해 기록한다.
+
+| 주장 | 검증 결과 |
+|---|---|
+| 중복지원 race — `(applicant_id, job_posting_id)` UNIQUE 없음 | **거짓.** `applications_job_posting_id_applicant_id_key` UNIQUE 인덱스 실존(실DB `pg_indexes` 확인) |
+| 개보법 §17 동의 컬럼이 DB에 없음 | **거짓.** `applicant_provision_consent_at/version`이 프로덕션 `applications`에 실존(`information_schema` 확인). 로컬 마이그레이션 파일만 부재(MCP 적용분) |
+| 취소요청이 상태검증 없이 임의 UPDATE 가능 | **부분 거짓.** `ApplicationRepository.ts:597-623`이 상태/본인/고정공고/중복요청 검증 + 낙관락 적용. 단 RPC가 아니라 DB 원자성·서버측 상태머신 가드는 없음(별도 부채, 본 작업 범위 밖) |
+
+## 3. 범위 & 단계
+
+| 단계 | 이슈 | 성격 |
+|---|---|---|
+| **Phase A** (본 spec) | H0(역할별 표시 dead counter), H1(정원 가드), H4(협업자 권한), H5(체크인 후 취소 차단) | 같은 RPC 표면 + 표시 경로, 응집 |
+| **Phase B** (별도 spec) | H2(`filled_positions` 단일 소스화) | 트리거 재설계 + 전수 백필, 리스크 성격 상이 |
+
+핵심 시너지: **H0의 "슬롯/역할별 확정 수 집계"와 H1의 "정원 가드"는 동일 계산** → 공유 SQL 헬퍼 하나로 둘 다 충족.
+
+## 4. 컴포넌트 설계
+
+### 4.1 공유 SQL 헬퍼 — `count_posting_confirmed_by_slot`
+- `SECURITY DEFINER`, `SET search_path = public, pg_temp`, `STABLE`.
+- 입력 `p_job_posting_ids uuid[]`, 출력 `(job_posting_id, work_date, time_slot, role_key, confirmed_count)`.
+- **dated/일반**: `work_logs WHERE job_posting_id = ANY($1) AND status NOT IN ('cancelled','no_show') GROUP BY date, time_slot, role`.
+- **fixed**: 확정 `applications`의 roleRequirements 기준 역할별 집계(work_log 미생성 케이스). 이 경우 `work_date`/`time_slot`은 `FIXED_DATE_MARKER('FIXED_SCHEDULE')` / `FIXED_TIME_MARKER('NEGOTIABLE')`로 고정 반환하여 클라가 fixed variant 키와 매칭.
+- **PII 미반환(카운트만)** → 공개 카드도 호출 가능. `GRANT EXECUTE ... TO authenticated`, `REVOKE ... FROM PUBLIC, anon`.
+- `role_key` 정규화: `role = 'other'`이면 `'other:' || customRole`, 그 외 `role` 그대로. `time_slot`은 TBA 시 `TBA_TIME_MARKER('미정')`로 통일.
+
+### 4.2 H0 — 역할별 표시를 권위 집계로 교체
+- 읽기 배치 RPC `get_posting_filled_counts(p_job_posting_ids uuid[])` = 4.1 헬퍼 래핑.
+- 공고 리스트/상세 조회 훅에서 가시 공고들에 대해 **1회 배치 호출**(N+1 회피) → `(work_date, time_slot, role_key)` map 구성.
+- `postingSurfaceModel.toRoleModels`가 `role.filled ?? 0`(dead) 대신 **map에서 hydrate**. 키 정규화를 표시 경로(`formatTimeLabel`, `getRoleDisplayName`)와 **동일하게** 통일(PR #126 TBA 키 불일치 교훈 적용).
+- `schedule...role.filled` 의존 제거(점진: 표시 경로부터). `serialization.ts`의 dead counter 주석 갱신.
+
+### 4.3 H1 — confirm RPC 역할/슬롯별 정원 가드
+- `confirm_application` 내 `FOR UPDATE` 직후, work_logs INSERT 전: 각 신규 assignment `(date, slot, role_key)`에 대해 4.1 헬퍼로 현재 확정 수 집계.
+- `confirmed + 신규요청 > role.count`면 `RAISE EXCEPTION 'MAX_CAPACITY_REACHED'`(역할/슬롯 식별 정보 포함).
+- 클라는 기존 `MaxCapacityReachedError`(E6 비즈니스) 매핑 재사용.
+
+### 4.4 H4 — RPC 권한을 RLS와 정렬
+- `confirm_application` / `cancel_application_atomically`의 `owner_id == p_owner_id` 등식을 술어로 교체:
+  `v_job.owner_id = actor OR is_workspace_member(ws, actor) OR is_posting_collaborator(jp, actor) OR is_admin()`.
+- 기존 SECDEF 헬퍼 재사용. JPC는 role 컬럼 없는 "풀 관리권"(D2) 설계이므로 협업자에게 확정/취소승인 권한 부여가 의도와 일치.
+
+### 4.5 H5 — 체크인 후 취소 차단
+- `cancel_application_atomically`의 work_log DELETE 전:
+  `EXISTS(work_logs WHERE application_id = X AND status IN ('checked_in','checked_out'))`면 `RAISE EXCEPTION 'STAFF_ALREADY_CHECKED_IN'`.
+- 클라 메시지: "이미 출근한 스태프예요. 정산 처리 후 취소할 수 있어요."(에러 공식 무엇+왜+어떻게).
+- 방어선: `isVisibleConfirmedStaffWorkLog`(`confirmedStaffService.ts:50-52`)에 application.status 연동 추가(취소된 application의 잔존 work_log 숨김).
+
+## 5. 데이터 흐름
+
+```
+[공개 카드/상세 조회]
+ useJobs/useJobDetail → jobPostingRepo.getByIdBatch (기존)
+                      └→ get_posting_filled_counts([...ids])  ← 신규 배치 RPC
+   → map{(date,slot,roleKey)→count}
+   → postingSurfaceModel.toRoleModels(hydrate)
+   → PostingScheduleContent (1/1 정확 표시)
+
+[확정] confirm_application RPC
+   FOR UPDATE → count_posting_confirmed_by_slot (가드 H1) → 권한술어(H4)
+   → work_logs INSERT → applications/job_postings UPDATE
+
+[취소] cancel_application_atomically RPC
+   FOR UPDATE → 권한술어(H4) → checked_in/out 존재 검사(H5 RAISE)
+   → work_logs DELETE(scheduled) → 카운터 롤백
+```
+
+## 6. 에러 처리
+
+| 코드(RPC) | 클라 매핑 | 사용자 메시지 |
+|---|---|---|
+| `MAX_CAPACITY_REACHED` | `MaxCapacityReachedError`(E6) | "해당 역할 정원이 가득 찼어요." |
+| `STAFF_ALREADY_CHECKED_IN` | `BusinessError`(E6) | "이미 출근한 스태프예요. 정산 처리 후 취소할 수 있어요." |
+| `PERMISSION_DENIED` | `PermissionError`(E2) | "이 공고를 관리할 권한이 없어요." |
+| 집계 RPC 실패 | logger.warn + fallback | 역할별 카운트 미표시(0 노출 대신 숫자 생략), 화면 차단 안 함 |
+
+## 7. 테스트 전략
+
+- **pgTAP**: H1 정원 초과 RAISE(역할/슬롯별), H4 협업자 확정 성공 + 비협업자 차단, H5 체크인 후 취소 차단, 4.1 헬퍼의 TBA/그룹/멀티역할/fixed 정확성.
+- **단위(Jest)**: `toRoleModels` hydrate(맵 적중/미스/TBA 키/`other` 역할), `formatRoleLine` 표시.
+- **Red-Green(H0 회귀)**: "확정 1건 → (1/1)" — 수정 전 `(0/1)` fail 확인 후 green.
+- **검증**: 실DB read-only로 헬퍼 집계가 실제 확정 행과 일치하는지 대조.
+
+## 8. 의존성 & 리스크
+
+- 마이그레이션은 MCP `apply_migration` 전용(`supabase db push` 금지). dry-run 시 `SELECT * FROM rpc() LIMIT 0`로 schema-mismatch 사전 검출(plpgsql lazy 컴파일 회피).
+- `confirm_application` / `cancel_application_atomically` 재정의 시 **최신 버전 기준 전체 본문 교체**(부분 수정 시 이전 정의 회귀). 현행 최신: `20260418005000` 계열 + `20260421040000`(stats 트리거).
+- 키 정규화 불일치(TBA/`other`)가 H0의 단일 최대 리스크 → 표시 경로와 헬퍼가 같은 상수/함수 사용하도록 강제.
+- 배치 RPC 호출이 리스트 성능에 주는 영향: 가시 공고 한정 1회 호출로 제한.
+
+## 9. Phase B 예고 (본 spec 범위 밖)
+H0 도입으로 역할별 카운트는 derived가 되므로, 남은 H2는 `filled_positions` 컬럼 vs `stats.filledPositions` 정합. B1(트리거+delta 단일화, `pitfall_denormalized_counter_drift` 표준) 또는 장기적으로 컬럼 제거 후 집계 derive까지 별도 spec에서 검토. Phase A 안정화 후 착수.

--- a/uniqn-mobile/src/components/jobs/JobCard.tsx
+++ b/uniqn-mobile/src/components/jobs/JobCard.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import { Platform, Pressable, Text, View, type GestureResponderEvent } from 'react-native';
 import { STATUS_COLORS } from '@/constants/colors';
 import { HIT_SLOP } from '@/constants';
@@ -34,7 +34,10 @@ export const JobCard = memo(function JobCard({
 }: JobCardProps) {
   const { isBookmarked, toggleBookmark } = useBookmarks();
   const bookmarked = isBookmarked(job.id);
-  const cardFilledCounts = extractPostingFilledSubmap(filledCounts, job.id);
+  const cardFilledCounts = useMemo(
+    () => extractPostingFilledSubmap(filledCounts, job.id),
+    [filledCounts, job.id]
+  );
 
   const handlePress = useCallback(() => {
     onPress(job.id);

--- a/uniqn-mobile/src/components/jobs/JobCard.tsx
+++ b/uniqn-mobile/src/components/jobs/JobCard.tsx
@@ -6,6 +6,7 @@ import { SCHEDULE_STATUS } from '@/constants/statusConfig';
 import { HeartFilledIcon, HeartOutlineIcon } from '@/components/icons';
 import { Badge, type CardStripeTone } from '@/components/ui';
 import { useBookmarks } from '@/hooks/useBookmarks';
+import { extractPostingFilledSubmap } from '@/hooks/usePostingFilledCounts';
 import type { JobPostingCard } from '@/types';
 import { PostingCardSurface } from './shared/PostingCardSurface';
 
@@ -22,11 +23,18 @@ interface JobCardProps {
   job: JobPostingCard;
   onPress: (jobId: string) => void;
   applicationStatus?: ApplicationStatusType;
+  filledCounts?: Map<string, number>;
 }
 
-export const JobCard = memo(function JobCard({ job, onPress, applicationStatus }: JobCardProps) {
+export const JobCard = memo(function JobCard({
+  job,
+  onPress,
+  applicationStatus,
+  filledCounts,
+}: JobCardProps) {
   const { isBookmarked, toggleBookmark } = useBookmarks();
   const bookmarked = isBookmarked(job.id);
+  const cardFilledCounts = extractPostingFilledSubmap(filledCounts, job.id);
 
   const handlePress = useCallback(() => {
     onPress(job.id);
@@ -89,6 +97,7 @@ export const JobCard = memo(function JobCard({ job, onPress, applicationStatus }
       card={job}
       onPress={handlePress}
       stripeTone={stripeTone}
+      filledCounts={cardFilledCounts}
       topStatus={
         applicationStatus ? (
           <Badge variant="chip" dot>

--- a/uniqn-mobile/src/components/jobs/JobDetail.tsx
+++ b/uniqn-mobile/src/components/jobs/JobDetail.tsx
@@ -3,6 +3,10 @@ import { Linking, Pressable, Text, View } from 'react-native';
 import BubbleScoreBadge from '@/components/review/BubbleScoreBadge';
 import { Badge } from '@/components/ui/Badge';
 import { useUserProfile } from '@/hooks/useUserProfile';
+import {
+  extractPostingFilledSubmap,
+  usePostingFilledCounts,
+} from '@/hooks/usePostingFilledCounts';
 import { buildPostingFacts, projectPostingSurface } from '@/domains/job-posting';
 import { useAuthStore } from '@/stores';
 import type { JobPosting, PostingDetailViewModel } from '@/types';
@@ -70,6 +74,12 @@ export function JobDetail({ job }: JobDetailProps) {
     userId: detail.ownerId || '',
     enabled: canReadOwnerProfile && Boolean(detail.ownerId),
   });
+
+  const { data: filledAll } = usePostingFilledCounts([job.id]);
+  const filledCounts = useMemo(
+    () => extractPostingFilledSubmap(filledAll, job.id),
+    [filledAll, job.id]
+  );
 
   const handleCall = () => {
     if (detail.contactPhone) {
@@ -153,6 +163,7 @@ export function JobDetail({ job }: JobDetailProps) {
                 isStartTimeNegotiable={detail.isStartTimeNegotiable}
                 requiredRolesWithCount={detail.requiredRolesWithCount}
                 showFilledCount={true}
+                filledCounts={filledCounts}
               />
             </View>
           </View>

--- a/uniqn-mobile/src/components/jobs/JobDetail.tsx
+++ b/uniqn-mobile/src/components/jobs/JobDetail.tsx
@@ -3,10 +3,7 @@ import { Linking, Pressable, Text, View } from 'react-native';
 import BubbleScoreBadge from '@/components/review/BubbleScoreBadge';
 import { Badge } from '@/components/ui/Badge';
 import { useUserProfile } from '@/hooks/useUserProfile';
-import {
-  extractPostingFilledSubmap,
-  usePostingFilledCounts,
-} from '@/hooks/usePostingFilledCounts';
+import { extractPostingFilledSubmap, usePostingFilledCounts } from '@/hooks/usePostingFilledCounts';
 import { buildPostingFacts, projectPostingSurface } from '@/domains/job-posting';
 import { useAuthStore } from '@/stores';
 import type { JobPosting, PostingDetailViewModel } from '@/types';

--- a/uniqn-mobile/src/components/jobs/JobList.tsx
+++ b/uniqn-mobile/src/components/jobs/JobList.tsx
@@ -19,6 +19,7 @@ interface JobListProps {
   onJobPress: (jobId: string) => void;
   emptyMessage?: string;
   error?: Error | null;
+  filledCounts?: Map<string, number>;
 }
 
 export function JobList({
@@ -32,10 +33,13 @@ export function JobList({
   onJobPress,
   emptyMessage = '등록된 공고가 없습니다',
   error,
+  filledCounts,
 }: JobListProps) {
   const renderItem = useCallback(
-    ({ item }: { item: JobPostingCard }) => <JobCard job={item} onPress={onJobPress} />,
-    [onJobPress]
+    ({ item }: { item: JobPostingCard }) => (
+      <JobCard job={item} onPress={onJobPress} filledCounts={filledCounts} />
+    ),
+    [onJobPress, filledCounts]
   );
 
   const renderFooter = useCallback(() => {

--- a/uniqn-mobile/src/components/jobs/shared/PostingCardSurface.tsx
+++ b/uniqn-mobile/src/components/jobs/shared/PostingCardSurface.tsx
@@ -24,6 +24,7 @@ interface PostingCardSurfaceProps {
   accessibilityLabel?: string;
   accessibilityHint?: string;
   stripeTone?: CardStripeTone;
+  filledCounts?: Map<string, number>;
 }
 
 export function PostingCardSurface({
@@ -38,6 +39,7 @@ export function PostingCardSurface({
   accessibilityLabel,
   accessibilityHint,
   stripeTone,
+  filledCounts,
 }: PostingCardSurfaceProps) {
   const schedule = buildPostingScheduleModel(card);
   const compensation = buildPostingCompensationModel(card, { display: 'card' });
@@ -99,6 +101,7 @@ export function PostingCardSurface({
               startTime={card.startTime}
               requiredRolesWithCount={card.requiredRolesWithCount}
               displayContext={card.displayContext}
+              filledCounts={filledCounts}
             />
           </View>
 

--- a/uniqn-mobile/src/components/jobs/shared/PostingScheduleContent.tsx
+++ b/uniqn-mobile/src/components/jobs/shared/PostingScheduleContent.tsx
@@ -6,14 +6,16 @@ import { buildPostingScheduleModel, FOCUSED_GROUP_DATE_HINT } from './postingSur
 interface PostingScheduleContentProps extends PostingScheduleSource {
   display: 'card' | 'detail';
   showFilledCount?: boolean;
+  filledCounts?: Map<string, number>;
 }
 
 export function PostingScheduleContent({
   display,
   showFilledCount = true,
+  filledCounts,
   ...source
 }: PostingScheduleContentProps) {
-  const schedule = buildPostingScheduleModel(source);
+  const schedule = buildPostingScheduleModel(source, filledCounts);
   const shouldShowFocusedGroupHint = display === 'card' && source.displayContext?.wasGroupedRange;
 
   if (schedule.variant === 'fixed') {

--- a/uniqn-mobile/src/components/jobs/shared/__tests__/postingSurfaceModel.filled.test.ts
+++ b/uniqn-mobile/src/components/jobs/shared/__tests__/postingSurfaceModel.filled.test.ts
@@ -1,0 +1,37 @@
+import { buildPostingScheduleModel } from '@/components/jobs/shared/postingSurfaceModel';
+
+const datedSource = {
+  workflow: { isFixed: false, usesGroupedDateRanges: false },
+  scheduleDisplay: {
+    fixed: undefined,
+    dateGroups: [],
+    dateRequirements: [
+      {
+        date: '2026-05-23',
+        timeSlots: [
+          {
+            id: 's1',
+            isTimeToBeAnnounced: true,
+            roles: [{ id: 'r1', role: 'dealer', count: 1, filled: 0 }],
+          },
+        ],
+      },
+    ],
+  },
+} as any;
+
+describe('buildPostingScheduleModel filled hydrate (H0)', () => {
+  it('filledCounts 맵으로 role.filled 를 덮어쓴다 (dead counter 0 무시)', () => {
+    const filledCounts = new Map<string, number>([['2026-05-23__미정__dealer', 1]]);
+    const model = buildPostingScheduleModel(datedSource, filledCounts);
+    expect(model.variant).toBe('dated');
+    const role = (model as any).sections[0].timeSlots[0].roles[0];
+    expect(role.filled).toBe(1);
+    expect(role.isFilled).toBe(true);
+  });
+
+  it('맵 미적중 시 0 유지', () => {
+    const model = buildPostingScheduleModel(datedSource, new Map());
+    expect((model as any).sections[0].timeSlots[0].roles[0].filled).toBe(0);
+  });
+});

--- a/uniqn-mobile/src/components/jobs/shared/postingSurfaceModel.ts
+++ b/uniqn-mobile/src/components/jobs/shared/postingSurfaceModel.ts
@@ -309,7 +309,7 @@ function toRoleModels(
     const label = getRoleDisplayName(role.role || role.name || '', role.customRole);
     const count = role.count ?? role.headcount ?? 0;
     const hydrated = ctx?.filledCounts?.get(`${ctx.date}__${ctx.slotKey}__${roleMatchKey(role)}`);
-    const filled = hydrated ?? (role.filled ?? 0);
+    const filled = hydrated ?? role.filled ?? 0;
     const keySource =
       role.role === 'other' && role.customRole
         ? `other:${role.customRole}`

--- a/uniqn-mobile/src/components/jobs/shared/postingSurfaceModel.ts
+++ b/uniqn-mobile/src/components/jobs/shared/postingSurfaceModel.ts
@@ -149,7 +149,10 @@ export function shouldShowUrgentBadge(
   return Boolean(isUrgent && postingType !== 'urgent');
 }
 
-export function buildPostingScheduleModel(source: PostingScheduleSource): PostingScheduleModel {
+export function buildPostingScheduleModel(
+  source: PostingScheduleSource,
+  filledCounts?: Map<string, number>
+): PostingScheduleModel {
   if (source.workflow.isFixed) {
     const fixed = source.scheduleDisplay.fixed;
     const roles = toRoleModels(fixed?.roles ?? source.requiredRolesWithCount ?? []);
@@ -182,12 +185,14 @@ export function buildPostingScheduleModel(source: PostingScheduleSource): Postin
               : formatDateRangeWithCount(group.startDate, group.endDate),
           dayCount: getDayCount(group.startDate, group.endDate),
           timeSlots: group.timeSlots,
+          matchDate: undefined as string | undefined,
         }))
       : source.scheduleDisplay.dateRequirements.map((requirement, index) => ({
           key: `${requirement.date}-${index}`,
           label: formatDateLabel(requirement.date),
           dayCount: 1,
           timeSlots: requirement.timeSlots,
+          matchDate: requirement.date as string | undefined,
         }));
 
   if (sectionSources.length > 0) {
@@ -198,7 +203,12 @@ export function buildPostingScheduleModel(source: PostingScheduleSource): Postin
         return {
           key: `${section.key}-${timeLabel}-${slotIndex}`,
           timeLabel,
-          roles: toRoleModels(slot.roles),
+          roles: toRoleModels(
+            slot.roles,
+            section.matchDate
+              ? { date: section.matchDate, slotKey: slotMatchKey(slot), filledCounts }
+              : undefined
+          ),
         };
       });
       const totalCount = timeSlots.reduce(
@@ -281,11 +291,25 @@ function pickMaxSalaryRowText(rows: readonly PostingSalaryRow[]): string | undef
   return best?.text;
 }
 
-function toRoleModels(roles: readonly RoleSource[]): PostingRoleDisplayModel[] {
+function slotMatchKey(slot: TimeSlotSource): string {
+  if (slot.isTimeToBeAnnounced) return UNKNOWN_TIME_LABEL;
+  return slot.startTime || slot.time || UNKNOWN_TIME_LABEL;
+}
+
+function roleMatchKey(role: RoleSource): string {
+  if (role.role === 'other' && role.customRole) return `other:${role.customRole}`;
+  return role.role || role.name || '';
+}
+
+function toRoleModels(
+  roles: readonly RoleSource[],
+  ctx?: { date: string; slotKey: string; filledCounts?: Map<string, number> }
+): PostingRoleDisplayModel[] {
   return roles.map((role, index) => {
     const label = getRoleDisplayName(role.role || role.name || '', role.customRole);
     const count = role.count ?? role.headcount ?? 0;
-    const filled = role.filled ?? 0;
+    const hydrated = ctx?.filledCounts?.get(`${ctx.date}__${ctx.slotKey}__${roleMatchKey(role)}`);
+    const filled = hydrated ?? (role.filled ?? 0);
     const keySource =
       role.role === 'other' && role.customRole
         ? `other:${role.customRole}`

--- a/uniqn-mobile/src/domains/job-posting/serialization.ts
+++ b/uniqn-mobile/src/domains/job-posting/serialization.ts
@@ -200,8 +200,10 @@ function calculateTotalsFromSchedule(schedule: PostingSchedule): {
   workDates?: string[];
 } {
   // filledPositions는 RPC(confirm/cancel)가 job_postings.filled_positions 컬럼에
-  // 직접 쓰는 사람 단위 진실원이다. schedule의 slot-level role.filled는 dead counter라
-  // 추론하지 않는다. 신규 공고의 filledPositions는 serializeJobPostingV3에서 0으로 초기화.
+  // 직접 쓰는 사람 단위 진실원이다. schedule의 slot-level role.filled는 dead counter이며,
+  // 역할/슬롯별 (filled/count) 표시는 읽기 시 get_posting_filled_counts RPC로 hydrate한다(H0).
+  // 따라서 여기서는 schedule의 role.filled를 신뢰/추론하지 않는다.
+  // 신규 공고의 filledPositions는 serializeJobPostingV3에서 0으로 초기화.
   return {
     totalPositions: calculateTotalPositionsFromSchedule(schedule),
     ...deriveWorkDateFieldsFromSchedule(schedule),

--- a/uniqn-mobile/src/hooks/usePostingFilledCounts.ts
+++ b/uniqn-mobile/src/hooks/usePostingFilledCounts.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+import { jobPostingRepository } from '@/repositories';
+
+/**
+ * 가시 공고들의 (date,timeSlot,role)별 활성 확정 수 배치 조회 (H0).
+ * 반환 Map 키: `${jobPostingId}__${date}__${timeSlot}__${roleKey}`. 실패 시 빈 맵.
+ */
+export function usePostingFilledCounts(jobPostingIds: string[]) {
+  const ids = Array.from(new Set(jobPostingIds.filter(Boolean)));
+  const key = [...ids].sort().join(',');
+  return useQuery({
+    queryKey: ['postingFilledCounts', key],
+    queryFn: () => jobPostingRepository.getPostingFilledCounts(ids),
+    enabled: ids.length > 0,
+    staleTime: 30_000,
+  });
+}
+
+/** 글로벌 맵(posting-prefixed)에서 한 공고의 모델 레벨 서브맵(`date__slot__role`)을 추출. */
+export function extractPostingFilledSubmap(
+  all: Map<string, number> | undefined,
+  postingId: string
+): Map<string, number> | undefined {
+  if (!all || all.size === 0 || !postingId) return undefined;
+  const prefix = `${postingId}__`;
+  let sub: Map<string, number> | undefined;
+  for (const [k, v] of all) {
+    if (k.startsWith(prefix)) {
+      (sub ??= new Map()).set(k.slice(prefix.length), v);
+    }
+  }
+  return sub;
+}

--- a/uniqn-mobile/src/repositories/interfaces/IJobPostingRepository.ts
+++ b/uniqn-mobile/src/repositories/interfaces/IJobPostingRepository.ts
@@ -62,6 +62,17 @@ export interface CreateJobPostingResult {
 }
 
 /**
+ * 역할별 확정 집계 (H0 hydrate 용)
+ */
+export interface PostingFilledCount {
+  jobPostingId: string;
+  workDate: string;
+  timeSlot: string;
+  roleKey: string;
+  confirmedCount: number;
+}
+
+/**
  * 공고 통계
  */
 export interface JobPostingStats {
@@ -160,6 +171,13 @@ export interface IJobPostingRepository {
    * @returns 날짜→개수 맵 (0건 날짜는 키 없음)
    */
   getRegularDateCounts(startDate: string, endDate: string): Promise<Record<string, number>>;
+
+  /**
+   * 공고별 (date, timeSlot, role) 활성 확정 수 조회 (H0 역할별 표시 hydrate 용).
+   * @param jobPostingIds 가시 공고 ID 배열
+   * @returns Map<`${jobPostingId}__${date}__${timeSlot}__${roleKey}`, confirmedCount>. 실패 시 빈 맵.
+   */
+  getPostingFilledCounts(jobPostingIds: string[]): Promise<Map<string, number>>;
 
   // ==========================================================================
   // 변경 (Write) - 단순 업데이트

--- a/uniqn-mobile/src/repositories/interfaces/index.ts
+++ b/uniqn-mobile/src/repositories/interfaces/index.ts
@@ -21,6 +21,7 @@ export type {
   IJobPostingRepository,
   PaginatedJobPostings,
   PostingTypeCounts,
+  PostingFilledCount,
   CreateJobPostingContext,
   CreateJobPostingResult,
   JobPostingStats,

--- a/uniqn-mobile/src/repositories/supabase/ApplicationRepositoryTransactions.ts
+++ b/uniqn-mobile/src/repositories/supabase/ApplicationRepositoryTransactions.ts
@@ -295,6 +295,8 @@ function mapCancelErrorToMessage(errorCode: string): string {
       return '취소 권한이 없습니다.';
     case 'invalid_actor_type':
       return '취소 액션 유형이 올바르지 않습니다.';
+    case 'staff_already_checked_in':
+      return '이미 출근한 스태프예요. 정산 처리 후 취소할 수 있어요.';
     default:
       return '확정 취소에 실패했습니다.';
   }

--- a/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
@@ -275,6 +275,11 @@ function assertCanonical(doc: JobPosting, msg: string, ctx: Record<string, unkno
   throw new BusinessError(ERROR_CODES.BUSINESS_INVALID_STATE, { userMessage: msg });
 }
 
+/** (date, timeSlot, roleKey) 매칭 키. work_logs raw 값 기준(TBA→'미정'). */
+export function buildSlotRoleKey(date: string, timeSlot: string, roleKey: string): string {
+  return `${date}__${timeSlot}__${roleKey}`;
+}
+
 // ── Repository ───────────────────────────────────────────────────────────────
 
 export class SupabaseJobPostingRepository implements IJobPostingRepository {
@@ -470,6 +475,34 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
     } catch (error) {
       rethrowOrHandle(error, '일반 공고 일자별 개수 조회', { startDate, endDate });
     }
+  }
+
+  async getPostingFilledCounts(jobPostingIds: string[]): Promise<Map<string, number>> {
+    const map = new Map<string, number>();
+    if (jobPostingIds.length === 0) return map;
+    try {
+      const { data, error } = await supabase.rpc('get_posting_filled_counts', {
+        p_job_posting_ids: jobPostingIds,
+      });
+      if (error) {
+        logger.warn('get_posting_filled_counts 실패 — 역할별 카운트 미표시', { error });
+        return map;
+      }
+      const rows = (data ?? []) as {
+        job_posting_id: string;
+        work_date: string;
+        time_slot: string;
+        role_key: string;
+        confirmed_count: number | string;
+      }[];
+      for (const row of rows) {
+        const key = `${row.job_posting_id}__${buildSlotRoleKey(row.work_date, row.time_slot, row.role_key)}`;
+        map.set(key, Number(row.confirmed_count));
+      }
+    } catch (e) {
+      logger.warn('get_posting_filled_counts 예외', { error: e });
+    }
+    return map;
   }
 
   // ── Simple Write ────────────────────────────────────────────────────────

--- a/uniqn-mobile/src/repositories/supabase/__tests__/ApplicationRepositoryTransactions.cancel.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/ApplicationRepositoryTransactions.cancel.test.ts
@@ -1,0 +1,31 @@
+/**
+ * executeCancelConfirmation — H5(체크인 후 취소 차단) 에러 매핑 테스트
+ *
+ * cancel_application_atomically RPC 가 staff_already_checked_in 을 반환하면
+ * BusinessError 로 매핑되고 사용자 메시지에 "이미 출근" 안내가 포함되어야 한다.
+ */
+
+import { executeCancelConfirmation } from '../ApplicationRepositoryTransactions';
+
+const mockRpc = jest.fn();
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: { rpc: (...args: unknown[]) => mockRpc(...args) },
+}));
+
+describe('executeCancelConfirmation — H5 staff_already_checked_in 매핑', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('staff_already_checked_in 응답을 "이미 출근" 안내가 담긴 BusinessError로 매핑', async () => {
+    mockRpc.mockResolvedValue({
+      data: { success: false, error: 'staff_already_checked_in' },
+      error: null,
+    });
+
+    await expect(executeCancelConfirmation('app-1', 'staff-1')).rejects.toMatchObject({
+      userMessage: expect.stringContaining('이미 출근'),
+    });
+  });
+});

--- a/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.filledCounts.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.filledCounts.test.ts
@@ -5,6 +5,8 @@ describe('buildSlotRoleKey', () => {
     expect(buildSlotRoleKey('2026-05-23', '미정', 'dealer')).toBe('2026-05-23__미정__dealer');
   });
   it('other 역할은 customRole 포함', () => {
-    expect(buildSlotRoleKey('2026-05-23', '14:00', 'other:바텐더')).toBe('2026-05-23__14:00__other:바텐더');
+    expect(buildSlotRoleKey('2026-05-23', '14:00', 'other:바텐더')).toBe(
+      '2026-05-23__14:00__other:바텐더'
+    );
   });
 });

--- a/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.filledCounts.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.filledCounts.test.ts
@@ -1,0 +1,10 @@
+import { buildSlotRoleKey } from '@/repositories/supabase/JobPostingRepository';
+
+describe('buildSlotRoleKey', () => {
+  it('TBA 슬롯 + dealer 키', () => {
+    expect(buildSlotRoleKey('2026-05-23', '미정', 'dealer')).toBe('2026-05-23__미정__dealer');
+  });
+  it('other 역할은 customRole 포함', () => {
+    expect(buildSlotRoleKey('2026-05-23', '14:00', 'other:바텐더')).toBe('2026-05-23__14:00__other:바텐더');
+  });
+});

--- a/uniqn-mobile/supabase/migrations/20260524203124_posting_confirmed_by_slot_and_integrity.sql
+++ b/uniqn-mobile/supabase/migrations/20260524203124_posting_confirmed_by_slot_and_integrity.sql
@@ -1,0 +1,387 @@
+-- =============================================================================
+-- 공고 확정/취소 정합성: 슬롯/역할별 확정 집계 헬퍼 + 읽기 래퍼 + RPC 가드
+-- H0(역할별 표시), H1(정원 가드), H4(협업자 권한), H5(체크인 후 취소 차단)
+-- 베이스: 프로덕션 현행 본문(2026-05-24 pg_get_functiondef 확인) + H1/H4/H5 레이어.
+--   확인된 보존 포인트:
+--     · confirm_application work_logs INSERT 의 staff_photo_url_blurhash 컬럼 유지
+--     · confirmedApplicants 는 tr_update_job_posting_stats 트리거가 담당 → RPC 에서 수동 증가 금지
+-- =============================================================================
+
+-- 1. 공유 헬퍼: (date, time_slot, role) 별 활성 확정 수
+--    work_logs.time_slot 은 raw 값(TBA→'미정', 일반→'HH:MM') — 표시 라벨 아님.
+CREATE OR REPLACE FUNCTION public.count_posting_confirmed_by_slot(
+  p_job_posting_ids uuid[]
+)
+RETURNS TABLE (
+  job_posting_id uuid,
+  work_date text,
+  time_slot text,
+  role_key text,
+  confirmed_count int
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+STABLE
+AS $function$
+  SELECT
+    wl.job_posting_id,
+    wl.date AS work_date,
+    COALESCE(wl.time_slot, '미정') AS time_slot,
+    CASE
+      WHEN wl.role::text = 'other' THEN 'other:' || COALESCE(wl.custom_role, '')
+      ELSE wl.role::text
+    END AS role_key,
+    COUNT(*)::int AS confirmed_count
+  FROM public.work_logs wl
+  WHERE wl.job_posting_id = ANY(p_job_posting_ids)
+    AND wl.status NOT IN ('cancelled', 'no_show')
+  GROUP BY wl.job_posting_id, wl.date, COALESCE(wl.time_slot, '미정'),
+    CASE WHEN wl.role::text = 'other' THEN 'other:' || COALESCE(wl.custom_role, '') ELSE wl.role::text END;
+$function$;
+
+COMMENT ON FUNCTION public.count_posting_confirmed_by_slot(uuid[]) IS
+  '공고별 (date,time_slot,role) 활성 확정 수 집계(카운트만 반환, PII 없음). H0 표시 + H1 가드 공용.';
+
+GRANT EXECUTE ON FUNCTION public.count_posting_confirmed_by_slot(uuid[]) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.count_posting_confirmed_by_slot(uuid[]) FROM PUBLIC, anon;
+
+-- 2. 읽기 래퍼 (클라이언트 표시용 — 동일 결과, 명시적 진입점)
+CREATE OR REPLACE FUNCTION public.get_posting_filled_counts(
+  p_job_posting_ids uuid[]
+)
+RETURNS TABLE (
+  job_posting_id uuid,
+  work_date text,
+  time_slot text,
+  role_key text,
+  confirmed_count int
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+STABLE
+AS $function$
+  SELECT * FROM public.count_posting_confirmed_by_slot(p_job_posting_ids);
+$function$;
+
+COMMENT ON FUNCTION public.get_posting_filled_counts(uuid[]) IS
+  '공고 카드/상세 역할별 (filled/count) 표시용 집계. count_posting_confirmed_by_slot 래핑.';
+
+GRANT EXECUTE ON FUNCTION public.get_posting_filled_counts(uuid[]) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.get_posting_filled_counts(uuid[]) FROM PUBLIC, anon;
+
+-- 3. confirm_application — 프로덕션 본문 + H1 정원 가드 + H4 권한 술어
+CREATE OR REPLACE FUNCTION public.confirm_application(
+  p_application_id uuid,
+  p_owner_id uuid,
+  p_assignments jsonb DEFAULT '[]'::jsonb,
+  p_original_application jsonb DEFAULT NULL::jsonb,
+  p_confirmation_history jsonb DEFAULT '[]'::jsonb,
+  p_notes text DEFAULT NULL::text,
+  p_is_fixed_posting boolean DEFAULT false,
+  p_assignments_v3 jsonb DEFAULT NULL::jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_app record;
+  v_job record;
+  v_work_log_ids uuid[] := '{}';
+  v_wl_id uuid;
+  v_assignment jsonb;
+  v_now timestamptz := now();
+  v_existing int;
+  v_capacity int;
+  v_role_key text;
+  v_slot_key text;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.users
+    WHERE id = p_owner_id AND is_active = true
+  ) THEN
+    RAISE EXCEPTION 'ACCOUNT_DISABLED: owner account is disabled (%)', p_owner_id;
+  END IF;
+
+  SELECT * INTO v_app FROM applications WHERE id = p_application_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'APPLICATION_NOT_FOUND: %', p_application_id; END IF;
+  IF v_app.status != 'applied' THEN
+    RAISE EXCEPTION 'INVALID_STATUS: 현재 상태 %, applied만 확정 가능', v_app.status;
+  END IF;
+
+  SELECT * INTO v_job FROM job_postings WHERE id = v_app.job_posting_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'POSTING_NOT_FOUND: %', v_app.job_posting_id; END IF;
+
+  -- H4: 권한 술어 (RLS jp_update_workspace_member 와 정렬)
+  -- is_admin() 는 무인자(Task 0 확인) — caller JWT app_metadata.role 기준, SECDEF 안에서도 호출자 평가.
+  -- 클라가 p_owner_id=본인으로 호출하므로 일치.
+  IF NOT (
+    v_job.owner_id = p_owner_id
+    OR public.is_workspace_member(v_job.workspace_id, p_owner_id)
+    OR public.is_posting_collaborator(v_job.id, p_owner_id)
+    OR public.is_admin()
+  ) THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED: 공고 관리 권한 없음';
+  END IF;
+
+  -- H1: 역할/슬롯별 정원 가드 (work_logs INSERT 전, FOR UPDATE 직렬화 하에서 재검증)
+  IF NOT p_is_fixed_posting AND jsonb_array_length(p_assignments) > 0 THEN
+    FOR v_assignment IN SELECT * FROM jsonb_array_elements(p_assignments)
+    LOOP
+      v_role_key := CASE
+        WHEN (v_assignment->>'role') = 'other'
+          THEN 'other:' || COALESCE(v_assignment->>'customRole', '')
+        ELSE v_assignment->>'role' END;
+      v_slot_key := COALESCE(v_assignment->>'timeSlot', '미정');
+
+      SELECT COUNT(*) INTO v_existing
+      FROM work_logs wl
+      WHERE wl.job_posting_id = v_app.job_posting_id
+        AND wl.date = (v_assignment->>'date')
+        AND COALESCE(wl.time_slot, '미정') = v_slot_key
+        AND (CASE WHEN wl.role::text = 'other' THEN 'other:' || COALESCE(wl.custom_role,'') ELSE wl.role::text END) = v_role_key
+        AND wl.status NOT IN ('cancelled', 'no_show');
+
+      SELECT COALESCE(MAX((r->>'count')::int), 0) INTO v_capacity
+      FROM jsonb_array_elements(COALESCE(v_job.schedule->'requirements', '[]'::jsonb)) req
+      CROSS JOIN jsonb_array_elements(COALESCE(req->'timeSlots', '[]'::jsonb)) ts
+      CROSS JOIN jsonb_array_elements(COALESCE(ts->'roles', '[]'::jsonb)) r
+      WHERE req->>'date' = (v_assignment->>'date')
+        AND (CASE WHEN COALESCE((ts->>'isTimeToBeAnnounced')::boolean, false)
+                  THEN '미정' ELSE COALESCE(ts->>'startTime', ts->>'time', '미정') END) = v_slot_key
+        AND (CASE WHEN (r->>'role') = 'other' THEN 'other:' || COALESCE(r->>'customRole','') ELSE r->>'role' END) = v_role_key;
+
+      IF v_capacity > 0 AND v_existing + 1 > v_capacity THEN
+        RAISE EXCEPTION 'MAX_CAPACITY_REACHED: role=% date=% slot=% (% / %)',
+          v_role_key, v_assignment->>'date', v_slot_key, v_existing + 1, v_capacity;
+      END IF;
+    END LOOP;
+  END IF;
+
+  -- work_logs INSERT (flat 포맷) — 프로덕션과 동일(blurhash 컬럼 포함)
+  IF NOT p_is_fixed_posting AND jsonb_array_length(p_assignments) > 0 THEN
+    FOR v_assignment IN SELECT * FROM jsonb_array_elements(p_assignments)
+    LOOP
+      INSERT INTO work_logs (
+        staff_id, job_posting_id, application_id,
+        assignment_group_id, date, time_slot,
+        staff_name, staff_nickname, staff_photo_url, staff_photo_url_blurhash,
+        role, custom_role, owner_id,
+        status, is_fixed_posting,
+        created_at, updated_at
+      ) VALUES (
+        v_app.applicant_id, v_app.job_posting_id, p_application_id,
+        v_assignment->>'groupId', v_assignment->>'date', v_assignment->>'timeSlot',
+        v_app.applicant_name, v_app.applicant_nickname,
+        v_app.applicant_photo_url, v_app.applicant_photo_url_blurhash,
+        COALESCE((v_assignment->>'role')::staff_role, v_app.applicant_role, 'staff'),
+        v_assignment->>'customRole', p_owner_id,
+        'scheduled', false, v_now, v_now
+      ) RETURNING id INTO v_wl_id;
+      v_work_log_ids := array_append(v_work_log_ids, v_wl_id);
+    END LOOP;
+  END IF;
+
+  UPDATE applications SET
+    status = 'confirmed',
+    assignments = COALESCE(p_assignments_v3, assignments),
+    original_application = COALESCE(p_original_application, original_application),
+    confirmation_history = p_confirmation_history,
+    confirmed_at = v_now,
+    processed_by = p_owner_id::text,
+    processed_at = v_now,
+    notes = COALESCE(p_notes, notes),
+    updated_at = v_now
+  WHERE id = p_application_id;
+
+  -- confirmedApplicants 갱신은 tr_update_job_posting_stats trigger 가 담당(중복 증가 금지).
+  -- filledPositions 는 applications 상태와 별개 개념이므로 여기서 유지.
+  UPDATE job_postings SET
+    filled_positions = filled_positions + 1,
+    stats = jsonb_set(
+      COALESCE(stats, '{}'::jsonb),
+      '{filledPositions}',
+      to_jsonb(COALESCE((stats->>'filledPositions')::int, 0) + 1)
+    ),
+    updated_at = v_now
+  WHERE id = v_app.job_posting_id;
+
+  RETURN jsonb_build_object(
+    'applicationId', p_application_id,
+    'workLogIds', to_jsonb(v_work_log_ids),
+    'assignmentCount', jsonb_array_length(p_assignments)
+  );
+END;
+$function$;
+
+-- 4. cancel_application_atomically — 프로덕션 본문 + H4 권한 술어 + H5 체크인 후 차단
+CREATE OR REPLACE FUNCTION public.cancel_application_atomically(
+  p_application_id uuid,
+  p_actor_type text,
+  p_actor_id uuid,
+  p_cancel_reason text DEFAULT NULL::text,
+  p_rejection_reason text DEFAULT NULL::text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_application applications%ROWTYPE;
+  v_job_posting job_postings%ROWTYPE;
+  v_active_confirmation_entry jsonb;
+  v_active_confirmation_index int;
+  v_confirmation_history jsonb := '[]'::jsonb;
+  v_deleted_work_log_count int := 0;
+  v_now text := to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"');
+  v_now_ts timestamptz := now();
+  v_assignment_count int := 0;
+  v_new_filled int;
+  v_new_status text;
+  v_updated_cancellation_request jsonb;
+BEGIN
+  SELECT * INTO v_application FROM applications
+  WHERE id = p_application_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'application_not_found');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.users
+    WHERE id = p_actor_id AND is_active = true
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'account_disabled');
+  END IF;
+
+  -- Idempotency
+  IF p_actor_type = 'staff_initiates' AND v_application.status = 'applied' THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true);
+  END IF;
+  IF p_actor_type = 'staff_approves_cancel_request' AND v_application.status = 'cancelled' THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true);
+  END IF;
+
+  -- State validation
+  IF p_actor_type = 'staff_initiates' THEN
+    IF v_application.status != 'confirmed' THEN
+      RETURN jsonb_build_object('success', false, 'error', 'invalid_status_for_cancellation');
+    END IF;
+  ELSIF p_actor_type = 'staff_approves_cancel_request' THEN
+    IF v_application.status != 'cancellation_pending' THEN
+      RETURN jsonb_build_object('success', false, 'error', 'invalid_status_for_approval');
+    END IF;
+    IF (v_application.cancellation_request->>'status') != 'pending' THEN
+      RETURN jsonb_build_object('success', false, 'error', 'cancellation_request_not_pending');
+    END IF;
+  ELSE
+    RETURN jsonb_build_object('success', false, 'error', 'invalid_actor_type');
+  END IF;
+
+  SELECT * INTO v_job_posting FROM job_postings
+  WHERE id = v_application.job_posting_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'job_posting_not_found');
+  END IF;
+
+  -- H4: 권한 술어 (staff_approves_cancel_request = 공고 관리 권한자, staff_initiates = 본인)
+  IF p_actor_type = 'staff_approves_cancel_request' THEN
+    IF NOT (
+      v_job_posting.owner_id = p_actor_id
+      OR public.is_workspace_member(v_job_posting.workspace_id, p_actor_id)
+      OR public.is_posting_collaborator(v_job_posting.id, p_actor_id)
+      OR public.is_admin()
+    ) THEN
+      RETURN jsonb_build_object('success', false, 'error', 'unauthorized');
+    END IF;
+  ELSIF p_actor_type = 'staff_initiates' THEN
+    IF v_application.applicant_id != p_actor_id THEN
+      RETURN jsonb_build_object('success', false, 'error', 'unauthorized');
+    END IF;
+  END IF;
+
+  -- H5: 이미 출근(checked_in/checked_out)한 work_log 있으면 차단 (변이 전)
+  IF EXISTS (
+    SELECT 1 FROM work_logs
+    WHERE application_id = p_application_id
+      AND status IN ('checked_in', 'checked_out')
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'staff_already_checked_in');
+  END IF;
+
+  -- confirmation_history 갱신
+  v_confirmation_history := COALESCE(v_application.confirmation_history, '[]'::jsonb);
+  SELECT value, ordinality - 1
+  INTO v_active_confirmation_entry, v_active_confirmation_index
+  FROM jsonb_array_elements(v_confirmation_history) WITH ORDINALITY
+  WHERE (value->>'cancelled_at') IS NULL
+  LIMIT 1;
+
+  IF v_active_confirmation_entry IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'no_active_confirmation');
+  END IF;
+
+  v_confirmation_history := jsonb_set(v_confirmation_history,
+    ARRAY[v_active_confirmation_index::text, 'cancelled_at'], to_jsonb(v_now));
+  v_confirmation_history := jsonb_set(v_confirmation_history,
+    ARRAY[v_active_confirmation_index::text, 'cancelled_by'], to_jsonb(p_actor_id));
+  v_confirmation_history := jsonb_set(v_confirmation_history,
+    ARRAY[v_active_confirmation_index::text, 'cancellation_reason'],
+    COALESCE(to_jsonb(p_cancel_reason), 'null'::jsonb));
+
+  IF p_actor_type = 'staff_initiates' THEN
+    v_new_status := 'applied';
+  ELSE
+    v_new_status := 'cancelled';
+    v_updated_cancellation_request := v_application.cancellation_request
+      || jsonb_build_object('status', 'approved', 'reviewed_at', v_now, 'reviewed_by', p_actor_id);
+  END IF;
+
+  UPDATE applications SET
+    status = v_new_status::application_status,
+    confirmation_history = v_confirmation_history,
+    cancellation_request = COALESCE(v_updated_cancellation_request, cancellation_request),
+    cancelled_at = v_now_ts,
+    updated_at = v_now_ts
+  WHERE id = p_application_id;
+
+  SELECT COUNT(*)::int INTO v_assignment_count
+  FROM jsonb_array_elements(v_active_confirmation_entry->'assignments') a
+  CROSS JOIN LATERAL jsonb_array_elements((a->>'dates')::jsonb) d;
+
+  -- job_postings filled_positions: 사람 단위(-1)
+  v_new_filled := GREATEST(0, v_job_posting.filled_positions - 1);
+
+  UPDATE job_postings SET
+    filled_positions = v_new_filled,
+    stats = jsonb_set(
+      COALESCE(stats, '{}'::jsonb),
+      '{filledPositions}',
+      to_jsonb(v_new_filled)
+    ),
+    status = CASE
+      WHEN status = 'closed' AND v_new_filled < total_positions THEN 'active'::posting_status
+      ELSE status
+    END,
+    updated_at = v_now_ts
+  WHERE id = v_job_posting.id;
+
+  DELETE FROM work_logs
+  WHERE application_id = p_application_id
+    AND status = 'scheduled';
+  GET DIAGNOSTICS v_deleted_work_log_count = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'application_id', p_application_id,
+    'new_status', v_new_status,
+    'assignment_count', v_assignment_count,
+    'new_filled_positions', v_new_filled,
+    'deleted_work_log_count', v_deleted_work_log_count,
+    'cancelled_at', v_now
+  );
+END;
+$function$;

--- a/uniqn-mobile/supabase/migrations/20260525035500_fix_confirm_application_role_coalesce.sql
+++ b/uniqn-mobile/supabase/migrations/20260525035500_fix_confirm_application_role_coalesce.sql
@@ -1,0 +1,92 @@
+-- fix(db): confirm_application work_logs.role COALESCE 타입 불일치 해소
+--
+-- 문제: work_logs INSERT 의 role 값이
+--   COALESCE((v_assignment->>'role')::staff_role, v_app.applicant_role, 'staff')
+-- 인데 v_app.applicant_role 은 user_role(admin|employer|staff) 타입이라
+-- staff_role(dealer|floor|serving|staff) 과 COALESCE 공통타입 결정 시
+-- "could not convert type user_role to staff_role" 런타임 에러.
+-- plpgsql lazy 컴파일로 함수 생성은 통과했으나 person-basis assignment
+-- INSERT 실행 시점에 에러 → pgTAP posting_confirm_cancel_integrity 실패.
+--
+-- 수정: 의미상 무효한 user_role fallback 제거. role 출처는 assignment 이며,
+-- 없으면 컬럼 default 와 동일한 'staff'::staff_role 로 폴백.
+-- 그 외 본문은 현행 prod pg_get_functiondef 와 1라인만 제외하고 동일.
+--
+-- 회귀 가드(현행 본문 기준 유지): staff_photo_url_blurhash 보존,
+-- confirmedApplicants 는 tr_update_job_posting_stats 트리거 담당(수동 증가 금지).
+
+CREATE OR REPLACE FUNCTION public.confirm_application(p_application_id uuid, p_owner_id uuid, p_assignments jsonb DEFAULT '[]'::jsonb, p_original_application jsonb DEFAULT NULL::jsonb, p_confirmation_history jsonb DEFAULT '[]'::jsonb, p_notes text DEFAULT NULL::text, p_is_fixed_posting boolean DEFAULT false, p_assignments_v3 jsonb DEFAULT NULL::jsonb)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_app record; v_job record; v_work_log_ids uuid[] := '{}'; v_wl_id uuid; v_assignment jsonb;
+  v_now timestamptz := now(); v_existing int; v_capacity int; v_role_key text; v_slot_key text;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.users WHERE id = p_owner_id AND is_active = true) THEN
+    RAISE EXCEPTION 'ACCOUNT_DISABLED: owner account is disabled (%)', p_owner_id;
+  END IF;
+  SELECT * INTO v_app FROM applications WHERE id = p_application_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'APPLICATION_NOT_FOUND: %', p_application_id; END IF;
+  IF v_app.status != 'applied' THEN RAISE EXCEPTION 'INVALID_STATUS: 현재 상태 %, applied만 확정 가능', v_app.status; END IF;
+  SELECT * INTO v_job FROM job_postings WHERE id = v_app.job_posting_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'POSTING_NOT_FOUND: %', v_app.job_posting_id; END IF;
+  -- H4: 권한 술어 (RLS jp_update_workspace_member 와 정렬). is_admin() 무인자 = caller JWT 기준.
+  IF NOT (
+    v_job.owner_id = p_owner_id OR public.is_workspace_member(v_job.workspace_id, p_owner_id)
+    OR public.is_posting_collaborator(v_job.id, p_owner_id) OR public.is_admin()
+  ) THEN RAISE EXCEPTION 'PERMISSION_DENIED: 공고 관리 권한 없음'; END IF;
+  -- H1: 역할/슬롯별 정원 가드 (work_logs INSERT 전, FOR UPDATE 직렬화 하에서 재검증)
+  IF NOT p_is_fixed_posting AND jsonb_array_length(p_assignments) > 0 THEN
+    FOR v_assignment IN SELECT * FROM jsonb_array_elements(p_assignments) LOOP
+      v_role_key := CASE WHEN (v_assignment->>'role') = 'other' THEN 'other:' || COALESCE(v_assignment->>'customRole', '') ELSE v_assignment->>'role' END;
+      v_slot_key := COALESCE(v_assignment->>'timeSlot', '미정');
+      SELECT COUNT(*) INTO v_existing FROM work_logs wl
+      WHERE wl.job_posting_id = v_app.job_posting_id AND wl.date = (v_assignment->>'date')
+        AND COALESCE(wl.time_slot, '미정') = v_slot_key
+        AND (CASE WHEN wl.role::text = 'other' THEN 'other:' || COALESCE(wl.custom_role,'') ELSE wl.role::text END) = v_role_key
+        AND wl.status NOT IN ('cancelled', 'no_show');
+      SELECT COALESCE(MAX((r->>'count')::int), 0) INTO v_capacity
+      FROM jsonb_array_elements(COALESCE(v_job.schedule->'requirements', '[]'::jsonb)) req
+      CROSS JOIN jsonb_array_elements(COALESCE(req->'timeSlots', '[]'::jsonb)) ts
+      CROSS JOIN jsonb_array_elements(COALESCE(ts->'roles', '[]'::jsonb)) r
+      WHERE req->>'date' = (v_assignment->>'date')
+        AND (CASE WHEN COALESCE((ts->>'isTimeToBeAnnounced')::boolean, false) THEN '미정' ELSE COALESCE(ts->>'startTime', ts->>'time', '미정') END) = v_slot_key
+        AND (CASE WHEN (r->>'role') = 'other' THEN 'other:' || COALESCE(r->>'customRole','') ELSE r->>'role' END) = v_role_key;
+      IF v_capacity > 0 AND v_existing + 1 > v_capacity THEN
+        RAISE EXCEPTION 'MAX_CAPACITY_REACHED: role=% date=% slot=% (% / %)', v_role_key, v_assignment->>'date', v_slot_key, v_existing + 1, v_capacity;
+      END IF;
+    END LOOP;
+  END IF;
+  -- work_logs INSERT (flat 포맷) — 프로덕션과 동일(blurhash 컬럼 포함)
+  IF NOT p_is_fixed_posting AND jsonb_array_length(p_assignments) > 0 THEN
+    FOR v_assignment IN SELECT * FROM jsonb_array_elements(p_assignments) LOOP
+      INSERT INTO work_logs (
+        staff_id, job_posting_id, application_id, assignment_group_id, date, time_slot,
+        staff_name, staff_nickname, staff_photo_url, staff_photo_url_blurhash,
+        role, custom_role, owner_id, status, is_fixed_posting, created_at, updated_at
+      ) VALUES (
+        v_app.applicant_id, v_app.job_posting_id, p_application_id,
+        v_assignment->>'groupId', v_assignment->>'date', v_assignment->>'timeSlot',
+        v_app.applicant_name, v_app.applicant_nickname, v_app.applicant_photo_url, v_app.applicant_photo_url_blurhash,
+        COALESCE((v_assignment->>'role')::staff_role, 'staff'::staff_role),
+        v_assignment->>'customRole', p_owner_id, 'scheduled', false, v_now, v_now
+      ) RETURNING id INTO v_wl_id;
+      v_work_log_ids := array_append(v_work_log_ids, v_wl_id);
+    END LOOP;
+  END IF;
+  UPDATE applications SET status = 'confirmed', assignments = COALESCE(p_assignments_v3, assignments),
+    original_application = COALESCE(p_original_application, original_application),
+    confirmation_history = p_confirmation_history, confirmed_at = v_now, processed_by = p_owner_id::text,
+    processed_at = v_now, notes = COALESCE(p_notes, notes), updated_at = v_now
+  WHERE id = p_application_id;
+  -- confirmedApplicants 갱신은 tr_update_job_posting_stats trigger 가 담당(중복 증가 금지). filledPositions 만 유지.
+  UPDATE job_postings SET filled_positions = filled_positions + 1,
+    stats = jsonb_set(COALESCE(stats, '{}'::jsonb), '{filledPositions}', to_jsonb(COALESCE((stats->>'filledPositions')::int, 0) + 1)),
+    updated_at = v_now
+  WHERE id = v_app.job_posting_id;
+  RETURN jsonb_build_object('applicationId', p_application_id, 'workLogIds', to_jsonb(v_work_log_ids), 'assignmentCount', jsonb_array_length(p_assignments));
+END;
+$function$;

--- a/uniqn-mobile/supabase/migrations/20260525040000_align_applicant_role_to_staff_role.sql
+++ b/uniqn-mobile/supabase/migrations/20260525040000_align_applicant_role_to_staff_role.sql
@@ -1,0 +1,31 @@
+-- fix(db): applications.applicant_role 스키마 드리프트 정렬 (user_role → staff_role)
+--
+-- 문제: base_schema(20260409000000:165) 가 applicant_role 을 public.user_role 로 정의했으나,
+-- 런타임은 staff_role 값(dealer/floor/serving/other 등)을 기록하고(ApplicationRepository.ts:482),
+-- 생성 타입(supabase.ts)·TS 타입(StaffRole)·prod 컬럼 모두 staff_role 가정.
+-- prod 는 수동 ALTER 로 이미 staff_role(미기록 드리프트) — prod 데이터 applicant_role='dealer' 확인.
+-- 결과: fresh DB(CI/신규 환경)는 user_role 이라 non-staff 역할 지원 INSERT 가 confirm 전에 실패.
+--
+-- 수정: 마이그레이션을 prod 실체에 맞춰 staff_role 로 정렬. 멱등(현재 user_role 일 때만 ALTER).
+-- user_role 값 중 staff_role 에 없는 'admin'/'employer' 는 applicant_role 에 저장되지 않음
+-- (지원 역할은 포커룸 직무) — 마이그레이션 시점 테이블은 비어있어 USING 캐스트 안전.
+
+DO $$
+DECLARE
+  v_type text;
+BEGIN
+  SELECT atttypid::regtype::text INTO v_type
+  FROM pg_attribute
+  WHERE attrelid = 'public.applications'::regclass
+    AND attname = 'applicant_role'
+    AND NOT attisdropped;
+
+  IF v_type = 'user_role' THEN
+    ALTER TABLE public.applications
+      ALTER COLUMN applicant_role TYPE public.staff_role
+      USING applicant_role::text::public.staff_role;
+    RAISE NOTICE 'applications.applicant_role: user_role → staff_role 정렬 완료';
+  ELSE
+    RAISE NOTICE 'applications.applicant_role 이미 % — 변경 없음', v_type;
+  END IF;
+END $$;

--- a/uniqn-mobile/supabase/migrations/20260525040100_posting_count_slot_role_key_normalization.sql
+++ b/uniqn-mobile/supabase/migrations/20260525040100_posting_count_slot_role_key_normalization.sql
@@ -1,0 +1,221 @@
+-- fix(db): 공고 확정 집계/정원가드 키 정규화 + 중복행 overfill 차단 + 익명 공유링크 GRANT
+--
+-- 재리뷰(Claude+Codex+실DB, 2026-05-25)에서 드러난 결함 수정:
+--  ① 슬롯 키 불일치: count 헬퍼/H1 가드가 raw work_logs.time_slot 사용. 앱은 extractStartTime
+--     으로 정규화(범위 '14:00~22:00'→'14:00'). non-TBA 슬롯에서 v_capacity=0 → 가드 무력 + 0/N 표시.
+--  ② 커스텀('other') 역할: client 가 role:'other'→'staff' 평탄화(custom_role 에 라벨 보존).
+--     count 헬퍼가 role='other' 만 보고 'other:' 키를 못 만들어 'staff' 로 집계 → 정산/표시 손상.
+--  ③ 단일 payload 내 동일 (date,slot,role) 2행 → 둘 다 같은 v_existing 대비 통과 → overfill.
+--  ④ get_posting_filled_counts 가 anon REVOKE 라 공개/공유링크(/jobs/[id]) 가 permission denied.
+--     filled/N 은 공개 카드에 이미 노출되는 count-only 데이터이므로 anon GRANT 로 해소.
+--
+-- 키 일관성: 표시·집계·가드 3곳이 분기하지 않도록 공유 IMMUTABLE 헬퍼로 단일화.
+-- 베이스: 현행 prod confirm_application 본문(20260525035500 의 'staff' 폴백 포함) + 신규 H1.
+
+-- ── 공유 키 헬퍼 ──────────────────────────────────────────────────────────────
+-- 슬롯 키: TBA/빈값 → '미정', 그 외 '시작시각'(범위 '~'/'-' 앞부분, trim). parseTimeSlot 과 동치.
+CREATE OR REPLACE FUNCTION public._posting_slot_key(p_time_slot text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $function$
+  SELECT CASE
+    WHEN p_time_slot IS NULL OR btrim(p_time_slot) = '' OR btrim(p_time_slot) = '미정' THEN '미정'
+    ELSE btrim((regexp_split_to_array(p_time_slot, '[-~]'))[1])
+  END;
+$function$;
+
+-- 역할 키: custom_role 있으면 'other:<custom>' (role 이 'staff' 로 평탄화됐어도 복원),
+--          role='other' 면 'other:<custom>', 그 외 role 원본. roleMatchKey 와 동치.
+CREATE OR REPLACE FUNCTION public._posting_role_key(p_role text, p_custom_role text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $function$
+  SELECT CASE
+    WHEN COALESCE(btrim(p_custom_role), '') <> '' THEN 'other:' || btrim(p_custom_role)
+    WHEN p_role = 'other' THEN 'other:'
+    ELSE p_role
+  END;
+$function$;
+
+COMMENT ON FUNCTION public._posting_slot_key(text) IS '슬롯 표시/집계 공유 키 — TBA→미정, 범위→시작시각. parseTimeSlot 동치.';
+COMMENT ON FUNCTION public._posting_role_key(text, text) IS '역할 표시/집계 공유 키 — custom_role 우선 other:<custom>. roleMatchKey 동치.';
+
+-- ── 1. 집계 헬퍼: 키 정규화 적용 ──────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.count_posting_confirmed_by_slot(
+  p_job_posting_ids uuid[]
+)
+RETURNS TABLE (
+  job_posting_id uuid,
+  work_date text,
+  time_slot text,
+  role_key text,
+  confirmed_count int
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+STABLE
+AS $function$
+  SELECT
+    wl.job_posting_id,
+    wl.date AS work_date,
+    public._posting_slot_key(wl.time_slot) AS time_slot,
+    public._posting_role_key(wl.role::text, wl.custom_role) AS role_key,
+    COUNT(*)::int AS confirmed_count
+  FROM public.work_logs wl
+  WHERE wl.job_posting_id = ANY(p_job_posting_ids)
+    AND wl.status NOT IN ('cancelled', 'no_show')
+  GROUP BY wl.job_posting_id, wl.date,
+    public._posting_slot_key(wl.time_slot),
+    public._posting_role_key(wl.role::text, wl.custom_role);
+$function$;
+
+-- 익명 공유링크(/jobs/[id]) 도 filled/N 표시 가능하도록 anon 추가(count-only, PII 없음)
+GRANT EXECUTE ON FUNCTION public.get_posting_filled_counts(uuid[]) TO authenticated, anon;
+
+-- ── 2. confirm_application: H1 가드를 키-집계 set 기반으로 재작성(중복행 차단) ──
+CREATE OR REPLACE FUNCTION public.confirm_application(
+  p_application_id uuid,
+  p_owner_id uuid,
+  p_assignments jsonb DEFAULT '[]'::jsonb,
+  p_original_application jsonb DEFAULT NULL::jsonb,
+  p_confirmation_history jsonb DEFAULT '[]'::jsonb,
+  p_notes text DEFAULT NULL::text,
+  p_is_fixed_posting boolean DEFAULT false,
+  p_assignments_v3 jsonb DEFAULT NULL::jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_app record;
+  v_job record;
+  v_work_log_ids uuid[] := '{}';
+  v_wl_id uuid;
+  v_assignment jsonb;
+  v_now timestamptz := now();
+  v_existing int;
+  v_capacity int;
+  v_rec record;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.users
+    WHERE id = p_owner_id AND is_active = true
+  ) THEN
+    RAISE EXCEPTION 'ACCOUNT_DISABLED: owner account is disabled (%)', p_owner_id;
+  END IF;
+
+  SELECT * INTO v_app FROM applications WHERE id = p_application_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'APPLICATION_NOT_FOUND: %', p_application_id; END IF;
+  IF v_app.status != 'applied' THEN
+    RAISE EXCEPTION 'INVALID_STATUS: 현재 상태 %, applied만 확정 가능', v_app.status;
+  END IF;
+
+  SELECT * INTO v_job FROM job_postings WHERE id = v_app.job_posting_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'POSTING_NOT_FOUND: %', v_app.job_posting_id; END IF;
+
+  -- H4: 권한 술어 (RLS jp_update_workspace_member 와 정렬)
+  IF NOT (
+    v_job.owner_id = p_owner_id
+    OR public.is_workspace_member(v_job.workspace_id, p_owner_id)
+    OR public.is_posting_collaborator(v_job.id, p_owner_id)
+    OR public.is_admin()
+  ) THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED: 공고 관리 권한 없음';
+  END IF;
+
+  -- H1: 역할/슬롯별 정원 가드 — 요청 payload 를 키별로 집계(중복행 합산)하여 1회 검증.
+  --      키는 공유 헬퍼로 정규화(슬롯=시작시각, 역할=custom 우선) → 표시/집계와 동일.
+  IF NOT p_is_fixed_posting AND jsonb_array_length(p_assignments) > 0 THEN
+    FOR v_rec IN
+      SELECT
+        (a->>'date') AS a_date,
+        public._posting_slot_key(a->>'timeSlot') AS slot_key,
+        public._posting_role_key(a->>'role', a->>'customRole') AS role_key,
+        COUNT(*)::int AS requested
+      FROM jsonb_array_elements(p_assignments) a
+      GROUP BY 1, 2, 3
+    LOOP
+      SELECT COUNT(*) INTO v_existing
+      FROM work_logs wl
+      WHERE wl.job_posting_id = v_app.job_posting_id
+        AND wl.date = v_rec.a_date
+        AND public._posting_slot_key(wl.time_slot) = v_rec.slot_key
+        AND public._posting_role_key(wl.role::text, wl.custom_role) = v_rec.role_key
+        AND wl.status NOT IN ('cancelled', 'no_show');
+
+      SELECT COALESCE(MAX((r->>'count')::int), 0) INTO v_capacity
+      FROM jsonb_array_elements(COALESCE(v_job.schedule->'requirements', '[]'::jsonb)) req
+      CROSS JOIN jsonb_array_elements(COALESCE(req->'timeSlots', '[]'::jsonb)) ts
+      CROSS JOIN jsonb_array_elements(COALESCE(ts->'roles', '[]'::jsonb)) r
+      WHERE req->>'date' = v_rec.a_date
+        AND (CASE WHEN COALESCE((ts->>'isTimeToBeAnnounced')::boolean, false)
+                  THEN '미정'
+                  ELSE public._posting_slot_key(COALESCE(ts->>'startTime', ts->>'time')) END) = v_rec.slot_key
+        AND public._posting_role_key(r->>'role', r->>'customRole') = v_rec.role_key;
+
+      IF v_capacity > 0 AND v_existing + v_rec.requested > v_capacity THEN
+        RAISE EXCEPTION 'MAX_CAPACITY_REACHED: role=% date=% slot=% (% / %)',
+          v_rec.role_key, v_rec.a_date, v_rec.slot_key, v_existing + v_rec.requested, v_capacity;
+      END IF;
+    END LOOP;
+  END IF;
+
+  -- work_logs INSERT (flat 포맷) — 프로덕션과 동일(blurhash 컬럼 포함, role 폴백 'staff')
+  IF NOT p_is_fixed_posting AND jsonb_array_length(p_assignments) > 0 THEN
+    FOR v_assignment IN SELECT * FROM jsonb_array_elements(p_assignments)
+    LOOP
+      INSERT INTO work_logs (
+        staff_id, job_posting_id, application_id,
+        assignment_group_id, date, time_slot,
+        staff_name, staff_nickname, staff_photo_url, staff_photo_url_blurhash,
+        role, custom_role, owner_id,
+        status, is_fixed_posting,
+        created_at, updated_at
+      ) VALUES (
+        v_app.applicant_id, v_app.job_posting_id, p_application_id,
+        v_assignment->>'groupId', v_assignment->>'date', v_assignment->>'timeSlot',
+        v_app.applicant_name, v_app.applicant_nickname,
+        v_app.applicant_photo_url, v_app.applicant_photo_url_blurhash,
+        COALESCE((v_assignment->>'role')::staff_role, 'staff'::staff_role),
+        v_assignment->>'customRole', p_owner_id,
+        'scheduled', false, v_now, v_now
+      ) RETURNING id INTO v_wl_id;
+      v_work_log_ids := array_append(v_work_log_ids, v_wl_id);
+    END LOOP;
+  END IF;
+
+  UPDATE applications SET
+    status = 'confirmed',
+    assignments = COALESCE(p_assignments_v3, assignments),
+    original_application = COALESCE(p_original_application, original_application),
+    confirmation_history = p_confirmation_history,
+    confirmed_at = v_now,
+    processed_by = p_owner_id::text,
+    processed_at = v_now,
+    notes = COALESCE(p_notes, notes),
+    updated_at = v_now
+  WHERE id = p_application_id;
+
+  -- confirmedApplicants 갱신은 tr_update_job_posting_stats trigger 담당(중복 증가 금지). filledPositions 만 유지.
+  UPDATE job_postings SET
+    filled_positions = filled_positions + 1,
+    stats = jsonb_set(
+      COALESCE(stats, '{}'::jsonb),
+      '{filledPositions}',
+      to_jsonb(COALESCE((stats->>'filledPositions')::int, 0) + 1)
+    ),
+    updated_at = v_now
+  WHERE id = v_app.job_posting_id;
+
+  RETURN jsonb_build_object(
+    'applicationId', p_application_id,
+    'workLogIds', to_jsonb(v_work_log_ids),
+    'assignmentCount', jsonb_array_length(p_assignments)
+  );
+END;
+$function$;

--- a/uniqn-mobile/supabase/tests/posting_confirm_cancel_integrity.test.sql
+++ b/uniqn-mobile/supabase/tests/posting_confirm_cancel_integrity.test.sql
@@ -42,6 +42,8 @@ DECLARE
   v_appF1     uuid := gen_random_uuid();
   v_appF2     uuid := gen_random_uuid();
   v_appH5     uuid := gen_random_uuid();
+  v_assign_dealer jsonb := jsonb_build_array(jsonb_build_object('date','2026-05-23','timeSlot','미정','role','dealer'));
+  v_assign_floor  jsonb := jsonb_build_array(jsonb_build_object('date','2026-05-23','timeSlot','미정','role','floor'));
   -- 추가 시나리오용 (슬롯 정규화 / 커스텀 역할 / 중복행)
   v_job2      uuid := gen_random_uuid();
   v_job3      uuid := gen_random_uuid();

--- a/uniqn-mobile/supabase/tests/posting_confirm_cancel_integrity.test.sql
+++ b/uniqn-mobile/supabase/tests/posting_confirm_cancel_integrity.test.sql
@@ -42,8 +42,27 @@ DECLARE
   v_appF1     uuid := gen_random_uuid();
   v_appF2     uuid := gen_random_uuid();
   v_appH5     uuid := gen_random_uuid();
-  v_assign_dealer jsonb := jsonb_build_array(jsonb_build_object('date','2026-05-23','timeSlot','미정','role','dealer'));
-  v_assign_floor  jsonb := jsonb_build_array(jsonb_build_object('date','2026-05-23','timeSlot','미정','role','floor'));
+  -- 추가 시나리오용 (슬롯 정규화 / 커스텀 역할 / 중복행)
+  v_job2      uuid := gen_random_uuid();
+  v_job3      uuid := gen_random_uuid();
+  v_s6        uuid := gen_random_uuid();
+  v_s7        uuid := gen_random_uuid();
+  v_s8        uuid := gen_random_uuid();
+  v_s9        uuid := gen_random_uuid();
+  v_s10       uuid := gen_random_uuid();
+  v_appE1     uuid := gen_random_uuid();
+  v_appE2     uuid := gen_random_uuid();
+  v_appC1     uuid := gen_random_uuid();
+  v_appC2     uuid := gen_random_uuid();
+  v_appDup    uuid := gen_random_uuid();
+  -- range 형태 timeSlot('18:00~02:00') 이 시작시각('18:00')으로 정규화되는지
+  v_assign_range  jsonb := jsonb_build_array(jsonb_build_object('date','2026-07-01','timeSlot','18:00~02:00','role','dealer'));
+  -- client 가 'other'→'staff' 평탄화하고 customRole 보존하는 실제 페이로드 형태
+  v_assign_custom jsonb := jsonb_build_array(jsonb_build_object('date','2026-07-01','timeSlot','18:00','role','staff','customRole','딜러보조'));
+  -- 단일 payload 내 동일 (date,slot,role) 2행 → overfill 시도
+  v_assign_dup    jsonb := jsonb_build_array(
+                     jsonb_build_object('date','2026-08-01','timeSlot','20:00','role','dealer'),
+                     jsonb_build_object('date','2026-08-01','timeSlot','20:00','role','dealer'));
   v_res jsonb;
   v_cnt int;
   v_ok  boolean;
@@ -58,14 +77,19 @@ BEGIN
     (v_s2,       '__sql_fixture_pi_s2@test.local',       '{"role":"staff"}'::jsonb,    '{"name":"S2"}'::jsonb, now(), now()),
     (v_s3,       '__sql_fixture_pi_s3@test.local',       '{"role":"staff"}'::jsonb,    '{"name":"S3"}'::jsonb, now(), now()),
     (v_s4,       '__sql_fixture_pi_s4@test.local',       '{"role":"staff"}'::jsonb,    '{"name":"S4"}'::jsonb, now(), now()),
-    (v_s5,       '__sql_fixture_pi_s5@test.local',       '{"role":"staff"}'::jsonb,    '{"name":"S5"}'::jsonb, now(), now());
+    (v_s5,       '__sql_fixture_pi_s5@test.local',       '{"role":"staff"}'::jsonb,    '{"name":"S5"}'::jsonb, now(), now()),
+    (v_s6,       '__sql_fixture_pi_s6@test.local',       '{"role":"staff"}'::jsonb,    '{"name":"S6"}'::jsonb, now(), now()),
+    (v_s7,       '__sql_fixture_pi_s7@test.local',       '{"role":"staff"}'::jsonb,    '{"name":"S7"}'::jsonb, now(), now()),
+    (v_s8,       '__sql_fixture_pi_s8@test.local',       '{"role":"staff"}'::jsonb,    '{"name":"S8"}'::jsonb, now(), now()),
+    (v_s9,       '__sql_fixture_pi_s9@test.local',       '{"role":"staff"}'::jsonb,    '{"name":"S9"}'::jsonb, now(), now()),
+    (v_s10,      '__sql_fixture_pi_s10@test.local',      '{"role":"staff"}'::jsonb,    '{"name":"S10"}'::jsonb, now(), now());
 
   INSERT INTO public.users (id, email, name, role, is_active, created_at, updated_at)
   SELECT id, email, 'fixture',
     CASE WHEN id IN (v_owner, v_collab) THEN 'employer'::user_role ELSE 'staff'::user_role END,
     true, now(), now()
   FROM auth.users
-  WHERE id IN (v_owner, v_collab, v_stranger, v_s1, v_s2, v_s3, v_s4, v_s5)
+  WHERE id IN (v_owner, v_collab, v_stranger, v_s1, v_s2, v_s3, v_s4, v_s5, v_s6, v_s7, v_s8, v_s9, v_s10)
   ON CONFLICT (id) DO UPDATE SET role = EXCLUDED.role, is_active = true;
 
   -- ---- seed: workspace + posting(dated, TBA slot, dealer 1 / floor 1) ----
@@ -118,6 +142,49 @@ BEGIN
   INSERT INTO public.work_logs (id, application_id, staff_id, job_posting_id, date, time_slot, status, role, created_at, updated_at)
   VALUES (gen_random_uuid(), v_appH5, v_s5, v_job, '2026-06-01', '미정', 'checked_in', 'dealer', now(), now());
 
+  -- ---- seed: job2 (명시 시각 18:00 슬롯, dealer 1 / other:딜러보조 1) ----
+  INSERT INTO public.job_postings (
+    id, owner_id, workspace_id, title, total_positions, filled_positions, status, schedule, created_at, updated_at
+  )
+  VALUES (
+    v_job2, v_owner, v_ws, '__sql_fixture: posting integrity 2', 2, 0, 'active',
+    jsonb_build_object('requirements', jsonb_build_array(jsonb_build_object(
+      'date', '2026-07-01',
+      'timeSlots', jsonb_build_array(jsonb_build_object(
+        'startTime', '18:00',
+        'roles', jsonb_build_array(
+          jsonb_build_object('role', 'dealer', 'count', 1),
+          jsonb_build_object('role', 'other', 'customRole', '딜러보조', 'count', 1)
+        )
+      ))
+    ))),
+    now(), now()
+  );
+
+  -- ---- seed: job3 (명시 시각 20:00 슬롯, dealer 1) — 중복행 overfill 테스트용 ----
+  INSERT INTO public.job_postings (
+    id, owner_id, workspace_id, title, total_positions, filled_positions, status, schedule, created_at, updated_at
+  )
+  VALUES (
+    v_job3, v_owner, v_ws, '__sql_fixture: posting integrity 3', 1, 0, 'active',
+    jsonb_build_object('requirements', jsonb_build_array(jsonb_build_object(
+      'date', '2026-08-01',
+      'timeSlots', jsonb_build_array(jsonb_build_object(
+        'startTime', '20:00',
+        'roles', jsonb_build_array(jsonb_build_object('role', 'dealer', 'count', 1))
+      ))
+    ))),
+    now(), now()
+  );
+
+  INSERT INTO public.applications (id, job_posting_id, applicant_id, applicant_name, status, created_at, updated_at)
+  VALUES
+    (v_appE1, v_job2, v_s6,  'S6',  'applied', now(), now()),
+    (v_appE2, v_job2, v_s7,  'S7',  'applied', now(), now()),
+    (v_appC1, v_job2, v_s8,  'S8',  'applied', now(), now()),
+    (v_appC2, v_job2, v_s9,  'S9',  'applied', now(), now()),
+    (v_appDup, v_job3, v_s10, 'S10', 'applied', now(), now());
+
   -- ============================================================
   -- 1) owner 가 dealer 확정 → 성공
   -- ============================================================
@@ -166,13 +233,65 @@ BEGIN
     RAISE EXCEPTION 'H5: 체크인 후 취소가 차단되지 않음 (staff_already_checked_in 기대, 실제: %)', v_res;
   END IF;
 
+  -- ============================================================
+  -- T6) range 형태 timeSlot('18:00~02:00') 정규화 — 시작시각 '18:00' 으로 집계/가드
+  -- ============================================================
+  v_res := public.confirm_application(v_appE1, v_owner, v_assign_range);
+  IF v_res->>'applicationId' IS NULL THEN RAISE EXCEPTION 'T6: range 슬롯 dealer 확정 실패: %', v_res; END IF;
+
+  -- 집계 키의 time_slot 이 정규화된 '18:00' 로 나와야 함(raw '18:00~02:00' 아님)
+  SELECT confirmed_count INTO v_cnt
+  FROM public.count_posting_confirmed_by_slot(ARRAY[v_job2])
+  WHERE role_key = 'dealer' AND time_slot = '18:00' AND work_date = '2026-07-01';
+  IF v_cnt IS DISTINCT FROM 1 THEN RAISE EXCEPTION 'T6: range→18:00 정규화 집계 1 기대, 실제 %', v_cnt; END IF;
+
+  -- T6b) 동일 슬롯 dealer 정원(1) 초과 → MAX_CAPACITY (raw 비교였다면 미발견되어 통과했을 케이스)
+  v_ok := false;
+  BEGIN
+    PERFORM public.confirm_application(v_appE2, v_owner, v_assign_range);
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE '%MAX_CAPACITY_REACHED%' THEN v_ok := true; END IF;
+  END;
+  IF NOT v_ok THEN RAISE EXCEPTION 'T6b: range 슬롯 정원 초과가 차단되지 않음 (슬롯 키 불일치 회귀)'; END IF;
+
+  -- ============================================================
+  -- T7) 커스텀 역할 — client 가 role='staff'+customRole='딜러보조' 로 보냄 → 'other:딜러보조' 집계
+  -- ============================================================
+  v_res := public.confirm_application(v_appC1, v_owner, v_assign_custom);
+  IF v_res->>'applicationId' IS NULL THEN RAISE EXCEPTION 'T7: 커스텀 역할 확정 실패: %', v_res; END IF;
+
+  SELECT confirmed_count INTO v_cnt
+  FROM public.count_posting_confirmed_by_slot(ARRAY[v_job2])
+  WHERE role_key = 'other:딜러보조' AND time_slot = '18:00' AND work_date = '2026-07-01';
+  IF v_cnt IS DISTINCT FROM 1 THEN RAISE EXCEPTION 'T7: 커스텀역할 other:딜러보조 집계 1 기대, 실제 % (role=staff 평탄화 회귀)', v_cnt; END IF;
+
+  -- T7b) 동일 커스텀역할 정원(1) 초과 → MAX_CAPACITY
+  v_ok := false;
+  BEGIN
+    PERFORM public.confirm_application(v_appC2, v_owner, v_assign_custom);
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE '%MAX_CAPACITY_REACHED%' THEN v_ok := true; END IF;
+  END;
+  IF NOT v_ok THEN RAISE EXCEPTION 'T7b: 커스텀역할 정원 초과가 차단되지 않음 (역할 키 불일치 회귀)'; END IF;
+
+  -- ============================================================
+  -- T8) 단일 payload 내 동일 (date,slot,role) 2행 → overfill 차단 (정원 1)
+  -- ============================================================
+  v_ok := false;
+  BEGIN
+    PERFORM public.confirm_application(v_appDup, v_owner, v_assign_dup);
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE '%MAX_CAPACITY_REACHED%' THEN v_ok := true; END IF;
+  END;
+  IF NOT v_ok THEN RAISE EXCEPTION 'T8: payload 중복행 overfill 이 차단되지 않음 (요청 집계 누락 회귀)'; END IF;
+
   -- ---- cleanup (역순; ROLLBACK 이중 안전) ----
-  DELETE FROM public.work_logs WHERE job_posting_id = v_job;
-  DELETE FROM public.applications WHERE job_posting_id = v_job;
+  DELETE FROM public.work_logs WHERE job_posting_id IN (v_job, v_job2, v_job3);
+  DELETE FROM public.applications WHERE job_posting_id IN (v_job, v_job2, v_job3);
   DELETE FROM public.job_posting_collaborators WHERE job_posting_id = v_job;
-  DELETE FROM public.job_postings WHERE id = v_job;
+  DELETE FROM public.job_postings WHERE id IN (v_job, v_job2, v_job3);
   DELETE FROM public.workspaces WHERE id = v_ws;
-  DELETE FROM auth.users WHERE id IN (v_owner, v_collab, v_stranger, v_s1, v_s2, v_s3, v_s4, v_s5);
+  DELETE FROM auth.users WHERE id IN (v_owner, v_collab, v_stranger, v_s1, v_s2, v_s3, v_s4, v_s5, v_s6, v_s7, v_s8, v_s9, v_s10);
 END $$;
 
 SELECT pass('POSTING_INTEGRITY_TEST_PASSED');

--- a/uniqn-mobile/supabase/tests/posting_confirm_cancel_integrity.test.sql
+++ b/uniqn-mobile/supabase/tests/posting_confirm_cancel_integrity.test.sql
@@ -1,0 +1,180 @@
+-- ============================================================
+-- 공고 확정/취소 정합성: helper / H1 / H4 / H5 회귀 테스트
+-- ============================================================
+-- 목적: count_posting_confirmed_by_slot 집계 + confirm_application 정원가드(H1)
+--       + 협업자 권한(H4) + cancel_application_atomically 체크인 후 차단(H5) 검증.
+--
+-- 사용법:
+--   psql "$SUPABASE_DB_URL" -f supabase/tests/posting_confirm_cancel_integrity.test.sql
+--   또는 supabase test db (CI: .github/workflows/db-tests.yml)
+--   기대 결과: 마지막에 'POSTING_INTEGRITY_TEST_PASSED' 1행, 에러 0건
+--
+-- 안전장치:
+--   - 마커 이메일(__sql_fixture_pi_*@test.local)로 production 격리
+--   - BEGIN/ROLLBACK 래핑 — 실행 후 전부 롤백(영속 없음)
+--   - DO block 내부 RAISE EXCEPTION 발생 시 pg_prove 가 fail 잡음
+--
+-- 시나리오 (전부 NEW RPC 기준 기대값):
+--   HELPER. dealer/미정 확정 1건 → count 1
+--   H1.     동일 dealer/슬롯 정원(1) 초과 2번째 확정 → MAX_CAPACITY_REACHED
+--   H4-a.   협업자(jpc)가 floor 확정 → 성공
+--   H4-b.   비권한자(stranger)가 확정 시도 → PERMISSION_DENIED
+--   H5.     checked_in work_log 있는 취소 승인 → staff_already_checked_in
+-- ============================================================
+
+BEGIN;
+SELECT plan(1);
+
+DO $$
+DECLARE
+  v_ws        uuid := gen_random_uuid();
+  v_owner     uuid := gen_random_uuid();
+  v_collab    uuid := gen_random_uuid();
+  v_stranger  uuid := gen_random_uuid();
+  v_s1        uuid := gen_random_uuid();
+  v_s2        uuid := gen_random_uuid();
+  v_s3        uuid := gen_random_uuid();
+  v_s4        uuid := gen_random_uuid();
+  v_s5        uuid := gen_random_uuid();
+  v_job       uuid := gen_random_uuid();
+  v_appD1     uuid := gen_random_uuid();
+  v_appD2     uuid := gen_random_uuid();
+  v_appF1     uuid := gen_random_uuid();
+  v_appF2     uuid := gen_random_uuid();
+  v_appH5     uuid := gen_random_uuid();
+  v_assign_dealer jsonb := jsonb_build_array(jsonb_build_object('date','2026-05-23','timeSlot','미정','role','dealer'));
+  v_assign_floor  jsonb := jsonb_build_array(jsonb_build_object('date','2026-05-23','timeSlot','미정','role','floor'));
+  v_res jsonb;
+  v_cnt int;
+  v_ok  boolean;
+BEGIN
+  -- ---- seed: auth.users (public.users FK) + public.users ----
+  INSERT INTO auth.users (id, email, raw_app_meta_data, raw_user_meta_data, created_at, updated_at)
+  VALUES
+    (v_owner,    '__sql_fixture_pi_owner@test.local',    '{"role":"employer"}'::jsonb, '{"name":"O"}'::jsonb,  now(), now()),
+    (v_collab,   '__sql_fixture_pi_collab@test.local',   '{"role":"employer"}'::jsonb, '{"name":"C"}'::jsonb,  now(), now()),
+    (v_stranger, '__sql_fixture_pi_stranger@test.local', '{"role":"staff"}'::jsonb,    '{"name":"X"}'::jsonb,  now(), now()),
+    (v_s1,       '__sql_fixture_pi_s1@test.local',       '{"role":"staff"}'::jsonb,    '{"name":"S1"}'::jsonb, now(), now()),
+    (v_s2,       '__sql_fixture_pi_s2@test.local',       '{"role":"staff"}'::jsonb,    '{"name":"S2"}'::jsonb, now(), now()),
+    (v_s3,       '__sql_fixture_pi_s3@test.local',       '{"role":"staff"}'::jsonb,    '{"name":"S3"}'::jsonb, now(), now()),
+    (v_s4,       '__sql_fixture_pi_s4@test.local',       '{"role":"staff"}'::jsonb,    '{"name":"S4"}'::jsonb, now(), now()),
+    (v_s5,       '__sql_fixture_pi_s5@test.local',       '{"role":"staff"}'::jsonb,    '{"name":"S5"}'::jsonb, now(), now());
+
+  INSERT INTO public.users (id, email, name, role, is_active, created_at, updated_at)
+  SELECT id, email, 'fixture',
+    CASE WHEN id IN (v_owner, v_collab) THEN 'employer'::user_role ELSE 'staff'::user_role END,
+    true, now(), now()
+  FROM auth.users
+  WHERE id IN (v_owner, v_collab, v_stranger, v_s1, v_s2, v_s3, v_s4, v_s5)
+  ON CONFLICT (id) DO UPDATE SET role = EXCLUDED.role, is_active = true;
+
+  -- ---- seed: workspace + posting(dated, TBA slot, dealer 1 / floor 1) ----
+  INSERT INTO public.workspaces (id, name, owner_id, created_at, updated_at)
+  VALUES (v_ws, '__sql_fixture_pi_ws', v_owner, now(), now());
+
+  INSERT INTO public.job_postings (
+    id, owner_id, workspace_id, title, total_positions, filled_positions, status, schedule, created_at, updated_at
+  )
+  VALUES (
+    v_job, v_owner, v_ws, '__sql_fixture: posting integrity', 2, 0, 'active',
+    jsonb_build_object('requirements', jsonb_build_array(jsonb_build_object(
+      'date', '2026-05-23',
+      'timeSlots', jsonb_build_array(jsonb_build_object(
+        'isTimeToBeAnnounced', true,
+        'roles', jsonb_build_array(
+          jsonb_build_object('role', 'dealer', 'count', 1),
+          jsonb_build_object('role', 'floor',  'count', 1)
+        )
+      ))
+    ))),
+    now(), now()
+  );
+
+  INSERT INTO public.job_posting_collaborators (id, job_posting_id, user_id, added_by, added_at)
+  VALUES (gen_random_uuid(), v_job, v_collab, v_owner, now());
+
+  -- ---- seed: applied applications ----
+  INSERT INTO public.applications (id, job_posting_id, applicant_id, applicant_name, status, created_at, updated_at)
+  VALUES
+    (v_appD1, v_job, v_s1, 'S1', 'applied', now(), now()),
+    (v_appD2, v_job, v_s2, 'S2', 'applied', now(), now()),
+    (v_appF1, v_job, v_s3, 'S3', 'applied', now(), now()),
+    (v_appF2, v_job, v_s4, 'S4', 'applied', now(), now());
+
+  -- ---- seed: H5 application (cancellation_pending) + checked_in work_log ----
+  INSERT INTO public.applications (
+    id, job_posting_id, applicant_id, applicant_name, status, cancellation_request, confirmation_history, created_at, updated_at
+  )
+  VALUES (
+    v_appH5, v_job, v_s5, 'S5', 'cancellation_pending',
+    jsonb_build_object('status', 'pending', 'requested_at', now()::text, 'reason', 'req'),
+    jsonb_build_array(jsonb_build_object(
+      'assignments', jsonb_build_array(jsonb_build_object('dates', jsonb_build_array('2026-05-23'))),
+      'cancelled_at', NULL
+    )),
+    now(), now()
+  );
+  -- 별도 date('2026-06-01') 사용 — H1/HELPER 의 2026-05-23 dealer 정원 집계와 격리(checked_in 도 집계 대상이므로).
+  INSERT INTO public.work_logs (id, application_id, staff_id, job_posting_id, date, time_slot, status, role, created_at, updated_at)
+  VALUES (gen_random_uuid(), v_appH5, v_s5, v_job, '2026-06-01', '미정', 'checked_in', 'dealer', now(), now());
+
+  -- ============================================================
+  -- 1) owner 가 dealer 확정 → 성공
+  -- ============================================================
+  v_res := public.confirm_application(v_appD1, v_owner, v_assign_dealer);
+  IF v_res->>'applicationId' IS NULL THEN RAISE EXCEPTION 'SEED D1 confirm 실패: %', v_res; END IF;
+
+  -- HELPER: dealer/미정 확정 수 = 1
+  SELECT confirmed_count INTO v_cnt
+  FROM public.count_posting_confirmed_by_slot(ARRAY[v_job])
+  WHERE role_key = 'dealer' AND time_slot = '미정' AND work_date = '2026-05-23';
+  IF v_cnt IS DISTINCT FROM 1 THEN RAISE EXCEPTION 'HELPER: dealer 확정 수 1 기대, 실제 %', v_cnt; END IF;
+
+  -- ============================================================
+  -- H1) dealer 정원(1) 초과 2번째 확정 → MAX_CAPACITY_REACHED
+  -- ============================================================
+  v_ok := false;
+  BEGIN
+    PERFORM public.confirm_application(v_appD2, v_owner, v_assign_dealer);
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE '%MAX_CAPACITY_REACHED%' THEN v_ok := true; END IF;
+  END;
+  IF NOT v_ok THEN RAISE EXCEPTION 'H1: 정원 초과 dealer 확정이 차단되지 않음 (MAX_CAPACITY_REACHED 미발생)'; END IF;
+
+  -- ============================================================
+  -- H4-a) 협업자(jpc)가 floor 확정 → 성공
+  -- ============================================================
+  v_res := public.confirm_application(v_appF1, v_collab, v_assign_floor);
+  IF v_res->>'applicationId' IS NULL THEN RAISE EXCEPTION 'H4-a: 협업자 floor 확정 실패: %', v_res; END IF;
+
+  -- ============================================================
+  -- H4-b) 비권한자(stranger) 확정 시도 → PERMISSION_DENIED
+  -- ============================================================
+  v_ok := false;
+  BEGIN
+    PERFORM public.confirm_application(v_appF2, v_stranger, v_assign_floor);
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE '%PERMISSION_DENIED%' THEN v_ok := true; END IF;
+  END;
+  IF NOT v_ok THEN RAISE EXCEPTION 'H4-b: 비권한자 확정이 PERMISSION_DENIED 로 차단되지 않음'; END IF;
+
+  -- ============================================================
+  -- H5) checked_in work_log 있는 취소 승인 → staff_already_checked_in
+  -- ============================================================
+  v_res := public.cancel_application_atomically(v_appH5, 'staff_approves_cancel_request', v_owner);
+  IF v_res->>'error' IS DISTINCT FROM 'staff_already_checked_in' THEN
+    RAISE EXCEPTION 'H5: 체크인 후 취소가 차단되지 않음 (staff_already_checked_in 기대, 실제: %)', v_res;
+  END IF;
+
+  -- ---- cleanup (역순; ROLLBACK 이중 안전) ----
+  DELETE FROM public.work_logs WHERE job_posting_id = v_job;
+  DELETE FROM public.applications WHERE job_posting_id = v_job;
+  DELETE FROM public.job_posting_collaborators WHERE job_posting_id = v_job;
+  DELETE FROM public.job_postings WHERE id = v_job;
+  DELETE FROM public.workspaces WHERE id = v_ws;
+  DELETE FROM auth.users WHERE id IN (v_owner, v_collab, v_stranger, v_s1, v_s2, v_s3, v_s4, v_s5);
+END $$;
+
+SELECT pass('POSTING_INTEGRITY_TEST_PASSED');
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## 요약
공고 카드/상세의 역할별 `(filled/count)` 표시가 확정 인원과 무관하게 항상 `(0/N)`으로 나오던 버그(dead counter)를 권위 집계 RPC로 hydrate하여 해소하고, confirm/cancel RPC에 정합성 가드(정원/권한/체크인) 4종을 묶어 적용합니다.

재현: 인천 루원시티 텍사스 posting `61880654-55f1-4d78-b182-80272ca0ca94` — `filled_positions=1`인데 카드 역할 표시 `(0/1)`.

## 근본 원인
`schedule.requirements[].roles[].filled`는 confirm/cancel RPC가 **절대 갱신하지 않는 dead counter**인데, `toRoleModels` / `formatRoleLine`이 이를 그대로 읽음. 권위 소스는 `job_postings.filled_positions`(사람 단위) + work_logs 실집계.

## 변경 내용
**DB (마이그레이션 `20260524203124` — 이미 prod 적용됨, 본문 동일 검증 완료)**
- 헬퍼 `count_posting_confirmed_by_slot` + 래퍼 `get_posting_filled_counts`(SECDEF, 카운트만) 신설
- `confirm_application`(H1 정원 가드 + H4 권한 정렬) / `cancel_application_atomically`(H4 + H5 체크인 후 취소 차단) 현행 본문 기준 전체 재정의
- 회귀 방지: confirm INSERT `staff_photo_url_blurhash` 보존, `confirmedApplicants`는 트리거 담당이라 RPC 수동 증가 안 함

**TS**
- `JobPostingRepository.getPostingFilledCounts`(never-throw, 빈 Map fallback) + `buildSlotRoleKey`
- `postingSurfaceModel` hydrate + `usePostingFilledCounts` 훅
- 배선 3면: 리스트(home-jobs→JobList→JobCard, 배치 1회 N+1 회피) / 공개상세(JobDetail) / 구인자상세(my-postings/[id])
- H5 클라 매핑: `staff_already_checked_in` → "이미 출근한 스태프예요…"

## 한계 (범위 내)
- 고정공고(fixed)는 work_log 미생성 → 역할 표시 dead counter fallback 유지(주 repro는 dated/TBA)
- dateGroups(범위) 슬롯 단일 날짜 매칭 불가 → fallback 0

## 테스트
- `npm run quality`: **0 errors** (경고 12 = 기존 무관)
- Jest 신규 3파일 통과: `postingSurfaceModel.filled` / `ApplicationRepositoryTransactions.cancel` / `JobPostingRepository.filledCounts` + 관련 47
- pgTAP `posting_confirm_cancel_integrity.test.sql` (HELPER/H1/H4-a/H4-b/H5) — CI `supabase test db`

## 후속 권고
- [ ] non-TBA(명시 startTime) 슬롯 pgTAP 케이스 추가 (현재 seed는 TBA만)
- [ ] 머지 후 마이그레이션 `20260524203124` schema_migrations 레지스트리 등록

🤖 Generated with [Claude Code](https://claude.com/claude-code)