### PR TITLE
fix(rpc): cancel_application_atomically 만료 마감 공고 자동 재오픈 금지

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 > 언어: 한글 | 작업 디렉토리: uniqn-mobile/ | 배포 전: `npm run quality`
 
 ## 프로젝트
-포커룸 스태프 관리 앱 — Expo 55 / RN 0.83.4 / React 19.2 / TS strict / NativeWind 4.2 / Supabase
+홀덤 스태프 관리앱 — Expo 55 / RN 0.83.4 / React 19.2 / TS strict / NativeWind 4.2 / Supabase
 
 ## 핵심 규칙
 | 항목 | 필수 | 금지 |

--- a/uniqn-mobile/supabase/migrations/20260528120000_cancel_rpc_expired_reopen_guard.sql
+++ b/uniqn-mobile/supabase/migrations/20260528120000_cancel_rpc_expired_reopen_guard.sql
@@ -1,0 +1,90 @@
+-- fix(rpc): cancel_application_atomically 만료 마감 공고 자동 재오픈 금지
+--
+-- 베이스: 20260525190100_rpc_drop_manual_filled.sql (SP3) 의 본문.
+-- 변경 1줄: reopen 분기에 closed_reason NOT IN ('expired', 'expired_by_work_date') 가드 추가.
+--
+-- 비즈니스 의도: 마감 기한이 지나 자동 close 된 공고는 staff 취소가 승인되어 자리가
+-- 비더라도 다시 active 로 돌아가면 안 된다. 유저가 만료 공고에 뒤늦게 지원해
+-- 사고가 생기는 것을 막기 위함. 일반 manual close 는 자리 비면 재오픈 유지(현행).
+--
+-- 검증: supabase/tests/cancel_application_expired_guard.test.sql 의 S1~S3 시나리오
+--   S1 manual closed → 취소 후 active 재오픈 (현행 동작 유지)
+--   S2 expired closed → 취소 후 closed 유지 (본 가드 도입)
+--   S3 expired_by_work_date closed → 취소 후 closed 유지 (본 가드 도입)
+
+CREATE OR REPLACE FUNCTION public.cancel_application_atomically(
+  p_application_id uuid, p_actor_type text, p_actor_id uuid,
+  p_cancel_reason text DEFAULT NULL::text, p_rejection_reason text DEFAULT NULL::text)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_application applications%ROWTYPE; v_job_posting job_postings%ROWTYPE;
+  v_active_confirmation_entry jsonb; v_active_confirmation_index int;
+  v_confirmation_history jsonb := '[]'::jsonb; v_deleted_work_log_count int := 0;
+  v_now text := to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"');
+  v_now_ts timestamptz := now(); v_assignment_count int := 0; v_new_filled int;
+  v_new_status text; v_updated_cancellation_request jsonb;
+BEGIN
+  SELECT * INTO v_application FROM applications WHERE id = p_application_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'application_not_found'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.users WHERE id = p_actor_id AND is_active = true) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'account_disabled'); END IF;
+  IF p_actor_type = 'staff_initiates' AND v_application.status = 'applied' THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true); END IF;
+  IF p_actor_type = 'staff_approves_cancel_request' AND v_application.status = 'cancelled' THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true); END IF;
+  IF p_actor_type = 'staff_initiates' THEN
+    IF v_application.status != 'confirmed' THEN RETURN jsonb_build_object('success', false, 'error', 'invalid_status_for_cancellation'); END IF;
+  ELSIF p_actor_type = 'staff_approves_cancel_request' THEN
+    IF v_application.status != 'cancellation_pending' THEN RETURN jsonb_build_object('success', false, 'error', 'invalid_status_for_approval'); END IF;
+    IF (v_application.cancellation_request->>'status') != 'pending' THEN RETURN jsonb_build_object('success', false, 'error', 'cancellation_request_not_pending'); END IF;
+  ELSE RETURN jsonb_build_object('success', false, 'error', 'invalid_actor_type'); END IF;
+  SELECT * INTO v_job_posting FROM job_postings WHERE id = v_application.job_posting_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'job_posting_not_found'); END IF;
+  -- H4: 권한
+  IF p_actor_type = 'staff_approves_cancel_request' THEN
+    IF NOT (v_job_posting.owner_id = p_actor_id OR public.is_workspace_member(v_job_posting.workspace_id, p_actor_id)
+      OR public.is_posting_collaborator(v_job_posting.id, p_actor_id) OR public.is_admin()) THEN
+      RETURN jsonb_build_object('success', false, 'error', 'unauthorized'); END IF;
+  ELSIF p_actor_type = 'staff_initiates' THEN
+    IF v_application.applicant_id != p_actor_id THEN RETURN jsonb_build_object('success', false, 'error', 'unauthorized'); END IF;
+  END IF;
+  -- H5: 출근 후 차단
+  IF EXISTS (SELECT 1 FROM work_logs WHERE application_id = p_application_id AND status IN ('checked_in', 'checked_out')) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'staff_already_checked_in'); END IF;
+  v_confirmation_history := COALESCE(v_application.confirmation_history, '[]'::jsonb);
+  SELECT value, ordinality - 1 INTO v_active_confirmation_entry, v_active_confirmation_index
+  FROM jsonb_array_elements(v_confirmation_history) WITH ORDINALITY WHERE (value->>'cancelled_at') IS NULL LIMIT 1;
+  IF v_active_confirmation_entry IS NULL THEN RETURN jsonb_build_object('success', false, 'error', 'no_active_confirmation'); END IF;
+  v_confirmation_history := jsonb_set(v_confirmation_history, ARRAY[v_active_confirmation_index::text, 'cancelled_at'], to_jsonb(v_now));
+  v_confirmation_history := jsonb_set(v_confirmation_history, ARRAY[v_active_confirmation_index::text, 'cancelled_by'], to_jsonb(p_actor_id));
+  v_confirmation_history := jsonb_set(v_confirmation_history, ARRAY[v_active_confirmation_index::text, 'cancellation_reason'], COALESCE(to_jsonb(p_cancel_reason), 'null'::jsonb));
+  IF p_actor_type = 'staff_initiates' THEN v_new_status := 'applied';
+  ELSE v_new_status := 'cancelled';
+    v_updated_cancellation_request := v_application.cancellation_request || jsonb_build_object('status', 'approved', 'reviewed_at', v_now, 'reviewed_by', p_actor_id);
+  END IF;
+  -- status 변경 UPDATE 가 fn_update_job_posting_stats 트리거를 발화 → filled_positions -1 자동.
+  UPDATE applications SET status = v_new_status::application_status, confirmation_history = v_confirmation_history,
+    cancellation_request = COALESCE(v_updated_cancellation_request, cancellation_request), cancelled_at = v_now_ts, updated_at = v_now_ts
+  WHERE id = p_application_id;
+  SELECT COUNT(*)::int INTO v_assignment_count FROM jsonb_array_elements(v_active_confirmation_entry->'assignments') a
+  CROSS JOIN LATERAL jsonb_array_elements((a->>'dates')::jsonb) d;
+  -- reopen 분기: closed_reason 가드 추가. expired/expired_by_work_date 는 자리 비어도 재오픈 금지.
+  UPDATE job_postings SET
+    status = CASE
+      WHEN status = 'closed'
+       AND filled_positions < total_positions
+       AND closed_reason NOT IN ('expired', 'expired_by_work_date')
+      THEN 'active'::posting_status
+      ELSE status
+    END,
+    updated_at = v_now_ts
+  WHERE id = v_job_posting.id;
+  SELECT filled_positions INTO v_new_filled FROM job_postings WHERE id = v_job_posting.id;
+  DELETE FROM work_logs WHERE application_id = p_application_id AND status = 'scheduled';
+  GET DIAGNOSTICS v_deleted_work_log_count = ROW_COUNT;
+  RETURN jsonb_build_object('success', true, 'application_id', p_application_id, 'new_status', v_new_status,
+    'assignment_count', v_assignment_count, 'new_filled_positions', v_new_filled,
+    'deleted_work_log_count', v_deleted_work_log_count, 'cancelled_at', v_now);
+END;
+$function$;

