### PR TITLE
chore(config): 죽은 Firebase Cloud Functions API 설정 제거

### DIFF
--- a/uniqn-mobile/src/config/env.ts
+++ b/uniqn-mobile/src/config/env.ts
@@ -21,14 +21,8 @@ export interface EnvironmentConfig {
   isDevelopment: boolean;
   isStaging: boolean;
   isProduction: boolean;
-  api: ApiConfig;
   features: FeatureFlags;
   logging: LoggingConfig;
-}
-
-export interface ApiConfig {
-  baseUrl: string;
-  timeout: number;
 }
 
 export interface FeatureFlags {
@@ -66,26 +60,6 @@ function detectEnvironment(): Environment {
 }
 
 const currentEnvironment = detectEnvironment();
-
-// ============================================================================
-// API Configuration
-// ============================================================================
-
-const apiConfigs: Record<Environment, ApiConfig> = {
-  development: {
-    // NOTE: 실제 디바이스에서는 로컬 IP 주소 사용 필요 (예: http://192.168.x.x:5001/...)
-    baseUrl: 'http://localhost:5001/tholdem-ebc18/asia-northeast3',
-    timeout: 30000,
-  },
-  staging: {
-    baseUrl: 'https://asia-northeast3-tholdem-ebc18.cloudfunctions.net',
-    timeout: 15000,
-  },
-  production: {
-    baseUrl: 'https://asia-northeast3-tholdem-ebc18.cloudfunctions.net',
-    timeout: 10000,
-  },
-};
 
 // ============================================================================
 // Feature Flags
@@ -154,7 +128,6 @@ export const env: EnvironmentConfig = {
   isDevelopment: currentEnvironment === 'development',
   isStaging: currentEnvironment === 'staging',
   isProduction: currentEnvironment === 'production',
-  api: apiConfigs[currentEnvironment],
   features: featureFlagsConfig[currentEnvironment],
   logging: loggingConfigs[currentEnvironment],
 };


### PR DESCRIPTION
## 배경
PR #146 OTA 번들 검증 중, 발행된 `.hbc`에 옛 Firebase 펑션 에뮬레이터 URL(`http://localhost:5001/tholdem-ebc18/asia-northeast3`)이 박혀있는 것을 발견. 출처를 추적한 결과 `src/config/env.ts`의 `apiConfigs` 맵이었음.

## 변경
Firebase 제거(2026-04-11) 이후 어떤 코드도 읽지 않는 dead 설정 제거:
- `apiConfigs` 맵 (dev=localhost:5001 에뮬레이터, staging/prod=`asia-northeast3-tholdem-ebc18.cloudfunctions.net`)
- `ApiConfig` 인터페이스
- `EnvironmentConfig.api` 필드 + `env.api` 할당

## 안전성
- `env.api` / `.baseUrl` / `ApiConfig` 소비처 **grep 0건** → 완전 dead.
- `env`의 라이브 사용처는 유지: `isDevelopment`(7) / `isProduction`(2) / `features` / `environment` / `isFeatureEnabled`.

## 게이트
- `npm run quality`: tsc 0 / lint 0 errors / format pass
- `logger.test`(@/config/env mock): 32 pass

## 참고
이 문자열은 이미 무해(useEmulator=false 게이트 + Firebase 제거)했음. 라이브 번들 반영은 다음 정식 배포 때 자연히 적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)