### PR TITLE
chore(copy): "포커룸" 표현을 타깃 시장(홀덤펍·대회)에 맞게 정리 (B3)

### DIFF
--- a/uniqn-mobile/DESIGN.md
+++ b/uniqn-mobile/DESIGN.md
@@ -2,9 +2,9 @@
 
 ## Product Context
 
-- **What this is:** 포커룸 스태프 관리 모바일 앱 (스케줄, 구인, 출퇴근, 정산)
-- **Who it's for:** 포커룸 사업주(employer) + 딜러/스태프(dealer, floor, serving)
-- **Space/industry:** 포커룸 / 유흥업 인력 관리
+- **What this is:** 홀덤펍·대회 스태프 관리 모바일 앱 (스케줄, 구인, 출퇴근, 정산)
+- **Who it's for:** 홀덤펍·대회 사업주(employer) + 딜러/스태프(dealer, floor, serving)
+- **Space/industry:** 홀덤펍 / 홀덤 대회 인력 관리
 - **Project type:** Mobile app (Expo / React Native / NativeWind)
 
 ## Aesthetic Direction

--- a/uniqn-mobile/e2e/factories/job.factory.ts
+++ b/uniqn-mobile/e2e/factories/job.factory.ts
@@ -123,7 +123,7 @@ export function createTestJob(options: JobFactoryOptions = {}) {
     updatedAt,
     contactPhone: '+82101234567',
     location: {
-      name: options.locationName ?? '테스트포커룸',
+      name: options.locationName ?? '테스트홀덤펍',
       district: '강남구',
       detailedAddress: '테스트로 123',
     },

--- a/uniqn-mobile/e2e/tests/p0-critical/cancellation-lifecycle.spec.ts
+++ b/uniqn-mobile/e2e/tests/p0-critical/cancellation-lifecycle.spec.ts
@@ -73,7 +73,7 @@ async function seedConfirmedApplication(
     filled_positions: 0,
     view_count: 0,
     contact_phone: '+82101234567',
-    location: { name: 'E2E테스트포커룸', district: '강남구', detailedAddress: '테스트로 123' },
+    location: { name: 'E2E테스트홀덤펍', district: '강남구', detailedAddress: '테스트로 123' },
     schedule: {
       kind: 'dated',
       primaryDate: new Date(Date.now() + 10 * 86_400_000).toISOString().slice(0, 10),

--- a/uniqn-mobile/e2e/tests/p0-critical/e2e-user-journeys.spec.ts
+++ b/uniqn-mobile/e2e/tests/p0-critical/e2e-user-journeys.spec.ts
@@ -103,7 +103,7 @@ test.describe('E2E 유저 저니', () => {
           description: '저니 테스트 공고 설명',
           contact_phone: '+82101234567',
           location: {
-            name: '테스트포커룸',
+            name: '테스트홀덤펍',
             district: '강남구',
             detailedAddress: '테스트로 123',
           },

--- a/uniqn-mobile/e2e/tests/p1-important/collaborator-self-leave.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/collaborator-self-leave.spec.ts
@@ -51,7 +51,7 @@ test.describe('Collaborator Self Leave', () => {
         description: 'E2E — self-leave scenario',
         contact_phone: '+82109999999',
         location: {
-          name: '테스트포커룸',
+          name: '테스트홀덤펍',
           district: '강남구',
           detailedAddress: '테스트로 100',
         },

--- a/uniqn-mobile/e2e/tests/p1-important/collaborator-shared-postings.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/collaborator-shared-postings.spec.ts
@@ -50,7 +50,7 @@ test.describe('Collaborator Shared Postings', () => {
         description: 'E2E — shared posting scenario',
         contact_phone: '+82109999999',
         location: {
-          name: '테스트포커룸',
+          name: '테스트홀덤펍',
           district: '강남구',
           detailedAddress: '테스트로 100',
         },

--- a/uniqn-mobile/e2e/tests/p1-important/employer-applicants.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/employer-applicants.spec.ts
@@ -60,7 +60,7 @@ async function seedJobPosting(title: string): Promise<string> {
       description: `${title} 설명`,
       contact_phone: '+82101234567',
       location: {
-        name: '테스트포커룸',
+        name: '테스트홀덤펍',
         district: '강남구',
         detailedAddress: '테스트로 123',
       },

--- a/uniqn-mobile/e2e/tests/p1-important/employer-collaborator-add.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/employer-collaborator-add.spec.ts
@@ -51,7 +51,7 @@ test.describe('Employer Collaborator Add', () => {
         description: 'E2E — collaborator add scenario',
         contact_phone: '+82109999999',
         location: {
-          name: '테스트포커룸',
+          name: '테스트홀덤펍',
           district: '강남구',
           detailedAddress: '테스트로 100',
         },

--- a/uniqn-mobile/e2e/tests/p1-important/employer-posting-crud.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/employer-posting-crud.spec.ts
@@ -43,7 +43,7 @@ async function seedJobPosting(
       description: `E2E 테스트 공고 — ${title}`,
       contact_phone: '+82101234567',
       location: {
-        name: '테스트포커룸',
+        name: '테스트홀덤펍',
         district: '강남구',
         detailedAddress: '테스트로 123',
       },

--- a/uniqn-mobile/e2e/tests/p1-important/employer-settlement.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/employer-settlement.spec.ts
@@ -67,7 +67,7 @@ async function seedJobPosting(title: string): Promise<string> {
       description: `E2E 테스트 공고 — ${title}`,
       contact_phone: '+82101234567',
       location: {
-        name: '테스트포커룸',
+        name: '테스트홀덤펍',
         district: '강남구',
         detailedAddress: '테스트로 123',
       },

--- a/uniqn-mobile/e2e/tests/p1-important/job-detail-apply.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/job-detail-apply.spec.ts
@@ -44,7 +44,7 @@ test.describe('공고 상세와 지원 흐름', () => {
         description: '상세테스트공고 설명',
         contact_phone: '+82101234567',
         location: {
-          name: '테스트포커룸',
+          name: '테스트홀덤펍',
           district: '강남구',
           detailedAddress: '테스트로 123',
         },
@@ -170,7 +170,7 @@ test.describe('공고 상세와 지원 흐름', () => {
         schema_version: 3,
         description: '마감 테스트 공고',
         contact_phone: '+82101234567',
-        location: { name: '테스트포커룸', district: '강남구', detailedAddress: '테스트로 123' },
+        location: { name: '테스트홀덤펍', district: '강남구', detailedAddress: '테스트로 123' },
         schedule: {
           kind: 'dated',
           primaryDate: workDate,

--- a/uniqn-mobile/e2e/tests/p1-important/public-pages.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/public-pages.spec.ts
@@ -87,7 +87,7 @@ async function seedPublicJob(): Promise<SeededPublicJob | null> {
       filled_positions: 0,
       view_count: 0,
       contact_phone: '+82101234567',
-      location: { name: 'E2E테스트포커룸', district: '강남구', detailedAddress: '테스트로 123' },
+      location: { name: 'E2E테스트홀덤펍', district: '강남구', detailedAddress: '테스트로 123' },
       schedule: {
         kind: 'dated',
         primaryDate: workDate,

--- a/uniqn-mobile/src/components/home/widgets/__tests__/NextWorkWidget.test.tsx
+++ b/uniqn-mobile/src/components/home/widgets/__tests__/NextWorkWidget.test.tsx
@@ -54,7 +54,7 @@ const makeSchedule = (overrides = {}) => ({
   date: '2099-12-31',
   startTime: null,
   endTime: null,
-  location: '강남 포커룸',
+  location: '강남 홀덤펍',
   jobPostingName: '딜러 공고',
   role: 'dealer',
   type: 'confirmed' as const,

--- a/uniqn-mobile/src/components/home/widgets/__tests__/RecentNoticesWidget.test.tsx
+++ b/uniqn-mobile/src/components/home/widgets/__tests__/RecentNoticesWidget.test.tsx
@@ -100,7 +100,7 @@ describe('RecentNoticesWidget', () => {
             {
               announcements: [
                 makeNotice('n1', '4월 운영 공지'),
-                makeNotice('n2', '포커룸 안전 수칙'),
+                makeNotice('n2', '홀덤펍 안전 수칙'),
                 makeNotice('n3', '신규 기능 업데이트'),
                 makeNotice('n4', '네 번째 공지 — 보이면 안됨'),
               ],
@@ -116,7 +116,7 @@ describe('RecentNoticesWidget', () => {
     render(<RecentNoticesWidget />);
 
     expect(screen.getByText('4월 운영 공지')).toBeTruthy();
-    expect(screen.getByText('포커룸 안전 수칙')).toBeTruthy();
+    expect(screen.getByText('홀덤펍 안전 수칙')).toBeTruthy();
     expect(screen.getByText('신규 기능 업데이트')).toBeTruthy();
     expect(screen.queryByText('네 번째 공지 — 보이면 안됨')).toBeNull();
   });

--- a/uniqn-mobile/src/components/workspace/__tests__/WorkspaceRevocationModal.test.tsx
+++ b/uniqn-mobile/src/components/workspace/__tests__/WorkspaceRevocationModal.test.tsx
@@ -26,7 +26,7 @@ describe('WorkspaceRevocationModal', () => {
   });
 
   it('visible=false 면 signOut 호출 안 함', () => {
-    render(<WorkspaceRevocationModal visible={false} workspaceName="포커룸 A" />);
+    render(<WorkspaceRevocationModal visible={false} workspaceName="홀덤펍 A" />);
     act(() => {
       jest.advanceTimersByTime(10_000);
     });
@@ -35,7 +35,7 @@ describe('WorkspaceRevocationModal', () => {
   });
 
   it('visible=true 후 카운트다운 0 도달 시 signOut + login 이동', async () => {
-    render(<WorkspaceRevocationModal visible workspaceName="포커룸 A" countdownSeconds={3} />);
+    render(<WorkspaceRevocationModal visible workspaceName="홀덤펍 A" countdownSeconds={3} />);
     act(() => {
       jest.advanceTimersByTime(3_000);
     });
@@ -61,7 +61,7 @@ describe('WorkspaceRevocationModal', () => {
 
   it('signOut 실패해도 fallback 으로 login 화면 강제 이동 (E5 보안)', async () => {
     mockSignOut.mockRejectedValueOnce(new Error('network down'));
-    render(<WorkspaceRevocationModal visible workspaceName="포커룸 A" countdownSeconds={1} />);
+    render(<WorkspaceRevocationModal visible workspaceName="홀덤펍 A" countdownSeconds={1} />);
     act(() => {
       jest.advanceTimersByTime(1_000);
     });

--- a/uniqn-mobile/src/hooks/useWorkLogs.ts
+++ b/uniqn-mobile/src/hooks/useWorkLogs.ts
@@ -347,7 +347,7 @@ export function useWorkLogStats(enabled = true) {
  * 월별 정산 요약 hook
  *
  * Phase 2A.후속 (PR3-B, 2026-05-10) — useActiveWorkspace 의존 추가. Staff 가
- * 여러 워크스페이스(포커룸)에서 근무하는 경우 active workspace 별로 정산을
+ * 여러 워크스페이스(매장)에서 근무하는 경우 active workspace 별로 정산을
  * 분리 (PR #71 useMyJobPostings 패턴 복제). queryKey 에 workspaceId 포함하여
  * cache 격리, activeWorkspace 부재 시 enabled=false 로 ghost cache 회피.
  */

--- a/uniqn-mobile/src/repositories/interfaces/IWorkLogRepository.ts
+++ b/uniqn-mobile/src/repositories/interfaces/IWorkLogRepository.ts
@@ -156,7 +156,7 @@ export interface IWorkLogRepository {
   /**
    * 월별 정산 요약 조회
    *
-   * Phase 2A.후속 (PR3-B, 2026-05-10) — staff 가 여러 워크스페이스(포커룸)에서
+   * Phase 2A.후속 (PR3-B, 2026-05-10) — staff 가 여러 워크스페이스(매장)에서
    * 근무하는 경우 active workspace 별로 정산을 분리하기 위해 workspaceId? 추가.
    * work_logs 테이블에 workspace_id 컬럼이 없어 job_postings.workspace_id 를
    * inner-join 으로 필터링한다.

--- a/uniqn-mobile/src/schemas/__tests__/workspace.schema.test.ts
+++ b/uniqn-mobile/src/schemas/__tests__/workspace.schema.test.ts
@@ -43,7 +43,7 @@ describe('workspace schemas (PR #2)', () => {
     });
 
     it('이모지 포함 가능 (Unicode 안전)', () => {
-      const r = createWorkspaceSchema.safeParse({ name: '🎰 강남 포커룸' });
+      const r = createWorkspaceSchema.safeParse({ name: '🎰 강남 홀덤펍' });
       expect(r.success).toBe(true);
     });
   });

--- a/uniqn-mobile/src/services/jobs/__tests__/searchService.test.ts
+++ b/uniqn-mobile/src/services/jobs/__tests__/searchService.test.ts
@@ -98,7 +98,7 @@ describe('SearchService', () => {
       }),
       createMockJobPosting({
         id: 'job-2',
-        title: '역삼 포커룸 플로어 구인',
+        title: '역삼 홀덤펍 플로어 구인',
         ownerName: '포커하우스',
         location: { name: '서울 역삼동', address: '역삼동 456' } as any,
         viewCount: 50,

--- a/uniqn-mobile/src/types/role.ts
+++ b/uniqn-mobile/src/types/role.ts
@@ -11,7 +11,7 @@
  *    - employer: 구인자 (공고 관리, 지원자 관리)
  *    - staff: 스태프 (지원, 스케줄 확인)
  *
- * 2. **StaffRole** (직무 역할): 포커룸에서의 업무 역할
+ * 2. **StaffRole** (직무 역할): 매장(홀덤펍/대회장)에서의 업무 역할
  *    - dealer: 딜러
  *    - floor: 플로어
  *    - serving: 서빙
@@ -86,7 +86,7 @@ export const VALID_USER_ROLES: readonly UserRole[] = ['admin', 'employer', 'staf
 /**
  * 스태프 직무 역할
  *
- * @description 포커룸에서의 업무 역할
+ * @description 매장(홀덤펍/대회장)에서의 업무 역할
  *
  * - dealer: 딜러
  * - floor: 플로어


### PR DESCRIPTION
## 무엇
"포커룸" 잔재 카피/주석/테스트 픽스처를 타깃 시장(홀덤펍 + 대회사)에 맞게 정리.

## 왜
타깃 = 홀덤펍 사장 + 대회사 운영팀 (포커룸 비타깃). "포커룸" 표현이 포지셔닝과 모순.

## 어떻게
- **Source 3건**: `role.ts` 직무 정의 "매장(홀덤펍/대회장)"으로 확장, `useWorkLogs.ts`·`IWorkLogRepository.ts` 주석 "워크스페이스(매장)"
- **DESIGN.md**: 제품 컨텍스트 "홀덤펍·대회" 포지셔닝
- **테스트 픽스처 16건** (e2e + unit): 워크스페이스/매장/공지 이름 "홀덤펍 OO"로 통일
- **DB seed 마이그레이션 2건**은 prod 적용분이라 미수정 (별도 TODO)

## 영향 파일 (20)
source 3 + DESIGN.md + e2e 11 + unit 5

## 테스트
- tsc 0 / quality exit0 / jest 4286 pass
- 잔존 "포커룸" 0건 (마이그레이션 2건 제외)
- E2E 픽스처 rename은 파일 내 일관, "테스트포커룸"은 seed/global-setup 키에 미사용 → 시드 매칭 무영향

## 롤백
단일 커밋 revert. 카피/주석 변경만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)