--- a/uniqn-mobile/supabase/tests/cancel_application_expired_guard.test.sql
+++ b/uniqn-mobile/supabase/tests/cancel_application_expired_guard.test.sql
@@ -1,12 +1,12 @@
 -- ============================================================
 -- T-B4: cancel_application_atomically expired 재오픈 가드 테스트
 -- ============================================================
--- DISABLED 사유 (2026-05-14): cancel_application_atomically RPC 가
--- closed jp 를 closed_reason 무관하게 active 로 재오픈한다 (CASE WHEN status='closed'
--- AND v_new_filled < total_positions THEN 'active'). S2 'expired' / S3
--- 'expired_by_work_date' 가드가 RPC 에 없음. test 의 비즈니스 의도 vs RPC 실제
--- 동작 결정 필요. 후속 PR: RPC 에 expired 가드 추가 (closed_reason NOT IN
--- ('expired', 'expired_by_work_date')) 또는 test 기대값 수정.
+-- ACTIVATED 2026-05-28: 20260528120000_cancel_rpc_expired_reopen_guard.sql 가
+-- reopen 분기에 closed_reason NOT IN ('expired', 'expired_by_work_date') 가드 추가.
+-- 동시에 fixture 의 jp.filled_positions 를 1 → 0 으로 낮춤. SP3 트리거
+-- (20260525190000_filled_positions_trigger.sql) 가 application INSERT 시점에
+-- status='cancellation_pending' 을 filled +1 처리하므로, 의도한 시작값(1) 을
+-- 얻으려면 jp 시드를 0 으로 두고 트리거에 맡겨야 한다.
 -- ============================================================
 -- 목적: closed_reason이 'expired' / 'expired_by_work_date'인 공고는
 --       취소 승인 후에도 closed 상태를 유지해야 함을 검증.
