### PR TITLE
feat(install): 비로그인 공유 화면 앱 설치 버튼을 실제 스토어로 연결

### DIFF
--- a/uniqn-mobile/src/constants/__tests__/version.test.ts
+++ b/uniqn-mobile/src/constants/__tests__/version.test.ts
@@ -1,8 +1,9 @@
-import { getStoreUrl, UPDATE_POLICY } from '@/constants/version';
+import { getStoreUrl, resolveInstallStoreUrl, UPDATE_POLICY } from '@/constants/version';
 
-describe('version store urls', () => {
-  it('falls back to the web url when the iOS App Store link is still a placeholder', () => {
-    expect(getStoreUrl('ios')).toBe(UPDATE_POLICY.STORE_URLS.web);
+describe('getStoreUrl', () => {
+  it('returns the configured App Store url on iOS', () => {
+    expect(getStoreUrl('ios')).toBe(UPDATE_POLICY.STORE_URLS.ios);
+    expect(UPDATE_POLICY.STORE_URLS.ios).toContain('apps.apple.com');
   });
 
   it('returns the configured Play Store url on Android', () => {
@@ -11,5 +12,43 @@ describe('version store urls', () => {
 
   it('returns the web url on non-mobile platforms', () => {
     expect(getStoreUrl('web')).toBe(UPDATE_POLICY.STORE_URLS.web);
+  });
+});
+
+describe('resolveInstallStoreUrl', () => {
+  it('routes iPhone web visitors to the App Store via userAgent', () => {
+    const ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15';
+    expect(resolveInstallStoreUrl('web', ua)).toBe(UPDATE_POLICY.STORE_URLS.ios);
+  });
+
+  it('routes Android web visitors to the Play Store via userAgent', () => {
+    const ua = 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36';
+    expect(resolveInstallStoreUrl('web', ua)).toBe(UPDATE_POLICY.STORE_URLS.android);
+  });
+
+  it('routes the in-app KakaoTalk browser on iOS to the App Store', () => {
+    const ua =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 KAKAOTALK';
+    expect(resolveInstallStoreUrl('web', ua)).toBe(UPDATE_POLICY.STORE_URLS.ios);
+  });
+
+  it('routes legacy iPad UA (with iPad token) to the App Store', () => {
+    const ua = 'Mozilla/5.0 (iPad; CPU OS 12_4 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148';
+    expect(resolveInstallStoreUrl('web', ua)).toBe(UPDATE_POLICY.STORE_URLS.ios);
+  });
+
+  it('routes iPadOS 13+ desktop UA (Macintosh + touch) to the App Store', () => {
+    const ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15';
+    expect(resolveInstallStoreUrl('web', ua, 5)).toBe(UPDATE_POLICY.STORE_URLS.ios);
+  });
+
+  it('falls back to the website for real desktop web visitors (no touch)', () => {
+    const ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15';
+    expect(resolveInstallStoreUrl('web', ua, 0)).toBe(UPDATE_POLICY.STORE_URLS.web);
+  });
+
+  it('uses the native platform store directly when not on web', () => {
+    expect(resolveInstallStoreUrl('ios', '')).toBe(UPDATE_POLICY.STORE_URLS.ios);
+    expect(resolveInstallStoreUrl('android', '')).toBe(UPDATE_POLICY.STORE_URLS.android);
   });
 });

--- a/uniqn-mobile/src/constants/index.ts
+++ b/uniqn-mobile/src/constants/index.ts
@@ -22,6 +22,7 @@ export {
   isVersionAtLeast,
   checkUpdateRequired,
   getStoreUrl,
+  resolveInstallStoreUrl,
   versionInfo,
   type UpdateType,
 } from './version';

--- a/uniqn-mobile/src/constants/version.ts
+++ b/uniqn-mobile/src/constants/version.ts
@@ -91,12 +91,12 @@ export const UPDATE_POLICY = {
   RECOMMENDED_DISMISS_DAYS: 3,
 
   /**
-   * 앱스토어 링크
-   * 스토어 등록 후 실제 ID로 교체 필요
+   * 앱스토어 링크 (출시 완료 — 실제 스토어 ID)
+   * iOS App Store ID: 6758857038 / Android package: com.uniqn.mobile
    */
   STORE_URLS: {
-    ios: 'https://apps.apple.com/app/uniqn/idXXXXXXXXXX', // 스토어 등록 후 실제 앱 ID로 교체
-    android: 'https://play.google.com/store/apps/details?id=com.uniqn.mobile', // 스토어 등록 후 확인
+    ios: 'https://apps.apple.com/kr/app/uniqn/id6758857038',
+    android: 'https://play.google.com/store/apps/details?id=com.uniqn.mobile',
     web: 'https://uniqn.app',
   },
 } as const;
@@ -190,6 +190,39 @@ export function getStoreUrl(platform: typeof Platform.OS = Platform.OS): string 
         : UPDATE_POLICY.STORE_URLS.web;
 
   return isStoreUrlConfigured(selectedUrl) ? selectedUrl : UPDATE_POLICY.STORE_URLS.web;
+}
+
+/**
+ * 앱 설치용 스토어 URL 해석
+ *
+ * @description 공유 링크는 카톡/SNS → 모바일 웹브라우저로 열리므로 `Platform.OS`가
+ * 'web'이 된다. 이때 `getStoreUrl`은 디바이스를 구분하지 못하고 웹 URL을 반환한다.
+ * 비로그인 사용자가 "앱 설치"를 눌렀을 때 기기에 맞는 스토어로 보내기 위해
+ * 웹에서는 userAgent로 iOS/Android를 판별한다(데스크톱은 웹사이트로 폴백).
+ * 네이티브 앱에서는 `Platform.OS` 기반 `getStoreUrl`을 그대로 사용한다.
+ *
+ * iPadOS 13+ Safari는 기본 UA를 'iPad'가 아닌 'Macintosh'(데스크톱)로 보고하므로
+ * 터치 지원(maxTouchPoints)을 함께 보고 iPad를 App Store로 라우팅한다.
+ */
+export function resolveInstallStoreUrl(
+  platform: typeof Platform.OS = Platform.OS,
+  userAgent: string = typeof navigator !== 'undefined' ? (navigator.userAgent ?? '') : '',
+  maxTouchPoints: number = typeof navigator !== 'undefined' ? (navigator.maxTouchPoints ?? 0) : 0
+): string {
+  if (platform === 'web') {
+    if (/android/i.test(userAgent)) {
+      return getStoreUrl('android');
+    }
+
+    const isIpadOsDesktopUa = /Macintosh/i.test(userAgent) && maxTouchPoints > 1;
+    if (/iphone|ipad|ipod/i.test(userAgent) || isIpadOsDesktopUa) {
+      return getStoreUrl('ios');
+    }
+
+    return UPDATE_POLICY.STORE_URLS.web;
+  }
+
+  return getStoreUrl(platform);
 }
 
 // ============================================================================

--- a/uniqn-mobile/src/hooks/__tests__/useInstallPrompt.test.tsx
+++ b/uniqn-mobile/src/hooks/__tests__/useInstallPrompt.test.tsx
@@ -1,9 +1,10 @@
 import { act, fireEvent, render, renderHook } from '@testing-library/react-native';
+import { Linking } from 'react-native';
 import { useInstallPrompt } from '../useInstallPrompt';
 
 const mockOpen = jest.fn();
 const mockClose = jest.fn();
-const mockInfo = jest.fn();
+const mockError = jest.fn();
 const mockPush = jest.fn();
 const expoRouter = jest.requireMock('expo-router') as { router?: { push?: jest.Mock } };
 
@@ -16,12 +17,12 @@ jest.mock('@/stores/modalStore', () => ({
 
 jest.mock('@/stores/toastStore', () => ({
   useToast: () => ({
-    info: mockInfo,
+    error: mockError,
   }),
 }));
 
 jest.mock('@/constants', () => ({
-  getStoreUrl: jest.fn(() => 'https://example.com/store'),
+  resolveInstallStoreUrl: jest.fn(() => 'https://apps.apple.com/kr/app/uniqn/id6758857038'),
 }));
 
 jest.mock('@/utils/logger', () => ({
@@ -37,15 +38,16 @@ describe('useInstallPrompt', () => {
   beforeEach(() => {
     mockOpen.mockReset();
     mockClose.mockReset();
-    mockInfo.mockReset();
+    mockError.mockReset();
     mockPush.mockReset();
+    (Linking.openURL as jest.Mock) = jest.fn().mockResolvedValue(undefined);
     expoRouter.router = {
       ...(expoRouter.router ?? {}),
       push: mockPush,
     };
   });
 
-  it('renders a login CTA and uses an explicit redirect for public job actions', async () => {
+  it('renders a login CTA and uses an explicit redirect for public job actions', () => {
     const { result } = renderHook(() => useInstallPrompt());
 
     act(() => {
@@ -69,12 +71,50 @@ describe('useInstallPrompt', () => {
 
     expect(mockClose).toHaveBeenCalled();
     expect(mockPush).toHaveBeenCalledWith('/(auth)/login?redirect=%2F(app)%2Fjobs%2Fjob-123');
+  });
+
+  it('opens the resolved store url when the install CTA is pressed', async () => {
+    const { result } = renderHook(() => useInstallPrompt());
+
+    act(() => {
+      result.current.openInstallPrompt('job-detail-cta', {
+        loginRedirect: '/(app)/jobs/job-123/apply',
+      });
+    });
+
+    const modalConfig = mockOpen.mock.calls[0][0];
 
     await act(async () => {
       await modalConfig.confirmButton.onPress();
     });
 
-    expect(mockInfo).toHaveBeenCalledWith('앱 설치 링크는 준비 중입니다.');
+    expect(Linking.openURL).toHaveBeenCalledWith(
+      'https://apps.apple.com/kr/app/uniqn/id6758857038'
+    );
+    expect(mockClose).toHaveBeenCalled();
+    expect(mockError).not.toHaveBeenCalled();
+  });
+
+  it('shows an error toast and keeps the modal open when the store fails to launch', async () => {
+    (Linking.openURL as jest.Mock).mockRejectedValueOnce(new Error('no handler'));
+
+    const { result } = renderHook(() => useInstallPrompt());
+
+    act(() => {
+      result.current.openInstallPrompt('job-detail-cta', {
+        loginRedirect: '/(app)/jobs/job-123/apply',
+      });
+    });
+
+    const modalConfig = mockOpen.mock.calls[0][0];
+
+    await act(async () => {
+      await modalConfig.confirmButton.onPress();
+    });
+
+    expect(Linking.openURL).toHaveBeenCalled();
+    expect(mockError).toHaveBeenCalledWith('스토어를 열 수 없어요. 잠시 후 다시 시도해주세요.');
+    expect(mockClose).not.toHaveBeenCalled();
   });
 
   it('uses the default protected redirect for public tabs', () => {

--- a/uniqn-mobile/src/hooks/useInstallPrompt.tsx
+++ b/uniqn-mobile/src/hooks/useInstallPrompt.tsx
@@ -1,7 +1,8 @@
 import { useCallback } from 'react';
+import { Linking } from 'react-native';
 import { router } from 'expo-router';
 import { InstallPromptContent } from '@/components/modals/InstallPromptContent';
-import { getStoreUrl } from '@/constants';
+import { resolveInstallStoreUrl } from '@/constants';
 import { getLoginRoute } from '@/shared/navigation/authRedirect';
 import { useModal } from '@/stores/modalStore';
 import { useToast } from '@/stores/toastStore';
@@ -67,6 +68,31 @@ export function useInstallPrompt() {
   const modal = useModal();
   const toast = useToast();
 
+  const openStore = useCallback(
+    async (source: InstallPromptSource) => {
+      const storeUrl = resolveInstallStoreUrl();
+
+      logger.info('Install CTA clicked', {
+        component: 'useInstallPrompt',
+        source,
+        storeUrl,
+      });
+
+      try {
+        await Linking.openURL(storeUrl);
+        modal.close();
+      } catch (error) {
+        logger.error('Failed to open store url from install prompt', error as Error, {
+          component: 'useInstallPrompt',
+          source,
+          storeUrl,
+        });
+        toast.error('스토어를 열 수 없어요. 잠시 후 다시 시도해주세요.');
+      }
+    },
+    [modal, toast]
+  );
+
   const openInstallPrompt = useCallback(
     (source: InstallPromptSource, options?: OpenInstallPromptOptions) => {
       const copy = getInstallPromptCopy(source);
@@ -103,15 +129,7 @@ export function useInstallPrompt() {
           label: '앱 설치',
           variant: 'primary',
           onPress: () => {
-            const storeUrl = getStoreUrl();
-
-            logger.info('Install CTA clicked before store links are connected', {
-              component: 'useInstallPrompt',
-              source,
-              storeUrl,
-            });
-
-            toast.info('앱 설치 링크는 준비 중입니다.');
+            void openStore(source);
           },
         },
         cancelButton: {
@@ -121,7 +139,7 @@ export function useInstallPrompt() {
         dismissible: true,
       });
     },
-    [modal, toast]
+    [modal, openStore]
   );
 
   return {


### PR DESCRIPTION
## 요약

비로그인 사용자가 공유된 공고 링크를 클릭했을 때 보는 화면의 **"앱 설치" 버튼이 실제 스토어로 연결**되도록 했습니다. 기존엔 `toast.info('앱 설치 링크는 준비 중입니다.')`만 떠서 스토어로 가지 못했습니다.

## 변경 내용

- **`version.ts`**: iOS 플레이스홀더(`idXXXXXXXXXX`) → 실제 App Store ID(`id6758857038`). `getStoreUrl('ios')`가 웹으로 폴백되던 문제 해소 (iOS 강제업데이트 플로우도 함께 정상화).
- **`resolveInstallStoreUrl` 신규**: 공유링크는 모바일 웹으로 열리므로(`Platform.OS=web`) userAgent로 iOS/Android를 판별해 맞는 스토어로 라우팅. 데스크톱은 웹사이트 폴백.
  - iPadOS 13+ Safari가 UA를 `Macintosh`로 보고하는 문제를 `maxTouchPoints`로 감지해 iPad → App Store 라우팅.
- **`useInstallPrompt`**: "앱 설치" 버튼을 `Linking.openURL`로 연결 (실패 시 에러 토스트, 성공 시 모달 닫기). job-card·각 탭 프롬프트도 동일 경로라 함께 해결.

## 비로그인 플로우
카톡/SNS 공유 → 모바일 웹(`uniqn.app/jobs/{id}`) → "지원하기" → 설치 프롬프트 → "앱 설치" → 기기별 스토어 이동.

## 테스트
- `version.test.ts`: getStoreUrl iOS 실링크 + resolveInstallStoreUrl UA 케이스(iPhone/Android/카톡 인앱/iPad legacy/iPadOS desktop/데스크톱)
- `useInstallPrompt.test.tsx`: 설치 CTA 성공·실패(에러 토스트) 경로
- 로컬: 관련 30/30 통과, `npm run quality` 0 errors

## 배포 메모
머지 후 웹은 Cloudflare 재배포, 모바일은 EAS OTA(`eas update`) 필요 — 머지만으론 프로덕션 앱 사용자에게 반영 안 됨.

## 리뷰
`/review` 멀티에이전트 적대적 리뷰로 iPad UA 라우팅 버그·에러경로 미테스트·죽은 폴백 3건 수정. canOpenURL=false 해피패스 P1 제기는 RNW `canOpenURL`이 항상 true 반환임을 확인해 거짓양성 판정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)