### PR TITLE
fix(jobs): Fixed 공고 취소 차단 사유 안내 추가 (B1)

### DIFF
--- a/uniqn-mobile/app/(app)/jobs/[id]/__tests__/JobDetailScreen.test.tsx
+++ b/uniqn-mobile/app/(app)/jobs/[id]/__tests__/JobDetailScreen.test.tsx
@@ -98,6 +98,7 @@ jest.mock('@/stores', () => ({
 
 jest.mock('@/utils/applicationStatusMessage', () => ({
   getApplicationStatusMessage: () => '지원 완료',
+  getCancelUnavailableReason: () => null,
 }));
 
 jest.mock('@/utils/jobPostingVisibility', () => ({

--- a/uniqn-mobile/app/(app)/jobs/[id]/index.tsx
+++ b/uniqn-mobile/app/(app)/jobs/[id]/index.tsx
@@ -20,7 +20,10 @@ import {
 import { resolveSessionUserId } from '@/hooks/internal/sessionUserId';
 import { trackJobView } from '@/services/observability';
 import { useThemeStore } from '@/stores';
-import { getApplicationStatusMessage } from '@/utils/applicationStatusMessage';
+import {
+  getApplicationStatusMessage,
+  getCancelUnavailableReason,
+} from '@/utils/applicationStatusMessage';
 import { isSupportedReleasePosting } from '@/utils/jobPostingVisibility';
 
 const DEFAULT_BOTTOM_ACTION_HEIGHT = 116;
@@ -161,6 +164,11 @@ export default function JobDetailScreen() {
     !isFixed &&
     applicationStatus?.status === STATUS.APPLICATION.CONFIRMED &&
     !applicationStatus?.cancellationRequest;
+  const cancelUnavailableReason = getCancelUnavailableReason({
+    status: applicationStatus?.status,
+    isFixed,
+    hasPendingCancellation: !!applicationStatus?.cancellationRequest,
+  });
 
   return (
     <SafeAreaView className="flex-1 bg-surface-page dark:bg-surface" edges={['top', 'bottom']}>
@@ -202,6 +210,11 @@ export default function JobDetailScreen() {
               <Text className="mb-2 text-sm text-secondary-500 dark:text-secondary-400 font-sans">
                 {getApplicationStatusMessage(applicationStatus?.status)}
               </Text>
+              {cancelUnavailableReason ? (
+                <Text className="mb-2 text-center text-xs text-secondary-500 dark:text-secondary-400 font-sans">
+                  {cancelUnavailableReason}
+                </Text>
+              ) : null}
               <View className="w-full flex-row">
                 <View className="mr-2 flex-1">
                   <Button

--- a/uniqn-mobile/src/utils/__tests__/applicationStatusMessage.test.ts
+++ b/uniqn-mobile/src/utils/__tests__/applicationStatusMessage.test.ts
@@ -1,0 +1,65 @@
+import {
+  getApplicationStatusMessage,
+  getCancelUnavailableReason,
+} from '@/utils/applicationStatusMessage';
+import { STATUS } from '@/constants';
+
+describe('getApplicationStatusMessage', () => {
+  it('확정 상태 메시지를 반환한다', () => {
+    expect(getApplicationStatusMessage(STATUS.APPLICATION.CONFIRMED)).toBe(
+      '지원이 확정되었습니다.'
+    );
+  });
+
+  it('취소 요청 검토 중 메시지를 반환한다', () => {
+    expect(getApplicationStatusMessage(STATUS.APPLICATION.CANCELLATION_PENDING)).toBe(
+      '취소 요청 검토 중입니다.'
+    );
+  });
+
+  it('상태가 없으면 null을 반환한다', () => {
+    expect(getApplicationStatusMessage(undefined)).toBeNull();
+  });
+});
+
+describe('getCancelUnavailableReason', () => {
+  it('고정(장기) 공고가 확정되면 앱 취소 불가 안내를 반환한다', () => {
+    expect(
+      getCancelUnavailableReason({
+        status: STATUS.APPLICATION.CONFIRMED,
+        isFixed: true,
+        hasPendingCancellation: false,
+      })
+    ).toBe('장기 알바는 앱에서 취소할 수 없어요. 사업주에게 직접 문의해 주세요.');
+  });
+
+  it('취소 요청이 접수된 확정 건은 검토 중 안내를 우선 반환한다', () => {
+    expect(
+      getCancelUnavailableReason({
+        status: STATUS.APPLICATION.CONFIRMED,
+        isFixed: true,
+        hasPendingCancellation: true,
+      })
+    ).toBe('취소 요청이 접수되어 검토 중이에요. 결과를 기다려 주세요.');
+  });
+
+  it('취소 가능한 일반(dated) 확정 건은 안내가 없다(null)', () => {
+    expect(
+      getCancelUnavailableReason({
+        status: STATUS.APPLICATION.CONFIRMED,
+        isFixed: false,
+        hasPendingCancellation: false,
+      })
+    ).toBeNull();
+  });
+
+  it('확정 상태가 아니면(지원 완료 등) 안내가 없다(null)', () => {
+    expect(
+      getCancelUnavailableReason({
+        status: STATUS.APPLICATION.APPLIED,
+        isFixed: true,
+        hasPendingCancellation: false,
+      })
+    ).toBeNull();
+  });
+});

--- a/uniqn-mobile/src/utils/applicationStatusMessage.ts
+++ b/uniqn-mobile/src/utils/applicationStatusMessage.ts
@@ -20,3 +20,31 @@ export function getApplicationStatusMessage(status: string | undefined): string 
       return null;
   }
 }
+
+/**
+ * 확정된 지원을 앱에서 취소할 수 없는 사유 안내 문구.
+ *
+ * @description 취소 버튼이 렌더되지 않는 경우(canRequestCancel=false) 사용자에게
+ *              "왜 취소할 수 없는지 + 어떻게 해야 하는지"를 한 줄로 안내한다.
+ *              확정 상태가 아니거나 정상적으로 취소 가능한 경우엔 null.
+ */
+export function getCancelUnavailableReason(params: {
+  status: string | undefined;
+  isFixed: boolean;
+  hasPendingCancellation: boolean;
+}): string | null {
+  // 확정 상태가 아니면 상태 메시지만으로 충분 → 별도 안내 불필요
+  if (params.status !== STATUS.APPLICATION.CONFIRMED) return null;
+
+  // 취소 요청이 이미 접수된 경우
+  if (params.hasPendingCancellation) {
+    return '취소 요청이 접수되어 검토 중이에요. 결과를 기다려 주세요.';
+  }
+
+  // 장기(고정) 공고는 앱 취소 불가 — 사업주 직접 문의 필요
+  if (params.isFixed) {
+    return '장기 알바는 앱에서 취소할 수 없어요. 사업주에게 직접 문의해 주세요.';
+  }
+
+  return null;
+}


### PR DESCRIPTION
## 무엇
확정된 장기(고정) 공고의 상세 화면에 "왜 취소할 수 없는지" 안내 1줄 추가.

## 왜
`canRequestCancel = !isFixed && confirmed && !취소요청` → false면 취소 버튼 자체가 렌더 안 됨. 사용자는 사유를 알 수 없어 혼란.

## 어떻게
- `getCancelUnavailableReason` 헬퍼 추가
  - 확정 + 고정 → "장기 알바는 앱에서 취소할 수 없어요. 사업주에게 직접 문의해 주세요."
  - 확정 + 취소요청 접수됨 → "취소 요청이 접수되어 검토 중이에요."
  - 그 외 → null
- `jobs/[id]` alreadyApplied 분기에서 사유 노출 (다크모드 클래스 유지)
- impeccable rule 10(무엇+왜+어떻게) 준수

## 영향 파일 (4)
- `src/utils/applicationStatusMessage.ts` (+헬퍼)
- `app/(app)/jobs/[id]/index.tsx`
- 테스트 2건 (신규 4분기 + JobDetailScreen mock 갱신)

## 테스트
- tsc 0 / quality exit0 / jest 4293 pass (신규 7건 포함)
- ⚠️ 수동 QA(실기기 fixed 공고 confirmed 진입) 미실시

## 롤백
단일 커밋 revert. UI 텍스트 추가만, RPC/DB 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)