### PR TITLE
fix(jobPosting): #145 사후리뷰 — 레거시 fixed 역호환 read 복구 + P2 3건

### DIFF
--- a/uniqn-mobile/src/components/jobs/shared/__tests__/postingSurfaceModel.hydrate.test.ts
+++ b/uniqn-mobile/src/components/jobs/shared/__tests__/postingSurfaceModel.hydrate.test.ts
@@ -137,4 +137,38 @@ describe('buildPostingScheduleModel hydrate — fixed/grouped/dated 단일 소�
     expect(role.filled).toBe(2);
     expect(role.isFilled).toBe(true);
   });
+
+  // 슬롯 startTime 이 range 문자열("18:00~22:00")이어도 hydrate 키는 서버 _posting_slot_key 와 동일하게
+  // 시작시간(18:00)으로 정규화돼야 매칭된다. (정규화 누락 시 0/N 으로 영원히 표시되는 회귀)
+  it('dated: range startTime 슬롯도 시작시간으로 정규화해 hydrate 매칭한다', () => {
+    const datedSource = {
+      workflow: { isFixed: false, usesGroupedDateRanges: false },
+      scheduleDisplay: {
+        variant: 'dated_requirements',
+        fixed: undefined,
+        dateGroups: [],
+        dateRequirements: [
+          {
+            date: '2026-06-10',
+            timeSlots: [
+              {
+                id: 's1',
+                startTime: '18:00~22:00',
+                roles: [{ role: 'dealer', count: 2, filled: 0 }],
+              },
+            ],
+          },
+        ],
+        workDate: '',
+        timeSlot: '',
+      },
+    } as any;
+
+    const filledCounts = new Map<string, number>([['2026-06-10__18:00__dealer', 2]]);
+    const model = buildPostingScheduleModel(datedSource, filledCounts);
+
+    const role = (model as any).sections[0].timeSlots[0].roles[0];
+    expect(role.filled).toBe(2);
+    expect(role.isFilled).toBe(true);
+  });
 });

--- a/uniqn-mobile/src/components/jobs/shared/postingSurfaceModel.ts
+++ b/uniqn-mobile/src/components/jobs/shared/postingSurfaceModel.ts
@@ -9,6 +9,7 @@ import type {
   PostingSalaryDisplay,
 } from '@/types';
 import { FIXED_DATE_MARKER, FIXED_TIME_MARKER } from '@/types/assignment';
+import { WorkLogCreator } from '@/domains/schedule';
 import { getRoleDisplayName } from '@/types/unified';
 import { formatDateRangeWithCount, formatDateShortWithDay, getDayCount } from '@/utils/date';
 import { formatSalary } from '@/utils/formatters';
