### PR TITLE
feat(jobs): 공고 공유 버튼 3곳 배치 + 공유 텍스트 강화 + 공유링크 anon RLS 수정

### DIFF
--- a/docs/superpowers/plans/2026-05-25-uniqn-promo-sample-image.md
+++ b/docs/superpowers/plans/2026-05-25-uniqn-promo-sample-image.md
@@ -1,0 +1,178 @@
+# UNIQN 홍보 샘플 이미지 1장 — 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** higgsfield CLI로 "밝은 홀덤 대회장 + UNIQN 앱 폰을 든 스태프" 컨셉의 1:1 홍보 샘플 이미지 1장을 생성하고 검증한다.
+
+**Architecture:** higgsfield `generate create` 로 Seedream 4.5 이미지 모델을 호출해 장면+폰(빈 골드 글로우 화면)을 생성한다. 실제 UI 합성·카피 오버레이·영상은 범위 밖. 결과는 `marketing/uniqn-campaign/sample-01/`에 저장하고 육안 검증 후 확장 여부를 판단한다.
+
+**Tech Stack:** higgsfield CLI (`@higgsfield/cli@0.1.40`), bash. 코드 변경 없음 — 산출물은 이미지 파일 + 프롬프트 기록.
+
+---
+
+## File Structure
+
+- `marketing/uniqn-campaign/sample-01/prompt.txt` — 사용한 영문 프롬프트 기록 (재현·반복용)
+- `marketing/uniqn-campaign/sample-01/sample-01.png` — 생성된 샘플 이미지
+- `marketing/uniqn-campaign/sample-01/job.json` — higgsfield job 응답(URL/메타) 원본
+
+검증은 별도 테스트 코드 없이 **CLI 출력 + 파일 존재 + 육안 확인**으로 수행한다.
+
+---
+
+## 사전 확인 (이미 충족됨)
+
+- higgsfield 인증됨: `higgsfield account status` → `tmdgh2qn@gmail.com — plus plan, ~353 credits`
+- 출력 디렉토리 존재: `marketing/uniqn-campaign/sample-01/`
+- 작업 브랜치: `docs/uniqn-promo-campaign`
+
+---
+
+### Task 1: 프롬프트 확정 및 기록
+
+**Files:**
+- Create: `marketing/uniqn-campaign/sample-01/prompt.txt`
+
+- [ ] **Step 1: 영문 프롬프트를 파일로 기록**
+
+`marketing/uniqn-campaign/sample-01/prompt.txt` 에 아래 내용을 저장:
+
+```
+Bright modern Texas Hold'em poker tournament hall, multiple green felt poker tables in rows, tournament banners and overhead stage lighting, lively crowd of players and staff, candid energetic atmosphere. In the foreground, a poker room staff member (no clear face, three-quarter or side angle) holds a modern smartphone front-facing toward the camera; the phone screen is blank with a soft warm gold glow (leave the screen empty for later UI compositing). Bright clean lighting with subtle gold accents, premium but approachable, photorealistic, cinematic, shallow depth of field, high detail. Square 1:1 composition, the phone held large and unobstructed in frame.
+```
+
+- [ ] **Step 2: 기록 확인**
+
+Run: `cat marketing/uniqn-campaign/sample-01/prompt.txt`
+Expected: 위 프롬프트가 그대로 출력됨.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add marketing/uniqn-campaign/sample-01/prompt.txt
+git commit -m "docs(marketing): 샘플 이미지 영문 프롬프트 확정"
+```
+
+---
+
+### Task 2: 모델 비용 사전 확인 (선택, 안전)
+
+**Files:** 없음 (조회만)
+
+- [ ] **Step 1: 생성 전 비용 추정 조회**
+
+Run: `higgsfield generate cost seedream_v4_5 --prompt "$(cat marketing/uniqn-campaign/sample-01/prompt.txt)" 2>&1 | head -20`
+Expected: 예상 크레딧 비용 출력. (서브커맨드가 다르면 `higgsfield generate --help`로 확인 후 해당 명령 사용. 비용 조회 불가 시 이 Task는 생략하고 Task 3 진행.)
+
+- [ ] **Step 2: 비용이 10 크레딧 미만인지 확인**
+
+Expected: 한 자릿수 크레딧. 만약 예상치 못하게 높으면(>20) 중단하고 사용자에게 보고.
+
+---
+
+### Task 3: 샘플 이미지 생성
+
+**Files:**
+- Create: `marketing/uniqn-campaign/sample-01/job.json`
+
+- [ ] **Step 1: higgsfield 로 이미지 생성 (JSON 응답 저장)**
+
+```bash
+cd "/c/Users/user/Desktop/T-HOLDEM"
+higgsfield generate create seedream_v4_5 \
+  --prompt "$(cat marketing/uniqn-campaign/sample-01/prompt.txt)" \
+  --aspect_ratio 1:1 \
+  --wait --wait-timeout 10m \
+  --json 2>&1 | tee marketing/uniqn-campaign/sample-01/job.json
+```
+
+Expected: job 이 완료(`completed`/`succeeded`)되고 결과 이미지 URL 이 JSON 에 포함됨.
+
+- [ ] **Step 2: 실패 시 분기 처리**
+
+- `--aspect_ratio 1:1` 이 거부되면: `higgsfield generate create seedream_v4_5 --help` 로 지원 파라미터 확인 후 올바른 비율 파라미터로 재시도.
+- 모델이 거부/오류면: 대안 모델 `nano_banana_2` 로 동일 명령 재시도.
+- 위 분기로도 실패하면 중단하고 CLI 에러 전문을 사용자에게 보고.
+
+- [ ] **Step 3: 결과 URL 확인**
+
+Run: `grep -oE 'https?://[^"]+\.(png|jpg|jpeg|webp)' marketing/uniqn-campaign/sample-01/job.json | head -5`
+Expected: 최소 1개의 이미지 URL 출력.
+
+---
+
+### Task 4: 이미지 다운로드 및 저장
+
+**Files:**
+- Create: `marketing/uniqn-campaign/sample-01/sample-01.png`
+
+- [ ] **Step 1: 결과 이미지 다운로드**
+
+```bash
+cd "/c/Users/user/Desktop/T-HOLDEM"
+URL=$(grep -oE 'https?://[^"]+\.(png|jpg|jpeg|webp)' marketing/uniqn-campaign/sample-01/job.json | head -1)
+curl -L -o marketing/uniqn-campaign/sample-01/sample-01.png "$URL"
+```
+
+Expected: `sample-01.png` 다운로드 완료 (curl 종료코드 0).
+
+- [ ] **Step 2: 파일 유효성 확인**
+
+Run: `ls -la marketing/uniqn-campaign/sample-01/sample-01.png && file marketing/uniqn-campaign/sample-01/sample-01.png`
+Expected: 0바이트 아님, `PNG/JPEG image data` 로 인식, 가급적 정사각형 해상도.
+
+---
+
+### Task 5: 육안 검증 (검증 기준 대조)
+
+**Files:** 없음 (검토)
+
+- [ ] **Step 1: 이미지를 열어 검증 기준 대조**
+
+`marketing/uniqn-campaign/sample-01/sample-01.png` 를 Read 도구로 열어 아래 체크:
+- [ ] 밝은 홀덤 대회장 분위기 + 골드 액센트가 브랜드와 맞는가
+- [ ] 폰/손 구도가 실제 UI 합성에 적합한가 (정면·충분히 큼·가림 없음)
+- [ ] 인물 톤(프리미엄 vs 캐주얼)이 의도와 맞는가, 얼굴 클로즈업 회피됐는가
+- [ ] 1:1 비율·해상도가 인스타 피드용으로 충분한가
+
+- [ ] **Step 2: 검증 결과 요약을 사용자에게 보고**
+
+이미지를 보여주고 4개 기준 통과 여부를 한 줄씩 요약. 미흡 항목이 있으면 프롬프트 조정안 제시.
+
+---
+
+### Task 6: 산출물 커밋
+
+**Files:** 모두 (sample-01 디렉토리)
+
+- [ ] **Step 1: 산출물 커밋**
+
+```bash
+cd "/c/Users/user/Desktop/T-HOLDEM"
+git add marketing/uniqn-campaign/sample-01/
+git commit -m "feat(marketing): UNIQN 홍보 샘플 이미지 1장 생성 (밝은 홀덤 대회장)"
+```
+
+Expected: prompt.txt / job.json / sample-01.png 커밋됨.
+
+> 참고: `.png`/`.json` 이 `.gitignore` 로 무시되면 `git add -f` 사용 또는 사용자에게 자산 보관 위치 확인.
+
+---
+
+## 검증 후 분기 (범위 밖 — 별도 계획)
+
+샘플이 통과하면 사용자 결정에 따라 확장:
+- 이미지 세트(여러 컷, count 늘리기 / variant)
+- 실제 UI 합성 + 한글 카피 오버레이 + 최종 export
+- 숏폼 영상 (이 이미지를 start frame 으로 image→video, Veo 3.1 / Kling)
+
+이들은 본 계획 범위 밖이며, 검증 통과 후 신규 spec/plan 으로 진행한다.
+
+---
+
+## Self-Review
+
+- **Spec 커버리지:** 스펙 §4(샘플 스펙)=Task 1~4, §6(검증 기준)=Task 5, §2~3(컨셉/앱화면)=Task 1 프롬프트에 반영(빈 골드 글로우 화면). §7(크레딧)=Task 2. §8(범위 밖)=계획 말미 분기에 명시. 갭 없음.
+- **Placeholder 스캔:** 프롬프트 전문·명령어·예상 출력 모두 구체값. TBD 없음.
+- **일관성:** 모델명 `seedream_v4_5`(1순위)/`nano_banana_2`(대안), 경로 `marketing/uniqn-campaign/sample-01/`, 파일명 `prompt.txt`/`job.json`/`sample-01.png` 전 Task 동일.
+- **불확실 지점:** `generate cost` 서브커맨드 존재 여부와 `--aspect_ratio` 정확 표기는 CLI 실측이 필요 → Task 2/3에 실패 시 `--help` 확인 분기를 명시해 대응.

--- a/docs/superpowers/specs/2026-05-25-uniqn-promo-campaign-design.md
+++ b/docs/superpowers/specs/2026-05-25-uniqn-promo-campaign-design.md
@@ -1,0 +1,82 @@
+# UNIQN 홍보 캠페인 — 설계 문서
+
+- 작성일: 2026-05-25
+- 도구: higgsfield CLI (`@higgsfield/cli@0.1.40`) — 인증됨 (`tmdgh2qn@gmail.com`, plus plan, 약 353 크레딧)
+- 상태: 설계 합의 완료 → 1차 범위 = **히어로 샘플 이미지 1장**
+
+## 1. 목적
+
+UNIQN(포커룸 스태프 관리 앱)의 **브랜드 인지도** 홍보물 제작. 구인자(매장/대회 운영자)와
+스태프(딜러/플로어/서빙) **양쪽 모두**에게 통하는 톤으로, 인스타 피드(1:1) 중심 배포.
+
+최종 산출물은 **홍보 이미지 세트 + 숏폼 영상**이지만, 본 1차 작업은 컨셉 검증을 위한
+**샘플 이미지 1장**만 생성한다. 검증 통과 후 세트/영상으로 확장한다.
+
+## 2. 크리에이티브 방향
+
+- **핵심 메시지(태그라인 방향)**: "편리함 / 올인원" — *구인부터 출퇴근·정산까지, 한 앱에서*.
+  - 카피(한글 텍스트)는 생성 이미지에 직접 넣지 않고 **후반 오버레이**로 처리한다.
+    (생성 모델의 한글 텍스트 렌더링은 불안정)
+- **비주얼 컨셉**: 앱 + 실사 하이브리드(제품샷). 밝고 활기찬 **홀덤 대회장**을 배경으로,
+  스태프/딜러가 UNIQN 앱이 켜진 폰을 든 시네마틱 제품샷.
+- **분위기**: 어두운 프리미엄룸 ❌ → **밝은 홀덤 대회장**(이벤트·스케일). 여러 포커 테이블,
+  대회 배너/무대 조명, 사람 많고 활기찬 사교적 분위기.
+- **브랜드 컬러**: Black & Gold. 배경을 어둡게 깔지 않고 **골드(`#D4AF37`)를 액센트**로만 사용.
+- **인물**: 등장 O(장면마다 다양). 동일 인물 유지(soul-id) 불필요. 얼굴 클로즈업은 지양(초상권).
+
+## 3. 폰 안 "앱 화면" 처리 — 실제 UI 합성
+
+- higgsfield는 **장면 + 폰(빈/골드 글로우 화면)**까지만 생성한다.
+- 실제 UNIQN UI는 **후반 합성**(스크린샷을 폰 화면 자리에 합성)으로 넣는다 → 정확도 최우선.
+- 샘플 단계에서는 합성하지 않고 **화면 자리만 확보**(정면·충분히 큰 화면 구도)한다.
+
+## 4. 샘플 1장 스펙
+
+| 항목 | 값 |
+|------|-----|
+| 장면 | 밝은 홀덤 대회장(여러 테이블·대회 배너·무대 조명), 분주한 딜러/스태프, 한 스태프가 폰을 든 손 |
+| 폰 화면 | 빈 / 골드 글로우 상태로 생성 (실제 UI는 추후 합성, 오늘은 미합성) |
+| 비율 | **1:1** (인스타 피드) |
+| 모델(1순위) | **Seedream 4.5** (`seedream_v4_5`) — 실사+인물 강함 |
+| 모델(대안) | Nano Banana Pro (`nano_banana_2`) / Soul Cinematic (`soul_cinematic`) |
+| 명령 | `higgsfield generate create seedream_v4_5 --prompt "<영문 프롬프트>" --aspect_ratio 1:1 --wait` |
+| 참고 입력 | (선택) 앱 아이콘 `uniqn-mobile/assets/1024.png` 를 `--image`로 — 골드 톤 가이드 |
+| 출력 | `marketing/uniqn-campaign/sample-01/` 에 결과 이미지 저장 |
+| count | 1 (필요 시 1~3 variant) |
+
+### 프롬프트 방향 (영문, 후반 작성 확정)
+- bright modern Hold'em poker tournament hall, multiple felt tables, tournament banners, stage lighting
+- lively crowd, dealers and staff working, candid energy
+- a poker room staff member holding a smartphone with a clean glowing screen (screen blank/gold glow for later compositing)
+- warm bright lighting with subtle gold accents, premium but approachable, photoreal, cinematic, shallow depth of field
+- square 1:1 composition, phone held front-facing and large enough to composite a real app UI later
+
+## 5. 생산 파이프라인 (전체 캠페인 확장 시)
+
+```
+[1] higgsfield 장면 생성 (폰 화면 = 빈 골드 글로우)
+ → [2] 실제 앱 스크린샷 합성 (폰 화면 자리)
+ → [3] 한글 카피 오버레이 ("구인부터 정산까지, 한 앱에서")
+ → [4] 1:1 최종 export
+영상: [1] 이미지를 start frame 으로 image→video (Veo 3.1 / Kling 등), 1:1
+```
+- 샘플 단계는 **[1]만** 실행. [2]~[4]는 검증 후 진행.
+
+## 6. 검증 기준 (샘플로 확인할 것)
+
+- [ ] 밝은 홀덤 대회장 분위기 + 골드 액센트가 브랜드와 맞는가
+- [ ] 폰/손 구도가 실제 UI 합성에 적합한가 (정면·충분히 큼)
+- [ ] 인물 톤(프리미엄 vs 캐주얼)이 의도와 맞는가
+- [ ] 1:1 비율·해상도가 인스타 피드용으로 충분한가
+
+## 7. 크레딧/비용
+
+- 이미지 1장: 대략 1~5 크레딧 추정(모델별 상이). 353 크레딧 대비 무시 수준.
+- 영상(확장 단계): Veo/Kling 등 클립당 수십 크레딧 → 확장 시 별도 견적.
+
+## 8. 범위 밖 (YAGNI — 이번 작업 제외)
+
+- 실제 UI 합성·카피 오버레이·최종 export
+- 이미지 세트 확장(여러 컷), 숏폼 영상 생성
+- 앱스토어 스크린샷, 오프라인 인쇄물
+- soul-id 인물 학습

