### PR TITLE
refactor(types): schedule discriminator를 kind로 통일 (B4)

### DIFF
--- a/uniqn-mobile/src/components/jobs/AssignmentSelector/__tests__/AssignmentSelector.test.tsx
+++ b/uniqn-mobile/src/components/jobs/AssignmentSelector/__tests__/AssignmentSelector.test.tsx
@@ -39,7 +39,7 @@ function createBaseScheduleResult(
   overrides: Partial<UseJobScheduleResult> = {}
 ): UseJobScheduleResult {
   return {
-    schedule: { type: 'dated', items: [] },
+    schedule: { kind: 'dated', items: [] },
     isFixed: false,
     isDated: true,
     allDates: [],
@@ -56,7 +56,7 @@ function createBaseScheduleResult(
 function createSingleDateSchedule() {
   return [
     {
-      type: 'dated' as const,
+      kind: 'dated' as const,
       date: '2026-04-01',
       timeSlots: [
         {
@@ -136,7 +136,7 @@ describe('AssignmentSelector', () => {
       createBaseScheduleResult({
         datedSchedules: [
           {
-            type: 'dated',
+            kind: 'dated',
             date: '2026-04-01',
             timeSlots: [
               {
@@ -199,7 +199,7 @@ describe('AssignmentSelector', () => {
         label: '4/1 ~ 4/2',
         dates: [
           {
-            type: 'dated',
+            kind: 'dated',
             date: '2026-04-01',
             timeSlots: [
               {
@@ -218,7 +218,7 @@ describe('AssignmentSelector', () => {
             ],
           },
           {
-            type: 'dated',
+            kind: 'dated',
             date: '2026-04-02',
             timeSlots: [
               {

--- a/uniqn-mobile/src/domains/application/__tests__/selectionUtils.test.ts
+++ b/uniqn-mobile/src/domains/application/__tests__/selectionUtils.test.ts
@@ -62,7 +62,7 @@ function createTestTimeSlot(
  */
 function createTestSchedule(date: string, timeSlots: TimeSlotInfo[]): DatedScheduleInfo {
   return {
-    type: 'dated',
+    kind: 'dated',
     date,
     timeSlots,
   };

--- a/uniqn-mobile/src/hooks/useJobSchedule.ts
+++ b/uniqn-mobile/src/hooks/useJobSchedule.ts
@@ -87,7 +87,7 @@ export function useJobSchedule(job: JobPosting | null): UseJobScheduleResult {
     // 공고 없으면 빈 결과 반환
     if (!job) {
       return {
-        schedule: { type: 'dated', items: [] },
+        schedule: { kind: 'dated', items: [] },
         isFixed: false,
         isDated: true,
         allDates: [],
@@ -102,7 +102,7 @@ export function useJobSchedule(job: JobPosting | null): UseJobScheduleResult {
 
     // 일정 정규화
     const schedule = normalizeJobSchedule(job);
-    const isFixed = schedule.type === 'fixed';
+    const isFixed = schedule.kind === 'fixed';
 
     // 날짜/역할 추출
     const allDates = extractAllDates(schedule);

--- a/uniqn-mobile/src/types/unified/schedule.ts
+++ b/uniqn-mobile/src/types/unified/schedule.ts
@@ -28,7 +28,7 @@ export type JobScheduleType = 'dated' | 'fixed';
  */
 export interface DatedScheduleInfo {
   /** 일정 타입 (discriminator) */
-  type: 'dated';
+  kind: 'dated';
 
   /** 날짜 (YYYY-MM-DD) */
   date: string;
@@ -44,7 +44,7 @@ export interface DatedScheduleInfo {
  */
 export interface FixedScheduleInfo {
   /** 일정 타입 (discriminator) */
-  type: 'fixed';
+  kind: 'fixed';
 
   /** 주 출근일수 (0 = 협의, 1-7 = 일수) */
   daysPerWeek: number;
@@ -63,7 +63,7 @@ export interface FixedScheduleInfo {
  * 정규화된 일정 정보 (Discriminated Union)
  *
  * @description DatedScheduleInfo 또는 FixedScheduleInfo
- * type 필드로 구분하여 타입 가드 사용 가능
+ * kind 필드로 구분하여 타입 가드 사용 가능
  */
 export type NormalizedSchedule = DatedScheduleInfo | FixedScheduleInfo;
 
@@ -72,7 +72,7 @@ export type NormalizedSchedule = DatedScheduleInfo | FixedScheduleInfo;
  */
 export interface NormalizedScheduleList {
   /** 일정 타입 ('dated' | 'fixed') */
-  type: JobScheduleType;
+  kind: JobScheduleType;
 
   /** 일정 목록 */
   items: NormalizedSchedule[];
@@ -89,7 +89,7 @@ export interface NormalizedScheduleList {
  * @returns DatedScheduleInfo 여부
  */
 export function isDatedSchedule(schedule: NormalizedSchedule): schedule is DatedScheduleInfo {
-  return schedule.type === 'dated';
+  return schedule.kind === 'dated';
 }
 
 /**
@@ -99,7 +99,7 @@ export function isDatedSchedule(schedule: NormalizedSchedule): schedule is Dated
  * @returns FixedScheduleInfo 여부
  */
 export function isFixedSchedule(schedule: NormalizedSchedule): schedule is FixedScheduleInfo {
-  return schedule.type === 'fixed';
+  return schedule.kind === 'fixed';
 }
 
 // ============================================================================
@@ -116,7 +116,7 @@ export function isFixedSchedule(schedule: NormalizedSchedule): schedule is Fixed
  */
 export function createDatedSchedule(date: string, timeSlots: TimeSlotInfo[]): DatedScheduleInfo {
   return {
-    type: 'dated',
+    kind: 'dated',
     date,
     timeSlots,
   };
@@ -139,7 +139,7 @@ export function createFixedSchedule(
   }
 ): FixedScheduleInfo {
   return {
-    type: 'fixed',
+    kind: 'fixed',
     daysPerWeek,
     startTime: options?.isStartTimeNegotiable ? null : (options?.startTime ?? null),
     isStartTimeNegotiable: options?.isStartTimeNegotiable ?? false,
@@ -158,7 +158,7 @@ export function createFixedSchedule(
  * @returns 날짜 배열 (정렬됨)
  */
 export function extractAllDates(scheduleList: NormalizedScheduleList): string[] {
-  if (scheduleList.type === 'fixed') {
+  if (scheduleList.kind === 'fixed') {
     return [];
   }
 

--- a/uniqn-mobile/src/utils/normalizers/__tests__/scheduleNormalizer.test.ts
+++ b/uniqn-mobile/src/utils/normalizers/__tests__/scheduleNormalizer.test.ts
@@ -321,9 +321,9 @@ describe('normalizeJobSchedule', () => {
         requiredRolesWithCount: [{ role: 'dealer', count: 3, filled: 1 }],
       });
       const result = normalizeJobSchedule(job);
-      expect(result.type).toBe('fixed');
+      expect(result.kind).toBe('fixed');
       expect(result.items).toHaveLength(1);
-      expect(result.items[0].type).toBe('fixed');
+      expect(result.items[0].kind).toBe('fixed');
     });
 
     it('고정 공고의 daysPerWeek을 반영한다', () => {
@@ -334,7 +334,7 @@ describe('normalizeJobSchedule', () => {
       });
       const result = normalizeJobSchedule(job);
       const fixedItem = result.items[0];
-      if (fixedItem.type === 'fixed') {
+      if (fixedItem.kind === 'fixed') {
         expect(fixedItem.daysPerWeek).toBe(3);
       }
     });
@@ -349,7 +349,7 @@ describe('normalizeJobSchedule', () => {
       });
       const result = normalizeJobSchedule(job);
       const fixedItem = result.items[0];
-      if (fixedItem.type === 'fixed') {
+      if (fixedItem.kind === 'fixed') {
         expect(fixedItem.roles).toHaveLength(2);
       }
     });
@@ -362,7 +362,7 @@ describe('normalizeJobSchedule', () => {
       });
       const result = normalizeJobSchedule(job);
       const fixedItem = result.items[0];
-      if (fixedItem.type === 'fixed') {
+      if (fixedItem.kind === 'fixed') {
         expect(fixedItem.startTime).toBe('19:00');
       }
     });
@@ -375,7 +375,7 @@ describe('normalizeJobSchedule', () => {
       });
       const result = normalizeJobSchedule(job);
       const fixedItem = result.items[0];
-      if (fixedItem.type === 'fixed') {
+      if (fixedItem.kind === 'fixed') {
         expect(fixedItem.isStartTimeNegotiable).toBe(true);
       }
     });
@@ -397,7 +397,7 @@ describe('normalizeJobSchedule', () => {
         ],
       });
       const result = normalizeJobSchedule(job);
-      expect(result.type).toBe('dated');
+      expect(result.kind).toBe('dated');
       expect(result.items).toHaveLength(2);
     });
 
@@ -417,7 +417,7 @@ describe('normalizeJobSchedule', () => {
       const result = normalizeJobSchedule(job);
       expect(result.items).toHaveLength(1);
       const datedItem = result.items[0];
-      if (datedItem.type === 'dated') {
+      if (datedItem.kind === 'dated') {
         expect(datedItem.timeSlots).toHaveLength(2);
       }
     });
@@ -431,10 +431,10 @@ describe('normalizeJobSchedule', () => {
         roles: [{ role: 'dealer', count: 2, filled: 0 }],
       });
       const result = normalizeJobSchedule(job);
-      expect(result.type).toBe('dated');
+      expect(result.kind).toBe('dated');
       expect(result.items).toHaveLength(1);
       const datedItem = result.items[0];
-      if (datedItem.type === 'dated') {
+      if (datedItem.kind === 'dated') {
         expect(datedItem.date).toBe('2025-01-28');
         expect(datedItem.timeSlots).toHaveLength(1);
       }
@@ -451,7 +451,7 @@ describe('normalizeJobSchedule', () => {
       });
       const result = normalizeJobSchedule(job);
       const datedItem = result.items[0];
-      if (datedItem.type === 'dated') {
+      if (datedItem.kind === 'dated') {
         expect(datedItem.timeSlots[0].roles).toHaveLength(2);
       }
     });
@@ -464,7 +464,7 @@ describe('normalizeJobSchedule', () => {
         roles: [],
       });
       const result = normalizeJobSchedule(job);
-      expect(result.type).toBe('dated');
+      expect(result.kind).toBe('dated');
       expect(result.items).toEqual([]);
     });
   });

--- a/uniqn-mobile/src/utils/normalizers/scheduleNormalizer.ts
+++ b/uniqn-mobile/src/utils/normalizers/scheduleNormalizer.ts
@@ -90,27 +90,27 @@ function sortDatedSchedules(schedules: DatedScheduleInfo[]): DatedScheduleInfo[]
 export function normalizeJobSchedule(job: JobPosting): NormalizedScheduleList {
   if (job.schedule.kind === 'fixed') {
     return {
-      type: 'fixed',
+      kind: 'fixed',
       items: [normalizeFixedSchedule(job.schedule)],
     };
   }
 
   if (job.schedule.requirements.length > 0) {
     return {
-      type: 'dated',
+      kind: 'dated',
       items: sortDatedSchedules(job.schedule.requirements.map(normalizeDateRequirement)),
     };
   }
 
   if (job.workDate) {
     return {
-      type: 'dated',
+      kind: 'dated',
       items: [normalizeLegacySchedule(job)],
     };
   }
 
   return {
-    type: 'dated',
+    kind: 'dated',
     items: [],
   };
 }


### PR DESCRIPTION
## 무엇
정규화(UI) 레이어 `unified/schedule.ts`의 일정 타입 discriminator 필드 `type` → `kind`로 통일. DB 문서 레이어 `jobPosting.ts`(이미 `kind`)와 정합.

## 왜
동일 개념(dated/fixed)을 두 레이어가 다른 키(`type` vs `kind`)로 표현 → 인지 부조화 + 양쪽 동시 사용 시 버그 위험.

## 어떻게
- `DatedScheduleInfo`/`FixedScheduleInfo`/`NormalizedScheduleList` 필드 + 타입가드 + factory rename
- TypeScript 컴파일러를 게이트로 소비처 식별 → 실제 discriminator 소비처는 5건뿐
- 계획서가 나열한 `schedule.*` 컴포넌트 다수의 `schedule.type`은 **스케줄 상태값(`STATUS.SCHEDULE.*`)**으로 별개 필드라 미변경 (오인 치환 0)

## 영향 파일 (6)
- `src/types/unified/schedule.ts`
- `src/utils/normalizers/scheduleNormalizer.ts`
- `src/hooks/useJobSchedule.ts`
- 테스트 3건

## 테스트
- tsc 0 errors / quality exit0 / jest 4286 pass

## 롤백
단일 커밋 revert로 안전 복구 (mechanical rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)