@@ -307,7 +308,10 @@ function pickMaxSalaryRowText(rows: readonly PostingSalaryRow[]): string | undef
 
 function slotMatchKey(slot: TimeSlotSource): string {
   if (slot.isTimeToBeAnnounced) return UNKNOWN_TIME_LABEL;
-  return slot.startTime || slot.time || UNKNOWN_TIME_LABEL;
+  // 서버 _posting_slot_key / apply 경로(slotCapacity)와 동일하게 range 문자열("14:00~22:00")에서
+  // 시작시간만 추출해 hydrate 키를 맞춘다. discrete HH:MM 값에는 항등(무변경).
+  const normalized = WorkLogCreator.extractStartTime(slot.startTime || slot.time || '');
+  return normalized || UNKNOWN_TIME_LABEL;
 }
 
 function roleMatchKey(role: RoleSource): string {

--- a/uniqn-mobile/src/domains/job-posting/__tests__/totalPositions.test.ts
+++ b/uniqn-mobile/src/domains/job-posting/__tests__/totalPositions.test.ts
@@ -41,6 +41,30 @@ describe('calculateTotalPositionsFromSchedule', () => {
       expect(calculateTotalPositionsFromSchedule(schedule)).toBe(0);
     });
 
+    // 같은 슬롯 안 동일 역할 중복 엔트리는 동시 필요 인원이므로 합산해야 한다.
+    // (peak-by-role 만 쓰면 [dealer:3, dealer:2] 가 max 3 으로 과소 집계되는 회귀)
+    it('sums duplicate same-role entries within one slot (dealer 3 + dealer 2 = 5)', () => {
+      const schedule: PostingSchedule = {
+        kind: 'fixed',
+        requirements: [
+          {
+            date: null,
+            timeSlots: [
+              {
+                startTime: '19:00',
+                isTimeToBeAnnounced: false,
+                roles: [
+                  { role: 'dealer', count: 3 },
+                  { role: 'dealer', count: 2 },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      expect(calculateTotalPositionsFromSchedule(schedule)).toBe(5);
+    });
+
     // SP3: calculateFilledPositionsFromSchedule 제거됨 — filled 는 schedule 에서 파생하지 않음(컬럼·트리거 권위).
     // 관련 테스트는 삭제. capacity/총원 계산은 위 calculateTotalPositionsFromSchedule 로 충분히 커버됨.
   });

--- a/uniqn-mobile/src/domains/job-posting/index.ts
+++ b/uniqn-mobile/src/domains/job-posting/index.ts
@@ -1,5 +1,6 @@
 export {
   FIXED_POSTING_DURATION_DAYS,
+  buildFixedSyntheticRequirement,
   deriveWorkDateFieldsFromSchedule,
   getCanonicalPostingType,
   isScheduleKindCompatibleWithPostingType,

--- a/uniqn-mobile/src/domains/job-posting/serialization.ts
+++ b/uniqn-mobile/src/domains/job-posting/serialization.ts
@@ -129,7 +129,7 @@ function normalizeRoleCatalog(
  * 목표 불변식: requirements.length===1, requirements[0].date===null,
  *              requirements[0].timeSlots.length===1, date:'' sentinel 금지.
  */
-function buildFixedSyntheticRequirement(
+export function buildFixedSyntheticRequirement(
   schedule: Extract<CreateJobPostingInput['schedule'], { kind: 'fixed' }> | Record<string, unknown>
 ): PostingDateRequirement {
   const s = schedule as {

--- a/uniqn-mobile/src/domains/job-posting/stats.ts
+++ b/uniqn-mobile/src/domains/job-posting/stats.ts
@@ -38,14 +38,22 @@ export function calculateTotalPositionsFromSchedule(schedule: PostingSchedule): 
 
   schedule.requirements.forEach((requirement) => {
     requirement.timeSlots.forEach((slot) => {
+      // 같은 슬롯 안 동일 역할 엔트리는 동시 필요 인원이므로 합산한다.
+      // (peak 를 바로 비교하면 [dealer:3, dealer:2] 같은 중복 역할이 5 아닌 3으로 과소 집계됨)
+      const slotSumByRole = new Map<string, number>();
       slot.roles.forEach((role) => {
         const key = getRoleKey(role);
         if (key === null) {
           return;
         }
+        slotSumByRole.set(key, (slotSumByRole.get(key) ?? 0) + role.count);
+      });
+
+      // 슬롯/날짜 간에는 같은 사람이 돌아가며 근무 가능 → 역할별 최대 동시 필요 인원(peak).
+      slotSumByRole.forEach((slotSum, key) => {
         const previous = peakByRole.get(key) ?? 0;
-        if (role.count > previous) {
-          peakByRole.set(key, role.count);
+        if (slotSum > previous) {
+          peakByRole.set(key, slotSum);
         }
       });
     });

--- a/uniqn-mobile/src/schemas/__tests__/jobPosting.schema.test.ts
+++ b/uniqn-mobile/src/schemas/__tests__/jobPosting.schema.test.ts
@@ -495,6 +495,47 @@ describe('jobPosting schemas', () => {
       expect(isJobPostingDocument({ bad: true })).toBe(false);
     });
 
+    // SP1 역호환: 레거시 fixed 문서(roleRequirements[])는 strict 스키마가 거부하면 안 된다.
+    // safeParse 이전 입력 정규화로 통일 구조(requirements[])로 흡수해 읽기 경로에서 살아남아야 함.
+    // (fix 이전엔 .strict() + requirements 필수로 reject → parseJobPostingDocument 가 null 반환 = 공고 증발)
+    it('absorbs legacy fixed schedule (roleRequirements) on read instead of dropping it', () => {
+      const legacyFixedDocument = {
+        ...createValidDocument(),
+        id: 'legacy-fixed',
+        postingType: 'fixed' as const,
+        workDate: '',
+        workDates: undefined,
+        schedule: {
+          kind: 'fixed' as const,
+          daysPerWeek: 5,
+          startTime: '19:00',
+          roleRequirements: [
+            { role: 'dealer', count: 3, filled: 1 },
+            { role: 'floor', count: 2 },
+          ],
+        },
+      };
+
+      const parsed = parseJobPostingDocument(legacyFixedDocument);
+
+      expect(parsed).not.toBeNull();
+      expect(parsed?.id).toBe('legacy-fixed');
+      expect(parsed?.schedule.kind).toBe('fixed');
+      expect(parsed?.schedule.requirements).toHaveLength(1);
+      expect(parsed?.schedule.requirements[0]?.date).toBeNull();
+      expect(parsed?.schedule.requirements[0]?.timeSlots).toHaveLength(1);
+
+      const roles = parsed?.schedule.requirements[0]?.timeSlots[0]?.roles ?? [];
+      expect(roles).toHaveLength(2);
+      expect(roles.find((r) => r.role === 'dealer')?.count).toBe(3);
+      expect(roles.find((r) => r.role === 'floor')?.count).toBe(2);
+      // dead counter `filled`(SP3 제거)는 흡수 과정에서 복사되지 않는다.
+      expect(roles.every((r) => !('filled' in r))).toBe(true);
+
+      // type guard 도 동일하게 레거시 fixed 문서를 인정해야 한다.
+      expect(isJobPostingDocument(legacyFixedDocument)).toBe(true);
+    });
+
     it('rejects non-canonical top-level fields on read', () => {
       const parsed = parseJobPostingDocument({
         ...createValidDocument(),

--- a/uniqn-mobile/src/schemas/jobPosting.schema.ts
+++ b/uniqn-mobile/src/schemas/jobPosting.schema.ts
@@ -7,6 +7,7 @@ import { VALID_STAFF_ROLES } from '@/types/role';
 import type { JobPosting, JobPostingDocumentV3 } from '@/types';
 import {
   FIXED_POSTING_DURATION_DAYS,
+  buildFixedSyntheticRequirement,
   deriveWorkDateFieldsFromSchedule,
   deserializeJobPostingDocument,
   getCanonicalPostingType,
@@ -521,8 +522,38 @@ function toJobPostingDocumentV3(document: JobPostingDocumentData): JobPostingDoc
   } as unknown as JobPostingDocumentV3;
 }
 
+/**
+ * 레거시 fixed 스케줄(roleRequirements[]) 문서를 strict 스키마가 받아들일 수 있는
+ * 통일 구조(requirements[])로 입력 단계에서 정규화한다.
+ *
+ * @description SP1 통일 후 fixed 스키마는 `requirements` 필수 + `.strict()`라
+ * 레거시 `{kind:'fixed', roleRequirements:[...]}` 문서는 safeParse 에서 거부되어
+ * 읽기 경로가 null 을 반환(공고 증발)한다. deserialize 의 역호환 흡수는 parse 통과
+ * 후에만 실행되므로 도달 불가능 — 따라서 safeParse 이전에 합성 슬롯으로 변환한다.
+ *
+ * canonical 문서(roleRequirements 키 없음)는 원본 그대로 반환(무변경 통과).
+ */
+function normalizeLegacyFixedScheduleInput(data: unknown): unknown {
+  if (!data || typeof data !== 'object') return data;
+  const doc = data as Record<string, unknown>;
+  const schedule = doc.schedule;
+  if (!schedule || typeof schedule !== 'object') return data;
+  const s = schedule as Record<string, unknown>;
+  if (s.kind !== 'fixed' || !('roleRequirements' in s)) return data;
+
+  // 레거시 흡수: roleRequirements → 합성 requirements 1건 + roleRequirements 키 제거(strict 통과)
+  const { roleRequirements: _legacyRoleRequirements, ...restSchedule } = s;
+  return {
+    ...doc,
+    schedule: {
+      ...restSchedule,
+      requirements: [buildFixedSyntheticRequirement(s)],
+    },
+  };
+}
+
 export function parseJobPostingDocument(data: unknown): JobPosting | null {
-  const result = jobPostingDocumentSchema.safeParse(data);
+  const result = jobPostingDocumentSchema.safeParse(normalizeLegacyFixedScheduleInput(data));
 
   if (result.success) {
     return deserializeJobPostingDocument(toJobPostingDocumentV3(result.data));
@@ -542,5 +573,5 @@ export function parseJobPostingDocuments(data: unknown[]): JobPosting[] {
 }
 
 export function isJobPostingDocument(data: unknown): data is JobPosting {
-  return jobPostingDocumentSchema.safeParse(data).success;
+  return jobPostingDocumentSchema.safeParse(normalizeLegacyFixedScheduleInput(data)).success;
 }

--- a/uniqn-mobile/src/types/__tests__/jobTemplate.test.ts
+++ b/uniqn-mobile/src/types/__tests__/jobTemplate.test.ts
@@ -2,6 +2,8 @@ import type { JobPostingFormData, JobPostingTemplate } from '@/types';
 import { STAFF_ROLES } from '@/constants';
 import { buildSeedTimeSlots } from '@/utils/job-posting/draftRoles';
 import { INITIAL_JOB_POSTING_FORM_DATA } from '@/types/jobPostingForm';
+import { INITIAL_JOB_POSTING_DRAFT } from '@/types/jobPostingDraft';
+import type { JobPostingDraft } from '@/types/jobPostingDraft';
 import { extractTemplateData, templateToFormData } from '@/types/jobTemplate';
 
 const DEALER_ROLE_NAME = STAFF_ROLES.find((role) => role.key === 'dealer')?.name ?? 'dealer';
@@ -17,6 +19,37 @@ function createTemplate(formData: JobPostingFormData): JobPostingTemplate {
     templateData: extractTemplateData(formData),
   };
 }
+
+describe('jobTemplate fixed schedule', () => {
+  // fixed 합성 슬롯 불변식: isTimeToBeAnnounced 가 소스에 없어도 템플릿 추출 시 false 로 고정돼야 한다.
+  // (buildFixedSyntheticRequirement 와 동일 — 누락 시 시간 미정 상태로 오인되는 발산 방지)
+  it('forces isTimeToBeAnnounced:false on fixed synthetic slot even when source omits it', () => {
+    const fixedDraft: JobPostingDraft = {
+      ...INITIAL_JOB_POSTING_DRAFT,
+      postingType: 'fixed',
+      schedule: {
+        kind: 'fixed',
+        daysPerWeek: 5,
+        startTime: '19:00',
+        requirements: [
+          {
+            date: null,
+            // isTimeToBeAnnounced 의도적 미설정
+            timeSlots: [{ startTime: '19:00', roles: [{ role: 'dealer', count: 2 }] }],
+          },
+        ],
+      },
+    } as JobPostingDraft;
+
+    const templateData = extractTemplateData(fixedDraft);
+    const schedule = templateData.schedule as
+      | { kind: string; requirements: { timeSlots: { isTimeToBeAnnounced?: boolean }[] }[] }
+      | undefined;
+
+    expect(schedule?.kind).toBe('fixed');
+    expect(schedule?.requirements[0].timeSlots[0].isTimeToBeAnnounced).toBe(false);
+  });
+});
 
 describe('jobTemplate dated template helpers', () => {
   it('stores a per-date seed schedule instead of aggregated role counts', () => {

--- a/uniqn-mobile/src/types/jobTemplate.ts
+++ b/uniqn-mobile/src/types/jobTemplate.ts
@@ -125,11 +125,13 @@ export function extractTemplateData(
       draft.schedule.kind === 'fixed'
         ? {
             ...draft.schedule,
-            // TODO(SP1 후속): buildFixedSyntheticRequirement 공유 헬퍼로 통합
             requirements: draft.schedule.requirements.map((requirement) => ({
               date: null,
               timeSlots: requirement.timeSlots.map((slot) => ({
                 ...slot,
+                // fixed 스케줄은 시간 미정 개념이 없다 — 합성 슬롯 불변식(isTimeToBeAnnounced:false)을
+                // buildFixedSyntheticRequirement 와 동일하게 명시 고정한다.
+                isTimeToBeAnnounced: false,
                 roles: slot.roles.map((role) => ({ ...role })),
               })),
             })),


### PR DESCRIPTION
## 배경
PR #145(SP1+SP2+SP3 스케줄 통일) 사후 리뷰에서 발견한 P1 1건 + P2 3건 수정. 현재 prod 영향은 거의 0(공고 2건 모두 dated, fixed/레거시 0건)이나, 코드에 남은 잠재 버그를 사용자 유입/배포 전에 차단.

## 변경

### [P1] 레거시 fixed 문서(roleRequirements[]) read 경로 증발
`parseJobPostingDocument`가 strict `safeParse`를 먼저 돌려, `requirements` 필수 + `.strict()`로 레거시 `{kind:'fixed', roleRequirements:[...]}` 문서를 거부 → `null` 반환(공고가 목록/상세에서 조용히 사라짐). `deserialize`의 `buildFixedSyntheticRequirement` 역호환 흡수는 parse 통과 후라 도달 불가능(dead code).
- **fix**: `safeParse` 이전 `normalizeLegacyFixedScheduleInput` 입력 정규화 단계 추가 — `roleRequirements` → 합성 `requirements` 1건 흡수 + `roleRequirements` 키 제거. canonical 문서는 무변경 통과. `isJobPostingDocument`도 동일 적용.
- `buildFixedSyntheticRequirement` export(serialization + 배럴)로 재사용.
- **Red-Green 검증**: fix 이전 `parsed=null`(공고 증발) → 이후 통일 구조 흡수.

### [P2-a] `stats.calculateTotalPositionsFromSchedule` 슬롯 내 중복 역할 과소집계
peak-by-role 직접 비교가 `[dealer:3, dealer:2]`를 max 3으로 집계. 슬롯 내 동일 역할은 동시 필요 인원 → **합산(5)**, 슬롯/날짜 간만 peak로 변경.

### [P2-b] `postingSurfaceModel.slotMatchKey` range startTime 미정규화
apply 경로(slotCapacity)·서버 `_posting_slot_key`와 달리 range(`"18:00~22:00"`)를 그대로 키로 사용 → hydrate 불일치 시 0/N 표시. `WorkLogCreator.extractStartTime`로 시작시간 정규화(discrete HH:MM 항등). TBA 분기는 미정 마커 유지.

### [P2-c] `jobTemplate.extractTemplateData` fixed 합성 슬롯 불변식 누락
`isTimeToBeAnnounced`를 명시 `false`로 고정(`buildFixedSyntheticRequirement`와 정합).

## SKIP
레거시 표시 컴포넌트 3건 정리(P2) — #145 무관 기존 dead-ish 코드 + `FixedScheduleDisplay`는 ApplicantCard 라이브 경로라 라이브 버그 없음 → `npx knip` 후속 권장.

## 게이트
- `npm run quality`: tsc 0 errors / lint 0 errors / format pass
- `npx jest`: **304 suites · 4286 tests PASS** (신규 4 테스트 포함)

## Test plan
- [x] 레거시 fixed 문서 read 흡수 (Red-Green)
- [x] 슬롯 내 중복 역할 합산
- [x] range startTime hydrate 매칭
- [x] jobTemplate fixed isTimeToBeAnnounced:false
- [ ] 배포 후 수동 QA (웹 Cloudflare + EAS OTA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)