@@ -86,7 +86,7 @@ BEGIN
   INSERT INTO public.job_postings (
     id, owner_id, workspace_id, title, total_positions, filled_positions, status, closed_reason, created_at, updated_at
   )
-  VALUES (v_job_manual_id, v_owner_id, v_workspace_id, '__sql_fixture: manual closed', 3, 1, 'closed', 'manual', now(), now());
+  VALUES (v_job_manual_id, v_owner_id, v_workspace_id, '__sql_fixture: manual closed', 3, 0, 'closed', 'manual', now(), now());
 
   INSERT INTO public.applications (
     id, job_posting_id, applicant_id, applicant_name, status, cancellation_request, confirmation_history, created_at, updated_at
@@ -108,7 +108,7 @@ BEGIN
   INSERT INTO public.job_postings (
     id, owner_id, workspace_id, title, total_positions, filled_positions, status, closed_reason, created_at, updated_at
   )
-  VALUES (v_job_expired_id, v_owner_id, v_workspace_id, '__sql_fixture: expired closed', 3, 1, 'closed', 'expired', now(), now());
+  VALUES (v_job_expired_id, v_owner_id, v_workspace_id, '__sql_fixture: expired closed', 3, 0, 'closed', 'expired', now(), now());
 
   INSERT INTO public.applications (
     id, job_posting_id, applicant_id, applicant_name, status, cancellation_request, confirmation_history, created_at, updated_at
@@ -130,7 +130,7 @@ BEGIN
   INSERT INTO public.job_postings (
     id, owner_id, workspace_id, title, total_positions, filled_positions, status, closed_reason, created_at, updated_at
   )
-  VALUES (v_job_expired_wd_id, v_owner_id, v_workspace_id, '__sql_fixture: expired_by_work_date closed', 3, 1, 'closed', 'expired_by_work_date', now(), now());
+  VALUES (v_job_expired_wd_id, v_owner_id, v_workspace_id, '__sql_fixture: expired_by_work_date closed', 3, 0, 'closed', 'expired_by_work_date', now(), now());
 
   INSERT INTO public.applications (
     id, job_posting_id, applicant_id, applicant_name, status, cancellation_request, confirmation_history, created_at, updated_at


### PR DESCRIPTION
## Summary

- \`cancel_application_atomically\` reopen 분기에 \`closed_reason NOT IN ('expired', 'expired_by_work_date')\` 가드 1줄 추가
- 만료 기한 또는 근무일이 지나 자동 close 된 공고는 staff 확정 취소가 승인되어 자리가 비더라도 closed 유지
- 일반 manual close 는 자리 비면 재오픈하던 현행 동작 유지
- \`cancel_application_expired_guard.test.sql.disabled\` → \`.sql\` 재활성화

## 비즈니스 의도

유저가 만료된 공고를 재노출 후 뒤늦게 지원해 "이미 끝난 공고였다" 알게 되는 사고 차단.

## 변경 파일

- \`uniqn-mobile/supabase/migrations/20260528120000_cancel_rpc_expired_reopen_guard.sql\` (신규)
- \`uniqn-mobile/supabase/tests/cancel_application_expired_guard.test.sql\` (rename + fixture 보정)

## Fixture 보정 사유

SP3 트리거 (\`20260525190000_filled_positions_trigger.sql\`) 가 application INSERT 시점 \`status='cancellation_pending'\` 을 filled +1 처리. 의도한 시작값(1) 을 얻으려면 jp 시드는 0 으로 두고 트리거에 맡겨야 함.

## Test plan (Red-Green)

- [x] **RED** (가드 없는 SP3 본문): S2 expected closed, got active → fail 확인
- [x] **GREEN** (가드 + fixture 보정): Files=14, Tests=105, Result: PASS
- [ ] CI db-tests.yml 통과 확인
- [ ] PROD 마이그레이션 적용 (머지 후 별도 단계)

## 관련

- 별도 PR: \`test/enable-person-basis-pgtap\` (person_basis_filled_positions.test.sql 활성화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)