--- a/uniqn-mobile/app/(app)/jobs/[id]/index.tsx
+++ b/uniqn-mobile/app/(app)/jobs/[id]/index.tsx
@@ -48,15 +48,7 @@ export default function JobDetailScreen() {
       return;
     }
 
-    const locationStr =
-      typeof job.location === 'string' ? job.location : (job.location?.name ?? '');
-
-    void shareJob({
-      id: job.id,
-      title: job.title,
-      location: locationStr,
-      workDate: job.workDate,
-    });
+    void shareJob(job);
   }, [job, shareJob]);
 
   useEffect(() => {

--- a/uniqn-mobile/app/(employer)/my-postings/[id]/index.tsx
+++ b/uniqn-mobile/app/(employer)/my-postings/[id]/index.tsx
@@ -23,6 +23,7 @@ import {
   DocumentIcon,
   EditIcon,
   MapPinIcon,
+  ShareIcon,
   TrashIcon,
   UserPlusIcon,
   UsersIcon,
@@ -42,6 +43,7 @@ import { getLayoutColor, SECONDARY_PALETTE } from '@/constants/colors';
 import { buildPostingFacts, projectPostingSurface } from '@/domains/job-posting';
 import { useApplicantsByJobPosting } from '@/hooks/applicant';
 import { useJobDetail } from '@/hooks/useJobDetail';
+import { useShare } from '@/hooks/useShare';
 import { useDeleteJobPosting } from '@/hooks/useJobManagement';
 import { extractPostingFilledSubmap, usePostingFilledCounts } from '@/hooks/usePostingFilledCounts';
 import { useThemeStore } from '@/stores/themeStore';
@@ -126,6 +128,7 @@ export default function JobPostingDetailScreen() {
     realtime: true,
   });
   const { mutate: deleteJobPosting, isPending: isDeleting } = useDeleteJobPosting();
+  const { shareJob, isSharing } = useShare();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [isInfoExpanded, setIsInfoExpanded] = useState(false);
 
@@ -193,6 +196,14 @@ export default function JobPostingDetailScreen() {
     setIsInfoExpanded((prev) => !prev);
   }, []);
 
+  const handleShare = useCallback(() => {
+    if (!posting) {
+      return;
+    }
+
+    void shareJob(posting);
+  }, [posting, shareJob]);
+
   const handleRefresh = useCallback(async () => {
     await Promise.all([refresh(), refreshApplicants()]);
   }, [refresh, refreshApplicants]);
@@ -242,7 +253,19 @@ export default function JobPostingDetailScreen() {
         titleSuffix={<JobTitleSuffix jobTitle={posting.title} />}
         fallbackHref="/(app)/(tabs)/employer"
         rightAction={
-          !(contextIsFixed || isFixed) ? <HeaderQRAction onPress={handleShowQR} /> : null
+          <View className="flex-row items-center">
+            <Pressable
+              onPress={handleShare}
+              disabled={isSharing}
+              hitSlop={8}
+              className="p-2"
+              accessibilityRole="button"
+              accessibilityLabel="공고 공유하기"
+            >
+              <ShareIcon size={22} color={getLayoutColor(isDark, 'headerTint')} />
+            </Pressable>
+            {!(contextIsFixed || isFixed) ? <HeaderQRAction onPress={handleShowQR} /> : null}
+          </View>
         }
       />
       <ScrollView

--- a/uniqn-mobile/app/jobs/[id].tsx
+++ b/uniqn-mobile/app/jobs/[id].tsx
@@ -45,15 +45,7 @@ export default function PublicJobDetailAliasRoute() {
       return;
     }
 
-    const locationStr =
-      typeof job.location === 'string' ? job.location : (job.location?.name ?? '');
-
-    void shareJob({
-      id: job.id,
-      title: job.title,
-      location: locationStr,
-      workDate: job.workDate,
-    });
+    void shareJob(job);
   }, [job, shareJob]);
 
   const shareAction = job ? (

--- a/uniqn-mobile/src/components/employer/posting/JobPostingCard.tsx
+++ b/uniqn-mobile/src/components/employer/posting/JobPostingCard.tsx
@@ -2,10 +2,11 @@ import React, { memo, useMemo } from 'react';
 import { Pressable, Text, View } from 'react-native';
 import { TournamentStatusBadge } from '@/components/jobs/TournamentStatusBadge';
 import { PostingCardSurface } from '@/components/jobs/shared/PostingCardSurface';
-import { QrCodeIcon, UsersIcon } from '@/components/icons';
+import { QrCodeIcon, ShareIcon, UsersIcon } from '@/components/icons';
 import { Badge, NumericText, type CardStripeTone } from '@/components/ui';
 import { STATUS } from '@/constants';
 import { toJobPostingCard } from '@/domains/job-posting';
+import { useShare } from '@/hooks/useShare';
 import { getPostingStatusMeta } from '@/components/jobs/shared/postingSurfaceModel';
 import type { JobPosting, JobPostingStatus, TournamentApprovalStatus } from '@/types';
 
@@ -49,6 +50,7 @@ export const JobPostingCard = memo(function JobPostingCard({
   const card = useMemo(() => toJobPostingCard(posting), [posting]);
   const stripeTone = POSTING_STRIPE_TONE[posting.status];
   const statusLabel = getPostingStatusMeta(posting.status).label;
+  const { shareJob, isSharing } = useShare();
 
   return (
     <View className="mx-4 mb-3">
@@ -69,6 +71,19 @@ export const JobPostingCard = memo(function JobPostingCard({
             </View>
 
             <View className="flex-row items-center gap-2">
+              <Pressable
+                onPress={(event) => {
+                  event?.stopPropagation?.();
+                  void shareJob(posting);
+                }}
+                disabled={isSharing}
+                className="p-1.5 active:opacity-70"
+                accessibilityLabel="공고 공유하기"
+                accessibilityRole="button"
+              >
+                <ShareIcon size={18} />
+              </Pressable>
+
               <Pressable
                 onPress={() => onShowQR(posting)}
                 className="p-1.5 active:opacity-70"

--- a/uniqn-mobile/src/components/employer/posting/__tests__/JobPostingCard.test.tsx
+++ b/uniqn-mobile/src/components/employer/posting/__tests__/JobPostingCard.test.tsx
@@ -30,6 +30,16 @@ jest.mock('@/components/jobs/FixedScheduleDisplay', () => ({
 jest.mock('@/components/icons', () => ({
   UsersIcon: () => null,
   QrCodeIcon: () => null,
+  ShareIcon: () => null,
+}));
+
+jest.mock('@/hooks/useShare', () => ({
+  useShare: () => ({
+    shareJob: jest.fn(),
+    shareJobById: jest.fn(),
+    share: jest.fn(),
+    isSharing: false,
+  }),
 }));
 
 describe('JobPostingCard', () => {

--- a/uniqn-mobile/src/components/jobs/JobCard.tsx
+++ b/uniqn-mobile/src/components/jobs/JobCard.tsx
@@ -3,9 +3,10 @@ import { Platform, Pressable, Text, View, type GestureResponderEvent } from 'rea
 import { STATUS_COLORS } from '@/constants/colors';
 import { HIT_SLOP } from '@/constants';
 import { SCHEDULE_STATUS } from '@/constants/statusConfig';
-import { HeartFilledIcon, HeartOutlineIcon } from '@/components/icons';
+import { HeartFilledIcon, HeartOutlineIcon, ShareIcon } from '@/components/icons';
 import { Badge, type CardStripeTone } from '@/components/ui';
 import { useBookmarks } from '@/hooks/useBookmarks';
+import { useShare } from '@/hooks/useShare';
 import { extractPostingFilledSubmap } from '@/hooks/usePostingFilledCounts';
 import type { JobPostingCard } from '@/types';
 import { PostingCardSurface } from './shared/PostingCardSurface';
@@ -33,6 +34,7 @@ export const JobCard = memo(function JobCard({
   filledCounts,
 }: JobCardProps) {
   const { isBookmarked, toggleBookmark } = useBookmarks();
+  const { shareJobById, isSharing } = useShare();
   const bookmarked = isBookmarked(job.id);
   const cardFilledCounts = useMemo(
     () => extractPostingFilledSubmap(filledCounts, job.id),
@@ -60,9 +62,44 @@ export const JobCard = memo(function JobCard({
     [handleBookmarkPress]
   );
 
+  // 카드는 trim 된 view model 만 갖고 있으므로 id 로 전체 공고를 조회한 뒤 공유한다.
+  const handleSharePress = useCallback(
+    (event?: GestureResponderEvent | React.MouseEvent) => {
+      event?.stopPropagation?.();
+      void shareJobById(job.id);
+    },
+    [job.id, shareJobById]
+  );
+
   const stripeTone: CardStripeTone = applicationStatus
     ? STRIPE_TONE_BY_STATUS[applicationStatus]
     : 'gold';
+
+  // 카드 래퍼(PostingCardSurface)는 web 에서 <button> 으로 렌더되므로, 그 안의 공유
+  // 컨트롤은 중첩 <button> 하이드레이션을 피하려 web 은 <View onClick>(div) 으로,
+  // native 는 Pressable 로 분기한다. accessibilityRole 은 지정하지 않는다.
+  const shareButton =
+    Platform.OS === 'web' ? (
+      <View
+        // @ts-expect-error React Native Web supports onClick on View
+        onClick={handleSharePress}
+        className="-my-1 p-1"
+        style={{ cursor: 'pointer' }}
+        accessibilityLabel="공고 공유하기"
+      >
+        <ShareIcon size={20} />
+      </View>
+    ) : (
+      <Pressable
+        onPress={handleSharePress}
+        disabled={isSharing}
+        hitSlop={HIT_SLOP.medium}
+        className="-my-1 p-1"
+        accessibilityLabel="공고 공유하기"
+      >
+        <ShareIcon size={20} />
+      </Pressable>
+    );
 
   const bookmarkButton =
     Platform.OS === 'web' ? (
@@ -116,7 +153,10 @@ export const JobCard = memo(function JobCard({
           >
             {job.ownerName ? `구인처 ${job.ownerName}` : ''}
           </Text>
-          {bookmarkButton}
+          <View className="flex-row items-center gap-1">
+            {shareButton}
+            {bookmarkButton}
+          </View>
         </View>
       }
       containerClassName="overflow-hidden"

--- a/uniqn-mobile/src/components/jobs/__tests__/JobCard.test.tsx
+++ b/uniqn-mobile/src/components/jobs/__tests__/JobCard.test.tsx
@@ -17,6 +17,17 @@ jest.mock('@/hooks/useBookmarks', () => ({
   }),
 }));
 
+const mockShareJobById = jest.fn();
+
+jest.mock('@/hooks/useShare', () => ({
+  useShare: () => ({
+    shareJob: jest.fn(),
+    shareJobById: mockShareJobById,
+    share: jest.fn(),
+    isSharing: false,
+  }),
+}));
+
 jest.mock('@/components/ui/Badge', () => ({
   Badge: ({ children, variant }: { children: React.ReactNode; variant?: string }) => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/uniqn-mobile/src/hooks/__tests__/useShare.test.tsx
+++ b/uniqn-mobile/src/hooks/__tests__/useShare.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * useShare unit tests
+ *
+ * shareJobById: 완전한 JobPosting 을 갖지 못한 화면(리스트 카드)에서 id 로 상세를
+ * 조회한 뒤 shareJob 과 동일 본문으로 공유하는 경로를 검증한다.
+ */
+
+import React from 'react';
+import { Share } from 'react-native';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useShare } from '../useShare';
+import type { JobPosting } from '@/types';
+
+// jest.setup.js 의 전역 react-query stub 을 실제 구현으로 복원 (useQueryClient/fetchQuery 필요)
+jest.mock('@tanstack/react-query', () => jest.requireActual('@tanstack/react-query'));
+
+const mockGetJob = jest.fn<Promise<JobPosting | null>, [string]>();
+
+jest.mock('@/hooks/useJobDetail', () => ({
+  getJobDetailQueryOptions: (jobId: string, userId?: string) => ({
+    queryKey: ['jobDetail', jobId, userId ?? 'public'],
+    queryFn: () => mockGetJob(jobId),
+  }),
+}));
+
+jest.mock('@/utils/jobShareMessage', () => ({
+  buildJobShareText: jest.fn(() => 'SHARE_BODY'),
+}));
+
+jest.mock('@/services/observability', () => ({
+  createJobDeepLink: jest.fn(() => 'https://uniqn.app/jobs/job-1'),
+  trackEvent: jest.fn(),
+}));
+
+const mockToast = {
+  success: jest.fn(),
+  error: jest.fn(),
+  warning: jest.fn(),
+  info: jest.fn(),
+};
+
+jest.mock('@/stores/toastStore', () => ({
+  useToast: () => mockToast,
+}));
+
+jest.mock('@/stores/authStore', () => ({
+  useAuthStore: (selector: (state: { user: { uid: string } }) => unknown) =>
+    selector({ user: { uid: 'user-1' } }),
+}));
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+  return Wrapper;
+}
+
+describe('useShare.shareJobById', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('id 로 전체 공고를 조회한 뒤 공유 본문을 생성해 공유한다', async () => {
+    const job = { id: 'job-1', title: '딜러 모집' } as JobPosting;
+    mockGetJob.mockResolvedValue(job);
+    const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: Share.sharedAction });
+
+    const { result } = renderHook(() => useShare(), { wrapper: makeWrapper() });
+
+    let shareResult: Awaited<ReturnType<typeof result.current.shareJobById>> | undefined;
+    await waitFor(async () => {
+      shareResult = await result.current.shareJobById('job-1');
+    });
+
+    expect(mockGetJob).toHaveBeenCalledWith('job-1');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { buildJobShareText } = require('@/utils/jobShareMessage');
+    expect(buildJobShareText).toHaveBeenCalledWith(job, 'https://uniqn.app/jobs/job-1');
+    expect(shareSpy).toHaveBeenCalledWith(
+      { title: '딜러 모집', message: 'SHARE_BODY' },
+      { dialogTitle: '공고 공유하기' }
+    );
+    expect(shareResult).toEqual({ success: true, action: 'shared' });
+
+    shareSpy.mockRestore();
+  });
+
+  it('공고를 찾지 못하면 실패를 반환하고 에러 토스트를 띄운다', async () => {
+    mockGetJob.mockResolvedValue(null);
+    const shareSpy = jest.spyOn(Share, 'share');
+
+    const { result } = renderHook(() => useShare(), { wrapper: makeWrapper() });
+
+    let shareResult: Awaited<ReturnType<typeof result.current.shareJobById>> | undefined;
+    await waitFor(async () => {
+      shareResult = await result.current.shareJobById('missing-job');
+    });
+
+    expect(shareSpy).not.toHaveBeenCalled();
+    expect(mockToast.error).toHaveBeenCalled();
+    expect(shareResult?.success).toBe(false);
+
+    shareSpy.mockRestore();
+  });
+});

--- a/uniqn-mobile/src/hooks/index.ts
+++ b/uniqn-mobile/src/hooks/index.ts
@@ -71,7 +71,7 @@ export {
   usePendingDeepLink,
 } from './useDeepLink';
 
-export { useShare, type ShareJobParams, type ShareResult, type UseShareReturn } from './useShare';
+export { useShare, type ShareResult, type UseShareReturn } from './useShare';
 export { useInstallPrompt, type InstallPromptSource } from './useInstallPrompt';
 export { useClearCache, type UseClearCacheReturn } from './useClearCache';
 export { useBookmarks, type BookmarkJobParams, type UseBookmarksReturn } from './useBookmarks';

--- a/uniqn-mobile/src/hooks/useShare.ts
+++ b/uniqn-mobile/src/hooks/useShare.ts
@@ -7,10 +7,13 @@
 
 import { useState, useCallback } from 'react';
 import { Share, Platform } from 'react-native';
+import { useQueryClient } from '@tanstack/react-query';
 import { logger } from '@/utils/logger';
 import { toError } from '@/errors';
 import { trackEvent, createJobDeepLink } from '@/services/observability';
 import { useToast } from '@/stores/toastStore';
+import { useAuthStore } from '@/stores/authStore';
+import { getJobDetailQueryOptions } from '@/hooks/useJobDetail';
 import { buildJobShareText } from '@/utils/jobShareMessage';
 import type { JobPosting } from '@/types';
 
@@ -27,6 +30,11 @@ export interface ShareResult {
 export interface UseShareReturn {
   /** 공고 공유 (근무 일정·역할·인원·급여 포함 본문 생성) */
   shareJob: (job: JobPosting) => Promise<ShareResult>;
+  /**
+   * 공고 ID 로 공유 — 완전한 JobPosting 을 보유하지 않은 화면(리스트 카드 등)에서
+   * id 로 상세를 조회한 뒤 shareJob 과 동일한 본문을 생성한다.
+   */
+  shareJobById: (jobId: string) => Promise<ShareResult>;
   /** 일반 콘텐츠 공유 */
   share: (options: { title: string; message: string; url?: string }) => Promise<ShareResult>;
   /** 공유 진행 중 여부 */
@@ -52,6 +60,8 @@ export interface UseShareReturn {
 export function useShare(): UseShareReturn {
   const [isSharing, setIsSharing] = useState(false);
   const toast = useToast();
+  const queryClient = useQueryClient();
+  const userId = useAuthStore((state) => state.user?.uid);
 
   /**
    * 웹 플랫폼 공유 (Web Share API → 클립보드 fallback)
@@ -141,16 +151,11 @@ export function useShare(): UseShareReturn {
   );
 
   /**
-   * 공고 공유
+   * 공고 공유 실행 코어 (isSharing 가드 없이 순수 공유만 수행).
+   * shareJob / shareJobById 가 공통으로 사용한다.
    */
-  const shareJob = useCallback(
+  const runJobShare = useCallback(
     async (job: JobPosting): Promise<ShareResult> => {
-      if (isSharing) {
-        return { success: false, error: new Error('이미 공유 중입니다') };
-      }
-
-      setIsSharing(true);
-
       try {
         // 웹 URL 생성 (외부 공유용)
         const url = createJobDeepLink(job.id, true);
@@ -191,15 +196,66 @@ export function useShare(): UseShareReturn {
       } catch (error) {
         logger.error('공고 공유 실패', toError(error), { jobId: job.id });
         return { success: false, error: toError(error) };
+      }
+    },
+    [webShare]
+  );
+
+  /**
+   * 공고 공유
+   */
+  const shareJob = useCallback(
+    async (job: JobPosting): Promise<ShareResult> => {
+      if (isSharing) {
+        return { success: false, error: new Error('이미 공유 중입니다') };
+      }
+
+      setIsSharing(true);
+      try {
+        return await runJobShare(job);
       } finally {
         setIsSharing(false);
       }
     },
-    [isSharing, webShare]
+    [isSharing, runJobShare]
+  );
+
+  /**
+   * 공고 ID 로 공유 — 리스트 카드처럼 완전한 JobPosting 을 갖지 못한 화면용.
+   * 상세 조회 쿼리를 재사용(캐시·dedupe)해 전체 JobPosting 을 확보한 뒤
+   * shareJob 과 동일한 본문으로 공유한다.
+   */
+  const shareJobById = useCallback(
+    async (jobId: string): Promise<ShareResult> => {
+      if (isSharing) {
+        return { success: false, error: new Error('이미 공유 중입니다') };
+      }
+
+      setIsSharing(true);
+      try {
+        const job = await queryClient.fetchQuery(getJobDetailQueryOptions(jobId, userId));
+
+        if (!job) {
+          logger.warn('공유할 공고를 찾지 못함', { jobId });
+          toast.error('공고 정보를 불러오지 못했어요. 잠시 후 다시 시도해주세요.');
+          return { success: false, error: new Error('공고를 찾을 수 없습니다') };
+        }
+
+        return await runJobShare(job);
+      } catch (error) {
+        logger.error('공고 공유 실패 (조회 단계)', toError(error), { jobId });
+        toast.error('공고 정보를 불러오지 못했어요. 잠시 후 다시 시도해주세요.');
+        return { success: false, error: toError(error) };
+      } finally {
+        setIsSharing(false);
+      }
+    },
+    [isSharing, queryClient, runJobShare, toast, userId]
   );
 
   return {
     shareJob,
+    shareJobById,
     share,
     isSharing,
   };

--- a/uniqn-mobile/src/hooks/useShare.ts
+++ b/uniqn-mobile/src/hooks/useShare.ts
@@ -11,17 +11,12 @@ import { logger } from '@/utils/logger';
 import { toError } from '@/errors';
 import { trackEvent, createJobDeepLink } from '@/services/observability';
 import { useToast } from '@/stores/toastStore';
+import { buildJobShareText } from '@/utils/jobShareMessage';
+import type { JobPosting } from '@/types';
 
 // ============================================================================
 // Types
 // ============================================================================
-
-export interface ShareJobParams {
-  id: string;
-  title: string;
-  location: string;
-  workDate?: string;
-}
 
 export interface ShareResult {
   success: boolean;
@@ -30,8 +25,8 @@ export interface ShareResult {
 }
 
 export interface UseShareReturn {
-  /** 공고 공유 */
-  shareJob: (job: ShareJobParams) => Promise<ShareResult>;
+  /** 공고 공유 (근무 일정·역할·인원·급여 포함 본문 생성) */
+  shareJob: (job: JobPosting) => Promise<ShareResult>;
   /** 일반 콘텐츠 공유 */
   share: (options: { title: string; message: string; url?: string }) => Promise<ShareResult>;
   /** 공유 진행 중 여부 */
@@ -149,7 +144,7 @@ export function useShare(): UseShareReturn {
    * 공고 공유
    */
   const shareJob = useCallback(
-    async (job: ShareJobParams): Promise<ShareResult> => {
+    async (job: JobPosting): Promise<ShareResult> => {
       if (isSharing) {
         return { success: false, error: new Error('이미 공유 중입니다') };
       }
@@ -160,20 +155,20 @@ export function useShare(): UseShareReturn {
         // 웹 URL 생성 (외부 공유용)
         const url = createJobDeepLink(job.id, true);
 
-        // 공유 메시지 구성
-        const dateInfo = job.workDate ? `\n${job.workDate}` : '';
-        const message = `[UNIQN] ${job.title}\n${job.location}${dateInfo}\n\n${url}`;
+        // 공유 메시지 구성 (일정·역할·인원·급여 포함, url 은 본문 마지막 1회)
+        const message = buildJobShareText(job, url);
 
         let action: 'shared' | 'dismissed';
 
         if (Platform.OS === 'web') {
-          action = await webShare({ title: job.title, text: message, url });
+          // url 은 message 본문에 이미 포함 — 별도 url 미전달로 중복 미리보기 방지
+          action = await webShare({ title: job.title, text: message });
         } else {
+          // iOS 에서 url 을 별도 전달하면 카톡이 본문+링크를 이중 렌더 → message 만 전달
           const result = await Share.share(
             {
               title: job.title,
               message,
-              ...(Platform.OS === 'ios' ? { url } : {}),
             },
             {
               dialogTitle: '공고 공유하기',

--- a/uniqn-mobile/src/utils/__tests__/jobShareMessage.test.ts
+++ b/uniqn-mobile/src/utils/__tests__/jobShareMessage.test.ts
@@ -1,0 +1,153 @@
+import { buildDateLines, composeJobShareText } from '../jobShareMessage';
+
+type ScheduleModel = Parameters<typeof buildDateLines>[0];
+
+const URL = 'https://uniqn.app/jobs/61880654-55f1-4d78-b182-80272ca0ca94';
+
+describe('buildDateLines', () => {
+  it("TBA 시간('미정')을 유지한다 — 상세 화면·승인 프리뷰와 일치 (회귀 가드)", () => {
+    const schedule = {
+      variant: 'dated',
+      sections: [{ label: '5/23(토)', timeSlots: [{ timeLabel: '미정', roles: [] }] }],
+    } as unknown as ScheduleModel;
+
+    expect(buildDateLines(schedule)).toEqual(['5/23(토) 미정']);
+  });
+
+  it('실제 시간은 그대로, 같은 시간 중복은 1회로', () => {
+    const schedule = {
+      variant: 'dated',
+      sections: [
+        {
+          label: '5/23(토)',
+          timeSlots: [
+            { timeLabel: '14:00', roles: [] },
+            { timeLabel: '14:00', roles: [] },
+          ],
+        },
+      ],
+    } as unknown as ScheduleModel;
+
+    expect(buildDateLines(schedule)).toEqual(['5/23(토) 14:00']);
+  });
+
+  it('빈 시간 라벨은 날짜만', () => {
+    const schedule = {
+      variant: 'dated',
+      sections: [{ label: '5/23(토)', timeSlots: [{ timeLabel: '', roles: [] }] }],
+    } as unknown as ScheduleModel;
+
+    expect(buildDateLines(schedule)).toEqual(['5/23(토)']);
+  });
+
+  it('fixed 변형: 요일 + 시간', () => {
+    const schedule = {
+      variant: 'fixed',
+      fixed: { daysLabel: '주 3일', timeLabel: '오후 6시', roles: [] },
+    } as unknown as ScheduleModel;
+
+    expect(buildDateLines(schedule)).toEqual(['주 3일 오후 6시']);
+  });
+
+  it('legacy 변형: 날짜 + 시간', () => {
+    const schedule = {
+      variant: 'legacy',
+      dateLabel: '5/23(토)',
+      timeLabel: '미정',
+    } as unknown as ScheduleModel;
+
+    expect(buildDateLines(schedule)).toEqual(['5/23(토) 미정']);
+  });
+});
+
+describe('composeJobShareText', () => {
+  it('스크린샷 케이스: 제목=근무지면 위치 라인 생략 + 일정·역할·급여 포함', () => {
+    const text = composeJobShareText({
+      title: '인천 루원시티 텍사스',
+      location: '인천 루원시티 텍사스',
+      dateLines: ['5/23(토) 미정'],
+      roleHeader: '딜러',
+      roleLine: '딜러 1명',
+      salary: '일급 ₩200,000',
+      url: URL,
+    });
+
+    expect(text).toBe(
+      [
+        '[UNIQN] 인천 루원시티 텍사스 딜러 모집',
+        '',
+        '📅 5/23(토) 미정',
+        '🙋 딜러 1명 모집',
+        '💰 일급 ₩200,000',
+        '',
+        '👉 지원하기',
+        URL,
+      ].join('\n')
+    );
+    // 위치 라인 생략 확인
+    expect(text).not.toContain('📍');
+  });
+
+  it('url 은 정확히 한 번만 포함된다 (중복 미리보기 방지)', () => {
+    const text = composeJobShareText({
+      title: '강남 홀덤펍',
+      location: '서울 강남',
+      dateLines: ['6/1(일) 오후 6시'],
+      roleHeader: '딜러 플로어',
+      roleLine: '딜러 2명, 플로어 1명',
+      salary: '딜러 일급 ₩200,000, 플로어 일급 ₩180,000',
+      url: URL,
+    });
+
+    const occurrences = text.split(URL).length - 1;
+    expect(occurrences).toBe(1);
+    expect(text).toContain('📍 서울 강남');
+    expect(text).toContain('🙋 딜러 2명, 플로어 1명 모집');
+  });
+
+  it('다중 날짜는 📅 라인을 여러 줄로 표시', () => {
+    const text = composeJobShareText({
+      title: '대구 토너먼트',
+      location: '대구',
+      dateLines: ['5/30(금) 미정', '5/31(토) 미정'],
+      roleHeader: '딜러',
+      roleLine: '딜러 4명',
+      salary: '일급 ₩220,000',
+      url: URL,
+    });
+
+    expect(text).toContain('📅 5/30(금) 미정\n📅 5/31(토) 미정');
+  });
+
+  it('역할 정보가 없으면 헤더에 "모집" 미표기 + 🙋 라인 생략', () => {
+    const text = composeJobShareText({
+      title: '인천 루원시티 텍사스',
+      location: '인천 루원시티 텍사스',
+      dateLines: ['5/23(토) 미정'],
+      roleHeader: '',
+      roleLine: '',
+      salary: '',
+      url: URL,
+    });
+
+    expect(text.startsWith('[UNIQN] 인천 루원시티 텍사스\n')).toBe(true);
+    expect(text).not.toContain('모집');
+    expect(text).not.toContain('🙋');
+    expect(text).not.toContain('💰');
+    expect(text.endsWith(`👉 지원하기\n${URL}`)).toBe(true);
+  });
+
+  it('본문 조각이 모두 비어도 헤더+CTA+url 은 항상 포함', () => {
+    const text = composeJobShareText({
+      title: '',
+      location: '',
+      dateLines: [],
+      roleHeader: '',
+      roleLine: '',
+      salary: '',
+      url: URL,
+    });
+
+    expect(text).toBe(`[UNIQN] 공고\n\n👉 지원하기\n${URL}`);
+  });
+});

--- a/uniqn-mobile/src/utils/jobShareMessage.ts
+++ b/uniqn-mobile/src/utils/jobShareMessage.ts
@@ -1,0 +1,173 @@
+/**
+ * 공고 외부 공유 텍스트 빌더
+ *
+ * @description 카톡·SNS 공유 본문에 근무 일정·역할·인원·급여를 함께 표시한다.
+ *   공고 상세 화면과 동일한 파생 모델(buildPostingFacts → projectPostingSurface →
+ *   buildPostingScheduleModel / buildPostingCompensationModel)을 재사용해 화면과
+ *   문자열이 일치하도록 한다. OG 미리보기에 의존하지 않는 자급식 공유 메시지.
+ */
+
+import { buildPostingFacts } from '@/domains/job-posting/facts';
+import { projectPostingSurface } from '@/domains/job-posting/projections';
+import {
+  buildPostingCompensationModel,
+  buildPostingScheduleModel,
+  type PostingRoleDisplayModel,
+} from '@/components/jobs/shared/postingSurfaceModel';
+import type { JobPosting, PostingDetailViewModel } from '@/types';
+import { logger } from '@/utils/logger';
+import { toError } from '@/errors';
+
+type ScheduleModel = ReturnType<typeof buildPostingScheduleModel>;
+
+function roleText(role: Pick<PostingRoleDisplayModel, 'label' | 'count'>): string {
+  return `${role.label} ${role.count}명`;
+}
+
+/**
+ * 날짜+시간 라인들 (variant 별). 빈 문자열만 제거하고 '미정'(시간 미정) 등
+ * 상세 화면이 노출하는 라벨은 그대로 유지 — 공유 텍스트가 화면과 일치하도록.
+ */
+export function buildDateLines(schedule: ScheduleModel): string[] {
+  if (schedule.variant === 'fixed') {
+    const time = schedule.fixed.timeLabel?.trim();
+    return [[schedule.fixed.daysLabel, time].filter(Boolean).join(' ').trim()].filter(Boolean);
+  }
+
+  if (schedule.variant === 'dated') {
+    return schedule.sections
+      .map((section) => {
+        const times = Array.from(
+          new Set(
+            section.timeSlots
+              .map((slot) => slot.timeLabel?.trim())
+              .filter((t): t is string => Boolean(t))
+          )
+        );
+        const timePart = times.length > 0 ? ` ${times.join(', ')}` : '';
+        return `${section.label}${timePart}`.trim();
+      })
+      .filter(Boolean);
+  }
+
+  // legacy
+  const line = [schedule.dateLabel, schedule.timeLabel]
+    .filter((v) => Boolean(v?.trim()))
+    .join(' ')
+    .trim();
+  return line ? [line] : [];
+}
+
+/** 역할+인원 집계 라인 (중복 라벨/카운트는 1회). */
+export function buildRoleLine(schedule: ScheduleModel): { header: string; line: string } {
+  const roles: PostingRoleDisplayModel[] = [];
+
+  if (schedule.variant === 'fixed') {
+    roles.push(...schedule.fixed.roles);
+  } else if (schedule.variant === 'dated') {
+    schedule.sections.forEach((section) =>
+      section.timeSlots.forEach((slot) => roles.push(...slot.roles))
+    );
+  }
+
+  // 동일 "라벨 N명" 은 한 번만 (다중 날짜 동일 역할 중복 제거)
+  const seen = new Set<string>();
+  const uniqueRoleTexts: string[] = [];
+  const uniqueLabels: string[] = [];
+  for (const role of roles) {
+    const text = roleText(role);
+    if (!seen.has(text)) {
+      seen.add(text);
+      uniqueRoleTexts.push(text);
+    }
+    if (!uniqueLabels.includes(role.label)) {
+      uniqueLabels.push(role.label);
+    }
+  }
+
+  return {
+    header: uniqueLabels.join(' '),
+    line: uniqueRoleTexts.join(', '),
+  };
+}
+
+/** 급여 라인 (역할별 급여면 행 나열, 단일이면 대표 금액). */
+function buildSalaryLine(detail: PostingDetailViewModel): string {
+  const comp = buildPostingCompensationModel(detail, { display: 'detail' });
+  if (!comp.useSameSalary && comp.rows.length > 0) {
+    return comp.rows.map((row) => `${row.roleLabel} ${row.text}`).join(', ');
+  }
+  return comp.primaryText && !comp.isPartial ? comp.primaryText : '';
+}
+
+export interface JobShareParts {
+  title: string;
+  location: string;
+  dateLines: string[];
+  roleHeader: string;
+  roleLine: string;
+  salary: string;
+  url: string;
+}
+
+/**
+ * 파생된 조각들로 이모지형 공유 본문을 조립하는 순수 함수.
+ * url 은 본문 마지막 1회만 포함 → 메시지/별도 url 중복 공유 방지.
+ */
+export function composeJobShareText(parts: JobShareParts): string {
+  const title = parts.title.trim() || '공고';
+  const headerLine = parts.roleHeader
+    ? `[UNIQN] ${title} ${parts.roleHeader} 모집`
+    : `[UNIQN] ${title}`;
+
+  const body: string[] = [];
+  // 제목과 근무지가 같으면 위치 라인 생략 (중복 방지)
+  const location = parts.location.trim();
+  if (location && location !== title) {
+    body.push(`📍 ${location}`);
+  }
+  parts.dateLines.filter(Boolean).forEach((d) => body.push(`📅 ${d}`));
+  if (parts.roleLine) {
+    body.push(`🙋 ${parts.roleLine} 모집`);
+  }
+  if (parts.salary) {
+    body.push(`💰 ${parts.salary}`);
+  }
+
+  const bodyBlock = body.length > 0 ? `\n\n${body.join('\n')}` : '';
+  return `${headerLine}${bodyBlock}\n\n👉 지원하기\n${parts.url}`;
+}
+
+/**
+ * 공고 공유 본문 생성 (이모지형). 공고 상세 화면과 동일 파생 모델 재사용.
+ */
+export function buildJobShareText(job: JobPosting, url: string): string {
+  try {
+    const facts = buildPostingFacts(job);
+    const detail = projectPostingSurface(facts, {
+      audience: 'public',
+      surface: 'detail',
+    }) as PostingDetailViewModel;
+
+    const schedule = buildPostingScheduleModel(detail);
+    const { header, line: roleLine } = buildRoleLine(schedule);
+
+    return composeJobShareText({
+      title: detail.title?.trim() || '공고',
+      location: detail.locationLabel?.trim() || '',
+      dateLines: buildDateLines(schedule),
+      roleHeader: header,
+      roleLine,
+      salary: buildSalaryLine(detail),
+      url,
+    });
+  } catch (error) {
+    // 파생 실패 시에도 공유는 동작해야 한다 — 최소 본문으로 fallback
+    logger.warn('공유 본문 생성 실패 — 최소 본문 fallback', { jobId: job?.id });
+    void toError(error);
+    const title = job?.title?.trim() || '공고';
+    return `[UNIQN] ${title}\n\n👉 지원하기\n${url}`;
+  }
+}
+
+export default buildJobShareText;

--- a/uniqn-mobile/supabase/migrations/20260525153952_fix_job_postings_anon_public_select.sql
+++ b/uniqn-mobile/supabase/migrations/20260525153952_fix_job_postings_anon_public_select.sql
@@ -1,0 +1,20 @@
+-- BUG: 공유 링크 클릭 시 비로그인(anon) 사용자가 공개 공고 상세에서
+-- "permission denied for function is_workspace_member" (SQLSTATE 42501) 발생.
+--
+-- 원인: public.job_postings 의 SELECT 정책 jp_select_managed 가 TO PUBLIC(anon 포함)인데
+-- USING 절에서 is_workspace_member()/is_posting_collaborator() 를 호출한다. 두 헬퍼는
+-- EXECUTE 가 authenticated/service_role/postgres 에만 부여되어 있어, anon 이 함수 권한
+-- 체크 단계에서 abort 된다. permissive 정책은 OR 로 합산되므로 jp_select_public_search
+-- (status 필터, TO PUBLIC)가 행을 허용하기 전에 함수 참조만으로 anon 쿼리 전체가 실패.
+--
+-- FIX: 관리자용 SELECT 정책을 authenticated 롤로 한정. anon 쿼리는 jp_select_public_search
+-- 만 평가하여 approved/active/closed 공고를 정상 조회한다. 로그인 사용자는 두 정책이
+-- OR 로 결합되어 동작 불변.
+--
+-- 안전성: 제거되는 것은 anon 에 대한 "추가" permissive 분기이므로 anon 가시성은 늘 수
+-- 없고 동일하거나 더 엄격해진다. jp_select_public_search 는 본 변경 이전부터 TO PUBLIC.
+--
+-- 적용: 2026-05-25 MCP apply_migration 으로 prod 선반영 + anon SELECT Red→Green 검증 완료.
+-- 본 파일은 레포/신규 스택 동기화용.
+
+ALTER POLICY jp_select_managed ON public.job_postings TO authenticated;

--- a/uniqn-mobile/supabase/tests/job_postings_anon_public_select.test.sql
+++ b/uniqn-mobile/supabase/tests/job_postings_anon_public_select.test.sql
@@ -1,0 +1,48 @@
+-- ============================================================
+-- 공개 공고 anon SELECT 회귀 테스트 (공유 링크 401 재발 방지)
+-- ============================================================
+-- 목적: 비로그인(anon) 사용자가 public.job_postings 를 SELECT 할 때
+--       "permission denied for function is_workspace_member" (42501)가
+--       다시 발생하지 않음을 보장.
+--
+-- 사용법:
+--   psql "$SUPABASE_DB_URL" -f supabase/tests/job_postings_anon_public_select.test.sql
+--   또는 supabase test db (CI: .github/workflows/db-tests.yml)
+--   기대 결과: 2 tests passed, 에러 0건
+--
+-- Red→Green:
+--   - FIX 이전(jp_select_managed TO PUBLIC): TEST 1 이 42501 로 die → fail.
+--   - FIX 이후(jp_select_managed TO authenticated): anon 은 jp_select_public_search
+--     만 평가 → 함수 참조 없음 → lives.
+--
+-- 안전장치: BEGIN/ROLLBACK 래핑, 시드 없음(테이블 행 유무와 무관한 권한 버그라
+--           실데이터를 건드리지 않고 정책 평가 경로만 검증).
+-- ============================================================
+
+BEGIN;
+SELECT plan(2);
+
+-- TEST 1 (behavioral / 핵심 회귀): anon SELECT 가 함수 권한으로 abort 되지 않는다.
+-- lives_ok 본문에서만 anon 으로 전환(테스트 러너 자신은 anon 권한 불필요).
+SELECT lives_ok(
+  $$ SET LOCAL ROLE anon;
+     SELECT count(*) FROM public.job_postings WHERE status = 'active';
+     RESET ROLE; $$,
+  'anon 은 42501 없이 공개(active) 공고를 SELECT 할 수 있어야 한다'
+);
+
+-- TEST 2 (structural / 회귀 가드): 관리자 SELECT 정책이 authenticated 로 한정되어
+-- anon 쿼리에 is_workspace_member 가 더 이상 섞이지 않는다.
+SELECT is(
+  (SELECT array_agg(rolname ORDER BY rolname)::text
+   FROM pg_policy p
+   CROSS JOIN LATERAL unnest(p.polroles) AS r(oid)
+   JOIN pg_roles ON pg_roles.oid = r.oid
+   WHERE p.polrelid = 'public.job_postings'::regclass
+     AND p.polname = 'jp_select_managed'),
+  '{authenticated}',
+  'jp_select_managed 는 authenticated 롤로만 적용되어야 한다(anon 제외)'
+);
+
+SELECT finish();
+ROLLBACK;


### PR DESCRIPTION
## 요약
공고 공유 기능을 카드/상세 여러 곳에 노출하고, 공유 본문에 근무 정보를 자동 포함하며, 공유 링크의 anon 401을 해소한다.

### 공유 버튼 배치 (3곳 추가)
- **구인구직 탭 카드** (`JobCard.tsx`): 북마크 옆. trim된 view model만 가지므로 `shareJobById(id)`로 전체 공고 조회 후 공유. 카드 래퍼가 web `<button>`이라 중첩 `<button>` 하이드레이션 회피 위해 web `<View onClick>`(div)·native `Pressable` 분기, `accessibilityRole` 미지정, `stopPropagation`으로 카드 네비게이션과 분리.
- **내 공고 탭 카드** (`employer/posting/JobPostingCard.tsx`): footer(카드 Pressable 밖)에 ShareIcon. `shareJob(posting)` 직접.
- **내 공고 상세** (`my-postings/[id]/index.tsx`): StackHeader rightAction에 ShareIcon + QR. 공개 상세 패턴 복제.

### useShare 확장
- `shareJobById(jobId)` 추가 — 완전한 JobPosting을 갖지 못한 리스트 카드용. `getJobDetailQueryOptions` 재사용(캐시·dedupe)으로 전체 공고 확보 후 `shareJob`과 동일 본문 생성. 공통 코어 `runJobShare`로 추출.

### 공유 텍스트 강화 (cf193046c)
- `jobShareMessage.ts`: 공유 본문에 일정·역할·인원·급여 자동 포함. 중복 미리보기 제거.

### 공유 링크 anon RLS (73e63585e)
- `job_postings` anon 공개 SELECT 401 해소 — `jp_select_managed` 정책을 `TO authenticated`로 한정(SECDEF 헬퍼 권한 abort 회피). 마이그레이션 `20260525153952` + pgTAP. **prod 적용 완료.**

## 디자인
- ShareIcon secondary 기본색(골드 남용 금지), 터치 타깃 44px(hitSlop), 다크모드 대응.

## Test plan
- [x] `npm run quality` (type-check + lint + format) 통과 (0 errors)
- [x] jest 30/30 (JobCard, JobPostingCard, jobShareMessage, useShare 신규 스위트)
- [x] Playwright 라이브 검증 (web): 3곳 공유 동작·중첩 button 0건·콘솔 에러 0건
  - 구인구직 카드: div 렌더 확인, 클릭→fetch→공유 완주, 카드 네비 차단
  - 내 공고 카드/상세: 임시 공고 생성→캡처→삭제로 확인
- [ ] CI (e2e) 통과 대기

## 참고
- 브랜치에 마케팅 캠페인 설계 docs 2건(`725263b2b`, `8bc937f27`)이 포함됨 — 이전 커밋.

🤖 Generated with [Claude Code](https://claude.com/claude-code)