### PR TITLE
전체리뷰 백로그 1단계 + U9 파일분할 (12커밋)

### DIFF
--- a/uniqn-mobile/app/(admin)/inquiries/index.tsx
+++ b/uniqn-mobile/app/(admin)/inquiries/index.tsx
@@ -8,7 +8,7 @@ import { View, Text, RefreshControl, ActivityIndicator, Pressable, ScrollView } 
 import { PRIMARY_COLORS } from '@/constants/colors';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
-import { FlashList } from '@shopify/flash-list';
+import { AppFlashList } from '@/components/ui/AppFlashList';
 import { StackHeader } from '@/components/headers';
 import { EmptyState } from '@/components/ui';
 import { InquiryCard } from '@/components/support';
@@ -133,10 +133,9 @@ export default function AdminInquiriesScreen() {
           <ActivityIndicator size="large" color={PRIMARY_COLORS[300]} />
         </View>
       ) : (
-        <FlashList
+        <AppFlashList
           data={inquiries}
           renderItem={renderItem}
-          // @ts-expect-error - estimatedItemSize is required in FlashList 2.x but types may be missing
           estimatedItemSize={120}
           keyExtractor={(item) => item.id}
           contentContainerStyle={{ paddingTop: 16, paddingBottom: 16 }}

--- a/uniqn-mobile/app/(admin)/reports/index.tsx
+++ b/uniqn-mobile/app/(admin)/reports/index.tsx
@@ -15,7 +15,7 @@
 import { SECONDARY_PALETTE } from '@/constants/colors';
 import { useState, useMemo, useCallback } from 'react';
 import { View, Text, ScrollView, Pressable, TextInput, RefreshControl } from 'react-native';
-import { FlashList } from '@shopify/flash-list';
+import { AppFlashList } from '@/components/ui/AppFlashList';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { StackHeader } from '@/components/headers';
@@ -273,11 +273,10 @@ export default function AdminReportsPage() {
       </View>
 
       {/* 신고 목록 */}
-      <FlashList
+      <AppFlashList
         data={filteredReports}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
-        // @ts-expect-error - estimatedItemSize is required in FlashList 2.x but types may be missing
         estimatedItemSize={140}
         refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={() => refetch()} />}
         ListEmptyComponent={

--- a/uniqn-mobile/app/(app)/(tabs)/employer.tsx
+++ b/uniqn-mobile/app/(app)/(tabs)/employer.tsx
@@ -2,7 +2,7 @@ import { SECONDARY_PALETTE, SURFACE_COLORS } from '@/constants/colors';
 import { PTR_REFRESH_PROPS } from '@/constants/ptr';
 import React, { useCallback, useMemo, useState } from 'react';
 import { Pressable, RefreshControl, Text, View } from 'react-native';
-import { FlashList } from '@shopify/flash-list';
+import { AppFlashList } from '@/components/ui/AppFlashList';
 import { router } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button, ConfirmModal, PostingSurfaceState } from '@/components';
@@ -362,7 +362,7 @@ function EmployerView() {
           message="새 공고를 작성해 보세요."
         />
       ) : (
-        <FlashList
+        <AppFlashList
           data={filteredPostings}
           renderItem={({ item }) => (
             <JobPostingCard
@@ -376,7 +376,6 @@ function EmployerView() {
             />
           )}
           keyExtractor={(item) => item.id}
-          // @ts-expect-error - estimatedItemSize is required in FlashList 2.x but types may be missing
           estimatedItemSize={200}
           refreshControl={
             <RefreshControl refreshing={isRefetching} onRefresh={refetch} {...PTR_REFRESH_PROPS} />

--- a/uniqn-mobile/app/(app)/reviews/history.tsx
+++ b/uniqn-mobile/app/(app)/reviews/history.tsx
@@ -6,7 +6,7 @@
 import { useState, useCallback, useMemo } from 'react';
 import { View, Text, Pressable, ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { FlashList } from '@shopify/flash-list';
+import { AppFlashList } from '@/components/ui/AppFlashList';
 import { StackHeader } from '@/components/headers';
 import { EmptyState, NumericText } from '@/components/ui';
 import ReviewCard from '@/components/review/ReviewCard';
@@ -79,13 +79,12 @@ export default function ReviewHistoryScreen() {
           <ActivityIndicator size="large" />
         </View>
       ) : (
-        <FlashList
+        <AppFlashList
           data={reviews}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
           onEndReached={handleEndReached}
           onEndReachedThreshold={0.5}
-          // @ts-expect-error - estimatedItemSize is required in FlashList 2.x but types may be missing
           estimatedItemSize={140}
           contentContainerStyle={{ paddingVertical: 8 }}
           ListEmptyComponent={

--- a/uniqn-mobile/app/(app)/support/my-inquiries.tsx
+++ b/uniqn-mobile/app/(app)/support/my-inquiries.tsx
@@ -8,7 +8,7 @@ import { View, RefreshControl, ActivityIndicator } from 'react-native';
 import { PRIMARY_COLORS } from '@/constants/colors';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
-import { FlashList } from '@shopify/flash-list';
+import { AppFlashList } from '@/components/ui/AppFlashList';
 import { EmptyState } from '@/components/ui';
 import { InquiryCard, INQUIRY_STATUS_STRIPE_TONE } from '@/components/support';
 import { StackHeader } from '@/components/headers';
@@ -87,10 +87,9 @@ export default function MyInquiriesScreen() {
   return (
     <SafeAreaView className="flex-1 bg-surface-page dark:bg-surface" edges={['top', 'bottom']}>
       <StackHeader title="문의 내역" fallbackHref="/(app)/support" />
-      <FlashList
+      <AppFlashList
         data={inquiries}
         renderItem={renderItem}
-        // @ts-expect-error - estimatedItemSize is required in FlashList 2.x but types may be missing
         estimatedItemSize={100}
         keyExtractor={(item) => item.id}
         contentContainerStyle={{ paddingTop: 16, paddingBottom: 16 }}

--- a/uniqn-mobile/app/(employer)/my-postings/[id]/cancellation-requests.tsx
+++ b/uniqn-mobile/app/(employer)/my-postings/[id]/cancellation-requests.tsx
@@ -10,7 +10,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { Modal, Pressable, RefreshControl, Text, View } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { FlashList } from '@shopify/flash-list';
+import { AppFlashList } from '@/components/ui/AppFlashList';
 import { CancellationRequestCard } from '@/components/employer';
 import { EmptyState, ErrorState, Loading } from '@/components';
 import { StackHeader } from '@/components/headers';
@@ -215,11 +215,10 @@ export default function CancellationRequestsScreen() {
           variant="content"
         />
       ) : (
-        <FlashList
+        <AppFlashList
           data={cancellationRequests}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
-          // @ts-expect-error - estimatedItemSize is required in FlashList 2.x but types may be missing
           estimatedItemSize={200}
           contentContainerStyle={{ paddingVertical: 8 }}
           refreshControl={

--- a/uniqn-mobile/app/(employer)/workspace/invitations.tsx
+++ b/uniqn-mobile/app/(employer)/workspace/invitations.tsx
@@ -9,7 +9,7 @@
 import { useCallback } from 'react';
 import { View, Text, RefreshControl, ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { FlashList } from '@shopify/flash-list';
+import { AppFlashList } from '@/components/ui/AppFlashList';
 import { router } from 'expo-router';
 import { StackHeader } from '@/components/headers';
 import { Avatar, Badge, Button, EmptyState, ErrorState } from '@/components/ui';
@@ -154,11 +154,10 @@ export default function WorkspaceInvitationsScreen() {
   return (
     <SafeAreaView className="flex-1 bg-surface-page dark:bg-surface" edges={['top', 'bottom']}>
       <StackHeader title="받은 초대" />
-      <FlashList
+      <AppFlashList
         data={invitations}
         keyExtractor={(item) => item.id}
         renderItem={renderItem}
-        // @ts-expect-error - estimatedItemSize is required in FlashList 2.x but types may be missing
         estimatedItemSize={140}
         refreshControl={<RefreshControl refreshing={false} onRefresh={refetch} />}
         contentContainerClassName="pt-3 pb-8"

--- a/uniqn-mobile/package.json
+++ b/uniqn-mobile/package.json
@@ -70,7 +70,6 @@
     "expo-image": "~55.0.8",
     "expo-image-manipulator": "~55.0.15",
     "expo-image-picker": "~55.0.18",
-    "expo-intent-launcher": "~55.0.12",
     "expo-linear-gradient": "~55.0.13",
     "expo-linking": "~55.0.13",
     "expo-local-authentication": "~55.0.13",

--- a/uniqn-mobile/src/__tests__/hooks/useApplicantManagement.test.ts
+++ b/uniqn-mobile/src/__tests__/hooks/useApplicantManagement.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { act, renderHook } from '@testing-library/react-native';
+import { ERROR_CODES } from '@/errors';
 import { createMockApplication, resetCounters } from '../mocks/factories';
 import {
   useApplicantManagement,
@@ -445,6 +446,7 @@ describe('useApplicantManagement Hooks', () => {
         successCount: 2,
         failedCount: 1,
         failedIds: ['app-3'],
+        failed: [{ applicationId: 'app-3', reason: '확정에 실패했습니다.' }],
         workLogIds: ['worklog-1', 'worklog-2'],
       });
 
@@ -457,6 +459,34 @@ describe('useApplicantManagement Hooks', () => {
       expect(mockAddToast).toHaveBeenCalledWith({
         type: 'warning',
         message: '1명 확정이 실패했습니다.',
+      });
+    });
+
+    it('should surface capacity-full reason in bulk confirm warning toast', async () => {
+      mockBulkConfirmApplications.mockResolvedValueOnce({
+        successCount: 1,
+        failedCount: 2,
+        failedIds: ['app-2', 'app-3'],
+        failed: [
+          {
+            applicationId: 'app-2',
+            code: ERROR_CODES.BUSINESS_MAX_CAPACITY_REACHED,
+            reason: '모집 인원이 마감되었습니다.',
+          },
+          { applicationId: 'app-3', reason: '확정에 실패했습니다.' },
+        ],
+        workLogIds: ['worklog-1'],
+      });
+
+      const { result } = renderHook(() => useBulkConfirmApplications());
+
+      await act(async () => {
+        result.current.mutate(['app-1', 'app-2', 'app-3']);
+      });
+
+      expect(mockAddToast).toHaveBeenCalledWith({
+        type: 'warning',
+        message: '2명 확정 실패 (정원 마감 1명).',
       });
     });
 

--- a/uniqn-mobile/src/components/employer/applicants/ApplicantList.tsx
+++ b/uniqn-mobile/src/components/employer/applicants/ApplicantList.tsx
@@ -8,7 +8,7 @@
 import { SECONDARY_PALETTE } from '@/constants/colors';
 import React, { useState, useCallback, useMemo } from 'react';
 import { View, RefreshControl } from 'react-native';
-import { FlashList } from '@shopify/flash-list';
+import { AppFlashList } from '@/components/ui/AppFlashList';
 import { ApplicantCard } from './ApplicantCard';
 import { EmptyState } from '../../ui/EmptyState';
 import { ErrorState } from '../../ui/ErrorState';
@@ -159,11 +159,10 @@ export function ApplicantList({
           description="다른 필터를 선택해 보세요."
         />
       ) : (
-        <FlashList
+        <AppFlashList
           data={filteredApplicants}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
-          // @ts-expect-error - estimatedItemSize is required in FlashList 2.x but types may be missing
           estimatedItemSize={180}
           refreshControl={
             onRefresh ? (

--- a/uniqn-mobile/src/components/employer/settlement/GroupedSettlementCard.tsx
+++ b/uniqn-mobile/src/components/employer/settlement/GroupedSettlementCard.tsx
@@ -79,6 +79,11 @@ const PAYROLL_STATUS_CONFIG: Record<
     bgColor: 'bg-success-50 dark:bg-success-900/30',
     textColor: 'text-success-700 dark:text-success-300',
   },
+  failed: {
+    label: '정산실패',
+    bgColor: 'bg-error-100 dark:bg-error-900/30',
+    textColor: 'text-error-700 dark:text-error-300',
+  },
 };
 
 // ============================================================================

--- a/uniqn-mobile/src/components/employer/settlement/SettlementDetailModal/constants.ts
+++ b/uniqn-mobile/src/components/employer/settlement/SettlementDetailModal/constants.ts
@@ -19,4 +19,5 @@ export const PAYROLL_STATUS_CONFIG: Record<
   pending: { label: '미정산', variant: 'warning' },
   processing: { label: '처리중', variant: 'primary' },
   completed: { label: '정산완료', variant: 'success' },
+  failed: { label: '정산실패', variant: 'error' },
 };

--- a/uniqn-mobile/src/components/employer/settlement/SettlementList.tsx
+++ b/uniqn-mobile/src/components/employer/settlement/SettlementList.tsx
@@ -8,7 +8,7 @@
 import { SECONDARY_PALETTE } from '@/constants/colors';
 import React, { useState, useCallback, useMemo } from 'react';
 import { View, Text, Pressable, RefreshControl } from 'react-native';
-import { FlashList } from '@shopify/flash-list';
+import { AppFlashList } from '@/components/ui/AppFlashList';
 import { PTR_REFRESH_PROPS } from '@/constants/ptr';
 import { GroupedSettlementCard } from './GroupedSettlementCard';
 import { SettlementSummaryCard } from './SettlementSummaryCard';
@@ -348,11 +348,10 @@ export function SettlementList({
       )}
 
       {/* 목록 */}
-      <FlashList
+      <AppFlashList
         data={groupedSettlements}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
-        // @ts-expect-error - estimatedItemSize is required in FlashList 2.x but types may be missing
         // 그룹 카드는 펼침 가능하여 높이가 가변적 (기본 약 200, 펼침 시 최대 ~500)
         estimatedItemSize={250}
         refreshControl={

--- a/uniqn-mobile/src/components/employer/settlement/helpers/settlementConfig.ts
+++ b/uniqn-mobile/src/components/employer/settlement/helpers/settlementConfig.ts
@@ -30,4 +30,5 @@ export const PAYROLL_STATUS_CONFIG: Record<
   pending: { label: '미정산', variant: 'warning', stripeTone: 'gold' },
   processing: { label: '처리중', variant: 'primary', stripeTone: 'info' },
   completed: { label: '정산완료', variant: 'success', stripeTone: 'muted' },
+  failed: { label: '정산실패', variant: 'error', stripeTone: 'error' },
 };

--- a/uniqn-mobile/src/components/job-posting/CollaboratorList.tsx
+++ b/uniqn-mobile/src/components/job-posting/CollaboratorList.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { View, Text } from 'react-native';
-import { FlashList } from '@shopify/flash-list';
+import { AppFlashList } from '@/components/ui/AppFlashList';
 import { CollaboratorRow } from './CollaboratorRow';
 import { SkeletonListItem } from '@/components/ui/Skeleton';
 import type { JobPostingCollaboratorWithUser } from '@/types/jobPostingCollaborator';
@@ -57,10 +57,9 @@ export function CollaboratorList({
   }
 
   return (
-    <FlashList<JobPostingCollaboratorWithUser>
+    <AppFlashList<JobPostingCollaboratorWithUser>
       data={collaborators}
       keyExtractor={(item) => item.id}
-      // @ts-expect-error - estimatedItemSize is required in FlashList 2.x but types may be missing
       estimatedItemSize={64}
       renderItem={({ item }) => (
         <CollaboratorRow

--- a/uniqn-mobile/src/components/jobs/JobList.tsx
+++ b/uniqn-mobile/src/components/jobs/JobList.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { ActivityIndicator, RefreshControl, View } from 'react-native';
-import { FlashList } from '@shopify/flash-list';
+import { AppFlashList } from '@/components/ui/AppFlashList';
 import { LIST_CONTAINER_STYLES } from '@/constants';
 import { PTR_REFRESH_PROPS } from '@/constants/ptr';
 import type { JobPostingCard } from '@/types';
@@ -94,11 +94,10 @@ export function JobList({
         />
       ) : null}
 
-      <FlashList
+      <AppFlashList
         data={jobs}
         renderItem={renderItem}
         keyExtractor={(item) => item.id}
-        // @ts-expect-error - estimatedItemSize is required in FlashList 2.x but types may be missing
         estimatedItemSize={160}
         contentContainerStyle={LIST_CONTAINER_STYLES.padding16}
         showsVerticalScrollIndicator={false}

--- a/uniqn-mobile/src/components/notifications/NotificationList.tsx
+++ b/uniqn-mobile/src/components/notifications/NotificationList.tsx
@@ -6,7 +6,9 @@ import { SECONDARY_PALETTE } from '@/constants/colors';
 import { PTR_REFRESH_PROPS } from '@/constants/ptr';
 import React, { memo, useCallback, useMemo } from 'react';
 import { View, Text, Pressable, RefreshControl } from 'react-native';
-import { FlashList, ListRenderItem } from '@shopify/flash-list';
+import { ListRenderItem } from '@shopify/flash-list';
+
+import { AppFlashList } from '@/components/ui/AppFlashList';
 import { BellSlashIcon } from '@/components/icons';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ScreenSkeleton } from '@/components/ui';
@@ -173,11 +175,10 @@ export const NotificationList = memo(function NotificationList({
         </View>
       ) : null}
 
-      <FlashList<NotificationListItem>
+      <AppFlashList<NotificationListItem>
         data={notifications}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
-        // @ts-expect-error - estimatedItemSize is required in FlashList 2.x but types may be missing
         estimatedItemSize={85}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}

--- a/uniqn-mobile/src/components/schedule/WorkLogList.tsx
+++ b/uniqn-mobile/src/components/schedule/WorkLogList.tsx
@@ -63,6 +63,11 @@ const PAYROLL_STATUS_CONFIG: Record<
     color: 'text-success-700 dark:text-success-300',
     bgColor: 'bg-success-50 dark:bg-success-900/30',
   },
+  failed: {
+    label: '정산 실패',
+    color: 'text-error-700 dark:text-error-300',
+    bgColor: 'bg-error-100 dark:bg-error-900/30',
+  },
 };
 
 function formatDate(dateString: string): string {

--- a/uniqn-mobile/src/components/schedule/WorkLogList.tsx
+++ b/uniqn-mobile/src/components/schedule/WorkLogList.tsx
@@ -1,7 +1,7 @@
 import { SECONDARY_PALETTE } from '@/constants/colors';
 import React, { useCallback, useMemo } from 'react';
 import { View, Text, RefreshControl, ActivityIndicator, Pressable } from 'react-native';
-import { FlashList } from '@shopify/flash-list';
+import { AppFlashList } from '@/components/ui/AppFlashList';
 import { Badge, Skeleton, EmptyState } from '@/components/ui';
 import { useThemeStore } from '@/stores/themeStore';
 import { WorkTimeDisplay } from '@/shared/time';
@@ -274,11 +274,10 @@ export const WorkLogList: React.FC<WorkLogListProps> = React.memo(
     }
 
     return (
-      <FlashList
+      <AppFlashList
         data={workLogs}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
-        // @ts-expect-error - estimatedItemSize is required in FlashList 2.x but types may be missing
         estimatedItemSize={180}
         contentContainerStyle={{ padding: 16 }}
         showsVerticalScrollIndicator={false}

--- a/uniqn-mobile/src/components/ui/AppFlashList.tsx
+++ b/uniqn-mobile/src/components/ui/AppFlashList.tsx
@@ -1,0 +1,49 @@
+/**
+ * UNIQN Mobile - AppFlashList 컴포넌트
+ *
+ * @description @shopify/flash-list FlashList의 thin 제네릭 래퍼.
+ *   FlashList 2.x 타입에는 `estimatedItemSize` prop이 누락되어 있어
+ *   사용처마다 `@ts-expect-error`를 복붙해야 했던 문제를 한 곳으로 캡슐화한다.
+ *   제네릭 `<T>` 추론과 ref 전달을 보존하며, 그 외 모든 props는 passthrough한다.
+ *   스타일(className/dark: 등)은 사용처가 직접 넘기므로 래퍼는 관여하지 않는다.
+ * @version 1.0.0
+ */
+
+import { FlashList, type FlashListProps, type FlashListRef } from '@shopify/flash-list';
+import React from 'react';
+
+/**
+ * FlashList 2.x 타입에 누락된 `estimatedItemSize`를 추가한 props 타입.
+ * 값을 전달하면 그대로 FlashList에 넘긴다.
+ */
+export type AppFlashListProps<T> = FlashListProps<T> & {
+  /** 아이템 추정 높이(px). FlashList 2.x 타입 누락분을 명시적으로 노출. */
+  estimatedItemSize?: number;
+  ref?: React.Ref<FlashListRef<T>>;
+};
+
+/**
+ * FlashList를 감싸는 제네릭 래퍼.
+ * 모든 props를 passthrough하며, 타입에 누락된 `estimatedItemSize`만 이 한 곳에서
+ * `@ts-expect-error`로 처리한다.
+ */
+function AppFlashListInner<T>({ ref, estimatedItemSize, ...rest }: AppFlashListProps<T>) {
+  return (
+    <FlashList<T>
+      ref={ref}
+      // @ts-expect-error - estimatedItemSize is required in FlashList 2.x but types may be missing
+      estimatedItemSize={estimatedItemSize}
+      {...rest}
+    />
+  );
+}
+
+/**
+ * 제네릭 추론을 보존하기 위한 타입 캐스트.
+ * (함수 컴포넌트 형태라 `AppFlashList<T>` 호출 시 T가 props로부터 추론된다.)
+ */
+export const AppFlashList = AppFlashListInner as <T>(
+  props: AppFlashListProps<T>
+) => React.JSX.Element;
+
+export default AppFlashList;

--- a/uniqn-mobile/src/components/ui/FormSelect.tsx
+++ b/uniqn-mobile/src/components/ui/FormSelect.tsx
@@ -12,7 +12,7 @@
 import { SECONDARY_PALETTE } from '@/constants/colors';
 import React, { useState, useCallback, useMemo, memo } from 'react';
 import { View, Text, Pressable, TextInput, type ViewProps } from 'react-native';
-import { FlashList } from '@shopify/flash-list';
+import { AppFlashList } from './AppFlashList';
 import { Modal } from './Modal';
 
 // ============================================================================
@@ -234,7 +234,7 @@ export function FormSelect<T = string>({
 
           {/* 옵션 목록 */}
           <View style={{ height: 320 }}>
-            <FlashList
+            <AppFlashList
               data={filteredOptions}
               keyExtractor={(item, index) => `${item.value}-${index}`}
               renderItem={({ item }) => (
@@ -263,7 +263,6 @@ export function FormSelect<T = string>({
                   )}
                 </View>
               }
-              // @ts-expect-error - estimatedItemSize is required in FlashList 2.x but types may be missing
               estimatedItemSize={56}
             />
           </View>

--- a/uniqn-mobile/src/components/ui/index.ts
+++ b/uniqn-mobile/src/components/ui/index.ts
@@ -164,6 +164,12 @@ export { MobileHeader, HeaderAction, LargeHeader } from './MobileHeader';
 export { FilterTabs, type FilterTabsProps, type FilterTabOption } from './FilterTabs';
 
 // ============================================================================
+// List Components
+// ============================================================================
+
+export { AppFlashList, type AppFlashListProps } from './AppFlashList';
+
+// ============================================================================
 // Password Components
 // ============================================================================
 

--- a/uniqn-mobile/src/constants/statusConfig.ts
+++ b/uniqn-mobile/src/constants/statusConfig.ts
@@ -176,6 +176,13 @@ export const PAYROLL_STATUS: Record<PayrollStatusType, StatusConfig> = {
     bgColor: 'bg-success-100 dark:bg-success-900/30',
     hexColor: STATUS_COLORS.success,
   },
+  failed: {
+    label: PAYROLL_STATUS_LABELS.failed,
+    variant: 'error',
+    textColor: 'text-error-600 dark:text-error-400',
+    bgColor: 'bg-error-100 dark:bg-error-900/30',
+    hexColor: STATUS_COLORS.error,
+  },
 };
 
 export type ConfirmedStaffStatusType = ConfirmedStaffStatus;

--- a/uniqn-mobile/src/constants/statusValues.ts
+++ b/uniqn-mobile/src/constants/statusValues.ts
@@ -52,10 +52,13 @@ export const INQUIRY_STATUS_VALUES = {
   CLOSED: 'closed',
 } as const satisfies Record<string, InquiryStatusType>;
 
+// DB enum payroll_status = ['pending','completed','failed']와 정합.
+// PROCESSING은 DB enum에 없는 UI 표시 전용 값(DB 컬럼에 직접 쓰지 않음).
 export const PAYROLL_STATUS_VALUES = {
   PENDING: 'pending',
   PROCESSING: 'processing',
   COMPLETED: 'completed',
+  FAILED: 'failed',
 } as const satisfies Record<string, PayrollStatus>;
 
 export const ANNOUNCEMENT_STATUS_VALUES = {

--- a/uniqn-mobile/src/domains/job-posting/__tests__/filledPositions.test.ts
+++ b/uniqn-mobile/src/domains/job-posting/__tests__/filledPositions.test.ts
@@ -1,7 +1,8 @@
 import { buildPostingFacts } from '@/domains/job-posting';
 import { deserializeJobPostingDocument } from '@/domains/job-posting/serialization';
 import { normalizePostingAggregateStats } from '@/domains/job-posting/stats';
-import type { JobPostingDocumentV3, PostingSchedule } from '@/types/jobPosting';
+import type { JobPosting, JobPostingDocumentV3, PostingSchedule } from '@/types/jobPosting';
+import { logger } from '@/utils/logger';
 
 const datedSchedule: PostingSchedule = {
   kind: 'dated',
@@ -79,5 +80,106 @@ describe('filledPositions authority', () => {
     );
 
     expect(stats.filledPositions).toBe(0);
+  });
+});
+
+/**
+ * resolveFilledPositions 단일 권위 해소 (U6)
+ *
+ * column(top-level filled_positions)이 권위, stats.filledPositions 는 부차 미러.
+ * deserialize 는 미러를 column 에 맞춰 정규화하므로, 여기서는 facts 레이어의 해소 로직을
+ * 검증하기 위해 deserialize 결과를 직접 override 하여 divergence/null 시나리오를 구성한다.
+ */
+describe('resolveFilledPositions authority (buildPostingFacts)', () => {
+  const buildBasePosting = (): JobPosting => {
+    const document = {
+      id: 'job-resolve',
+      schemaVersion: 3,
+      title: 'Resolve filled positions',
+      status: 'active',
+      ownerId: 'owner-1',
+      postingType: 'tournament',
+      workDate: '2025-05-01',
+      workDates: ['2025-05-01'],
+      roleKeys: ['dealer'],
+      totalPositions: 5,
+      filledPositions: 0,
+      viewCount: 0,
+      stats: {
+        totalApplicants: 0,
+        activeApplicants: 0,
+        confirmedApplicants: 0,
+        cancellationPendingApplicants: 0,
+        filledPositions: 0,
+      },
+      location: { name: 'Seoul' },
+      schedule: datedSchedule,
+      roleCatalog: [{ role: 'dealer' }],
+      compensation: {
+        mode: 'shared',
+        defaultSalary: { type: 'daily', amount: 100000 },
+      },
+      questions: { items: [] },
+    } as JobPostingDocumentV3;
+
+    return deserializeJobPostingDocument(document);
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('uses the top-level column as the authoritative source when both exist', () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const base = buildBasePosting();
+    const posting: JobPosting = {
+      ...base,
+      filledPositions: 3,
+      stats: { ...base.stats!, filledPositions: 3 },
+    };
+
+    const facts = buildPostingFacts(posting);
+
+    expect(facts.stats.filledPositions).toBe(3);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the stats mirror when the column is null/undefined', () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const base = buildBasePosting();
+    // 권위 컬럼이 누락된 레거시/부분 데이터 시나리오 (타입은 number 지만 런타임 방어)
+    const posting = {
+      ...base,
+      filledPositions: undefined,
+      stats: { ...base.stats, filledPositions: 4 },
+    } as unknown as JobPosting;
+
+    const facts = buildPostingFacts(posting);
+
+    expect(facts.stats.filledPositions).toBe(4);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('prefers the column and logs a divergence warning when column and mirror disagree', () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const base = buildBasePosting();
+    const posting: JobPosting = {
+      ...base,
+      filledPositions: 2,
+      stats: { ...base.stats!, filledPositions: 5 },
+    };
+
+    const facts = buildPostingFacts(posting);
+
+    expect(facts.stats.filledPositions).toBe(2);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'filledPositions divergence between column and stats mirror',
+      expect.objectContaining({
+        postingId: 'job-resolve',
+        columnFilledPositions: 2,
+        statsFilledPositions: 5,
+      })
+    );
   });
 });

--- a/uniqn-mobile/src/domains/job-posting/facts.ts
+++ b/uniqn-mobile/src/domains/job-posting/facts.ts
@@ -10,6 +10,7 @@ import { FIXED_TIME_MARKER } from '@/types/assignment';
 import { getRoleDisplayName } from '@/types/unified';
 import { getAllowanceItems } from '@/utils/allowanceUtils';
 import { isSupportedReleasePosting } from '@/utils/jobPostingVisibility';
+import { logger } from '@/utils/logger';
 import {
   getPostingDefaultSalary,
   getPostingDateGroups,
@@ -23,6 +24,35 @@ import {
   getPostingTaxLabel,
 } from './core';
 import { selectPostingWorkflow } from './selectors';
+
+/**
+ * filledPositions 단일 권위 해소 (SP3)
+ *
+ * @description top-level filled_positions 컬럼이 권위(fn_update_job_posting_stats 트리거로 갱신).
+ * stats.filledPositions 는 부차 미러로, column 이 null/undefined 일 때만 fallback.
+ * 두 값이 모두 존재하고 서로 다르면 divergence 를 logger.warn 으로 관측(무성 불일치 방지).
+ */
+function resolveFilledPositions(posting: JobPosting): number {
+  // 타입상 number 이지만 레거시/부분 데이터 런타임 방어로 nullable 로 본다.
+  const column: number | null | undefined = posting.filledPositions;
+  const mirror: number | null | undefined = posting.stats?.filledPositions;
+
+  if (column === null || column === undefined) {
+    return mirror ?? 0;
+  }
+
+  if (mirror !== null && mirror !== undefined && mirror !== column) {
+    logger.warn('filledPositions divergence between column and stats mirror', {
+      component: 'job-posting/facts',
+      action: 'resolveFilledPositions',
+      postingId: posting.id,
+      columnFilledPositions: column,
+      statsFilledPositions: mirror,
+    });
+  }
+
+  return column;
+}
 
 export function buildPostingFacts(posting: JobPosting): PostingFacts {
   const workflow = selectPostingWorkflow(posting);
@@ -54,7 +84,7 @@ export function buildPostingFacts(posting: JobPosting): PostingFacts {
   };
   const salaryRows = getPostingSalaryRows(posting);
   const defaultSalary = getPostingDefaultSalary(posting);
-  const filledPositions = posting.filledPositions ?? posting.stats?.filledPositions ?? 0;
+  const filledPositions = resolveFilledPositions(posting);
   const allowanceLabels = getAllowanceItems(posting.compensation.allowances);
   const dateRequirements = getPostingDateRequirements(posting);
   const requiredRolesWithCount = getPostingRequiredRolesWithCount(posting);

--- a/uniqn-mobile/src/hooks/applicant/useApplicantMutations.ts
+++ b/uniqn-mobile/src/hooks/applicant/useApplicantMutations.ts
@@ -219,9 +219,15 @@ export function useBulkConfirmApplications() {
       }
 
       if (result.failedCount > 0) {
+        const capacityFull = result.failed.filter(
+          (f) => f.code === ERROR_CODES.BUSINESS_MAX_CAPACITY_REACHED
+        ).length;
         addToast({
           type: 'warning',
-          message: `${result.failedCount}명 확정이 실패했습니다.`,
+          message:
+            capacityFull > 0
+              ? `${result.failedCount}명 확정 실패 (정원 마감 ${capacityFull}명).`
+              : `${result.failedCount}명 확정이 실패했습니다.`,
         });
       }
 

--- a/uniqn-mobile/src/hooks/useSettlement.ts
+++ b/uniqn-mobile/src/hooks/useSettlement.ts
@@ -351,6 +351,7 @@ export function useUpdateSettlementStatus() {
         pending: '정산 대기로 변경되었습니다.',
         processing: '정산 처리 중으로 변경되었습니다.',
         completed: '정산이 완료되었습니다.',
+        failed: '정산이 실패 처리되었습니다.',
       };
 
       addToast({

--- a/uniqn-mobile/src/repositories/index.ts
+++ b/uniqn-mobile/src/repositories/index.ts
@@ -62,6 +62,7 @@ export type {
   CreateJobPostingResult,
   JobPostingStats,
   JobPostingSubscriptionCallbacks,
+  ScheduleBoardSyncAction,
   // WorkLog
   IWorkLogRepository,
   WorkLogStats,

--- a/uniqn-mobile/src/repositories/interfaces/IEmployerApplicationRepository.ts
+++ b/uniqn-mobile/src/repositories/interfaces/IEmployerApplicationRepository.ts
@@ -1,0 +1,87 @@
+/**
+ * UNIQN Mobile - Employer Application Repository Interface
+ *
+ * @description 구인자 등록 신청 CRUD + RPC 호출 추상화
+ * @version 1.0.0
+ *
+ * 이 인터페이스의 목적:
+ * 1. DB 직접 의존 제거 → 테스트 용이성
+ * 2. 구인자 신청 조회/승인/거부 작업 캡슐화
+ * 3. 향후 백엔드 교체 가능성 확보
+ *
+ * 도메인 타입(EmployerApplication 등)은 구현체 모듈에 정의되어 있으므로
+ * 여기서 type import 후 인터페이스 시그니처에만 사용한다.
+ */
+
+import type {
+  ApproveRejectResult,
+  EmployerApplication,
+  EmployerApplicationRejectionCategory,
+  FetchApplicationsOptions,
+  FetchApplicationsResult,
+  RegisterAsEmployerResult,
+} from '../supabase/EmployerApplicationRepository';
+
+// ============================================================================
+// Interface
+// ============================================================================
+
+/**
+ * Employer Application Repository 인터페이스
+ *
+ * 구현체:
+ * - SupabaseEmployerApplicationRepository (프로덕션)
+ */
+export interface IEmployerApplicationRepository {
+  /**
+   * 구인자 신청 생성 (유저)
+   * @param agreementsSnapshot - 약관 동의 스냅샷
+   * @param intro - 신청 소개글
+   */
+  register(
+    agreementsSnapshot: Record<string, unknown>,
+    intro: string
+  ): Promise<RegisterAsEmployerResult>;
+
+  /**
+   * 최신 신청 조회 (유저 본인 또는 admin)
+   * @param userId - 미지정 시 RPC가 auth.uid() 사용
+   */
+  getLatest(userId?: string): Promise<EmployerApplication | null>;
+
+  /**
+   * 신청 목록 조회 (admin)
+   * @param options - status 필터, 페이지 크기, 커서
+   */
+  listForAdmin(options?: FetchApplicationsOptions): Promise<FetchApplicationsResult>;
+
+  /**
+   * 신청 상세 조회 (admin)
+   * @param applicationId - 신청 ID
+   */
+  getById(applicationId: string): Promise<EmployerApplication | null>;
+
+  /**
+   * 신청 승인 (admin)
+   * @param applicationId - 신청 ID
+   */
+  approve(applicationId: string): Promise<ApproveRejectResult>;
+
+  /**
+   * 신청 거부 (admin)
+   * @param applicationId - 신청 ID
+   * @param reason - 거부 사유 (자유 텍스트, XSS 검증 후 전달)
+   * @param category - 거부 분류
+   */
+  reject(
+    applicationId: string,
+    reason?: string,
+    category?: EmployerApplicationRejectionCategory
+  ): Promise<ApproveRejectResult>;
+
+  /**
+   * SLA 모니터링: 임계 시간 경과 pending 건수 (admin)
+   * @param hoursThreshold - 기본 24시간
+   */
+  countOverduePending(hoursThreshold?: number): Promise<number>;
+}

--- a/uniqn-mobile/src/repositories/interfaces/IJobPostingRepository.ts
+++ b/uniqn-mobile/src/repositories/interfaces/IJobPostingRepository.ts
@@ -89,6 +89,13 @@ export interface JobPostingSubscriptionCallbacks {
   onError?: (error: Error) => void;
 }
 
+/**
+ * schedule_board_sync_outbox action 종류.
+ *
+ * outbox CHECK 제약과 동일한 값 집합. Service 가 mutation 후 enqueue 시 사용.
+ */
+export type ScheduleBoardSyncAction = 'create' | 'update' | 'delete' | 'close' | 'reopen';
+
 // ============================================================================
 // Interface
 // ============================================================================
@@ -336,4 +343,25 @@ export interface IJobPostingRepository {
    * @returns 구독 해제 함수
    */
   subscribeById(jobPostingId: string, callbacks: JobPostingSubscriptionCallbacks): UnsubscribeFn;
+
+  // ==========================================================================
+  // Schedule Board Sync Outbox
+  // ==========================================================================
+
+  /**
+   * schedule_board_sync_outbox 에 sync 의도를 영속화 (enqueue).
+   *
+   * @description sync-schedule-board-outbox Edge Function 이 poll → sync_schedule_board
+   *   RPC 호출 → status 업데이트로 처리한다. snake_case 매핑은 Repository 내부에서 수행.
+   *   enqueue 실패는 main mutation 을 롤백시키지 않으며 warn 로그만 남긴다 (아키텍처 결정).
+   *
+   * @param jobPostingId - 공고 ID
+   * @param action - outbox action (create/update/delete/close/reopen)
+   * @param payload - sync RPC 가 참조할 부가 데이터 (기본 {})
+   */
+  enqueueScheduleBoardSync(
+    jobPostingId: string,
+    action: ScheduleBoardSyncAction,
+    payload?: Record<string, unknown>
+  ): Promise<void>;
 }

--- a/uniqn-mobile/src/repositories/interfaces/IWalletRepository.ts
+++ b/uniqn-mobile/src/repositories/interfaces/IWalletRepository.ts
@@ -1,0 +1,45 @@
+/**
+ * UNIQN Mobile - Wallet Repository Interface
+ *
+ * @description 결제 시스템 wallet 잔액/제품 조회 추상화 (read-only)
+ * @version 1.0.0
+ *
+ * 이 인터페이스의 목적:
+ * 1. DB 직접 의존 제거 → 테스트 용이성
+ * 2. wallet 조회 작업 캡슐화
+ * 3. 향후 백엔드 교체 가능성 확보
+ *
+ * 차감/적립/환불은 RPC 직접 호출 (Service 계층)이라 인터페이스 범위 밖.
+ *
+ * @see docs/superpowers/specs/2026-04-26-monetization-design.md §3, §6.1
+ */
+
+import type { DiamondProduct, WalletSummary } from '@/types/wallet';
+
+// ============================================================================
+// Interface
+// ============================================================================
+
+/**
+ * Wallet Repository 인터페이스 (read-only)
+ *
+ * 구현체:
+ * - WalletRepository (프로덕션, Supabase)
+ */
+export interface IWalletRepository {
+  /**
+   * 현재 사용자(또는 지정 사용자)의 지갑 요약 조회.
+   *
+   * @param userId 미지정 시 RPC가 auth.uid() 사용. admin/service_role만 타인 조회 가능.
+   * @returns heart/diamond 잔액 + lifetime 누적 + 만료 임박(7일) lot 목록.
+   * @throws Supabase RPC 에러 그대로 throw — 호출자가 처리.
+   */
+  getSummary(userId?: string): Promise<WalletSummary>;
+
+  /**
+   * 활성 다이아 충전 상품 목록 (display_order 오름차순).
+   *
+   * @returns active=true 상품만, 시드 6종 기준.
+   */
+  listProducts(): Promise<DiamondProduct[]>;
+}

--- a/uniqn-mobile/src/repositories/interfaces/index.ts
+++ b/uniqn-mobile/src/repositories/interfaces/index.ts
@@ -26,6 +26,7 @@ export type {
   CreateJobPostingResult,
   JobPostingStats,
   JobPostingSubscriptionCallbacks,
+  ScheduleBoardSyncAction,
 } from './IJobPostingRepository';
 
 // WorkLog Repository
@@ -137,3 +138,9 @@ export type {
 
 // 공고별 협업자 (Phase 5 — feat/job-posting-collaborators)
 export type { IJobPostingCollaboratorRepository } from './IJobPostingCollaboratorRepository';
+
+// Wallet Repository (결제 — read-only)
+export type { IWalletRepository } from './IWalletRepository';
+
+// Employer Application Repository (구인자 등록 신청)
+export type { IEmployerApplicationRepository } from './IEmployerApplicationRepository';

--- a/uniqn-mobile/src/repositories/supabase/ApplicationRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/ApplicationRepository.ts
@@ -14,16 +14,14 @@
 import { supabase } from '@/lib/supabase';
 import { logger } from '@/utils/logger';
 import {
-  toError,
   BusinessError,
-  NetworkError,
   PermissionError,
   AlreadyAppliedError,
   ApplicationClosedError,
   ValidationError,
   ERROR_CODES,
 } from '@/errors';
-import { handleSupabaseError, createRealtimeSubscription } from '@/utils/supabase';
+import { handleSupabaseError } from '@/utils/supabase';
 import { applicationValidator, validateRequiredAnswers } from '@/domains/application';
 import { selectPostingWorkflow } from '@/domains/job-posting';
 import { normalizeAssignmentRole, isValidAssignment } from '@/types/assignment';
@@ -51,20 +49,26 @@ import type {
 } from '../interfaces';
 import {
   TABLES,
-  ACTIVE_APPLICATION_STATUSES,
-  EMPLOYER_REALTIME_LIMIT,
   APPLICATION_COLUMNS,
-  JOB_POSTING_COLUMNS,
   toApplication,
-  rowsToApplications,
-  toJobPosting,
   rethrowOrHandle,
   loadApplication,
   loadJobPosting,
   loadAndVerifyJobPostingAccess,
   buildCanonicalFixedAssignment,
-  buildApplicantListWithStats,
 } from './ApplicationRepositoryHelpers';
+import {
+  executeGetById,
+  executeGetByApplicantId,
+  executeGetByApplicantIdWithStatuses,
+  subscribeByApplicantIdWithStatuses,
+  executeGetByJobPostingId,
+  executeHasApplied,
+  executeGetStatsByApplicantId,
+  executeGetCancellationRequests,
+  executeFindByJobPostingWithStats,
+  subscribeByJobPosting,
+} from './ApplicationRepositoryQueries';
 import {
   executeConfirmWithHistory,
   executeReviewCancellation,
@@ -119,79 +123,11 @@ export class SupabaseApplicationRepository implements IApplicationRepository {
   // ==========================================================================
 
   async getById(applicationId: string): Promise<ApplicationWithJob | null> {
-    try {
-      logger.info('지원 상세 조회', { applicationId });
-
-      const { data, error } = await supabase
-        .from(TABLES.APPLICATIONS)
-        .select(APPLICATION_COLUMNS)
-        .eq('id', applicationId)
-        .maybeSingle();
-
-      if (error)
-        handleSupabaseError(error, { operation: '지원 상세 조회', table: TABLES.APPLICATIONS });
-      if (!data) return null;
-
-      const application = toApplication(data as Record<string, unknown>);
-      if (!application) {
-        logger.warn('지원 상세 데이터 파싱 실패', { applicationId });
-        return null;
-      }
-
-      // 공고 정보 조인
-      const { data: jobData } = await supabase
-        .from(TABLES.JOB_POSTINGS)
-        .select(JOB_POSTING_COLUMNS)
-        .eq('id', application.jobPostingId)
-        .maybeSingle();
-
-      const jobPosting = jobData ? toJobPosting(jobData as Record<string, unknown>) : null;
-
-      return {
-        ...application,
-        ...(jobPosting ? { jobPosting } : {}),
-      };
-    } catch (error) {
-      rethrowOrHandle(error, '지원 상세 조회', { applicationId });
-    }
+    return executeGetById(applicationId);
   }
 
   async getByApplicantId(applicantId: string): Promise<ApplicationWithJob[]> {
-    try {
-      logger.info('내 지원 내역 조회', { applicantId });
-
-      const { data, error } = await supabase
-        .from(TABLES.APPLICATIONS)
-        .select(APPLICATION_COLUMNS)
-        .eq('applicant_id', applicantId)
-        .order('created_at', { ascending: false });
-
-      if (error)
-        handleSupabaseError(error, { operation: '내 지원 내역 조회', table: TABLES.APPLICATIONS });
-
-      const applications = rowsToApplications((data ?? []) as Record<string, unknown>[]);
-      if (applications.length === 0) return [];
-
-      // 공고 배치 조회
-      const jobPostingIds = [...new Set(applications.map((a) => a.jobPostingId))];
-      const { data: jobData } = await supabase
-        .from(TABLES.JOB_POSTINGS)
-        .select(JOB_POSTING_COLUMNS)
-        .in('id', jobPostingIds);
-
-      const jobMap = new Map<string, JobPosting>();
-      for (const row of (jobData ?? []) as Record<string, unknown>[]) {
-        const jp = toJobPosting(row);
-        if (jp) jobMap.set(jp.id, jp);
-      }
-
-      return applications.map((app) => {
-        const jp = jobMap.get(app.jobPostingId);
-        return jp ? { ...app, jobPosting: jp } : app;
-      });
-    } catch (error) {
-      rethrowOrHandle(error, '내 지원 내역 조회', { applicantId });
-    }
+    return executeGetByApplicantId(applicantId);
   }
 
   async getByApplicantIdWithStatuses(
@@ -199,27 +135,7 @@ export class SupabaseApplicationRepository implements IApplicationRepository {
     statuses: ApplicationStatus[],
     pageSize: number = 50
   ): Promise<Application[]> {
-    try {
-      logger.info('상태 필터 지원 내역 조회', { applicantId, statuses, pageSize });
-
-      const { data, error } = await supabase
-        .from(TABLES.APPLICATIONS)
-        .select(APPLICATION_COLUMNS)
-        .eq('applicant_id', applicantId)
-        .in('status', statuses)
-        .order('created_at', { ascending: false })
-        .limit(pageSize);
-
-      if (error)
-        handleSupabaseError(error, {
-          operation: '상태 필터 지원 내역 조회',
-          table: TABLES.APPLICATIONS,
-        });
-
-      return rowsToApplications((data ?? []) as Record<string, unknown>[]);
-    } catch (error) {
-      rethrowOrHandle(error, '상태 필터 지원 내역 조회', { applicantId, statuses });
-    }
+    return executeGetByApplicantIdWithStatuses(applicantId, statuses, pageSize);
   }
 
   subscribeByApplicantIdWithStatuses(
@@ -227,160 +143,28 @@ export class SupabaseApplicationRepository implements IApplicationRepository {
     statuses: ApplicationStatus[],
     onData: (applications: Application[]) => void,
     onError: (error: Error) => void,
-    _pageSize: number = 50
+    pageSize: number = 50
   ): UnsubscribeFn {
-    logger.info('지원 상태 필터 실시간 구독 시작', { applicantId, statuses });
-
-    if (statuses.length === 0) {
-      onData([]);
-      return () => undefined;
-    }
-
-    // 초기 데이터 1회 fetch — 변경 이벤트가 오지 않아도 구독자가 빈 상태에서 탈출
-    void this.getByApplicantIdWithStatuses(applicantId, statuses, _pageSize)
-      .then(onData)
-      .catch((error) => onError(toError(error)));
-
-    return createRealtimeSubscription(
-      TABLES.APPLICATIONS,
-      `applicant_id=eq.${applicantId}`,
-      (payload) => {
-        try {
-          const row = (payload.new ?? payload.old) as Record<string, unknown> | undefined;
-          if (!row) return;
-
-          // Realtime은 개별 변경만 오므로, 전체 목록을 다시 조회
-          void this.getByApplicantIdWithStatuses(applicantId, statuses, _pageSize)
-            .then(onData)
-            .catch(onError);
-        } catch (error) {
-          onError(toError(error));
-        }
-      },
-      (status) => {
-        if (status === 'CHANNEL_ERROR') {
-          // 일시 장애 — 상위에 통지하되, Phoenix가 자동 재연결을 시도한다.
-          // 'RECOVERED' 신호가 오면 데이터를 재동기화한다.
-          // isRetryable=true로 소비자가 warn 수준으로 다운그레이드할 수 있도록 표시.
-          onError(
-            new NetworkError(ERROR_CODES.NETWORK_REALTIME_TRANSIENT, {
-              message: `Realtime 채널 에러: ${TABLES.APPLICATIONS}`,
-              severity: 'low',
-            })
-          );
-        } else if (status === 'RECOVERED') {
-          // 재연결 성공 — 끊긴 동안 놓친 변경을 반영하기 위해 전체 목록 재조회.
-          logger.info('Realtime 채널 복구 — 데이터 재동기화', { applicantId });
-          void this.getByApplicantIdWithStatuses(applicantId, statuses, _pageSize)
-            .then(onData)
-            .catch(onError);
-        }
-        // TIMED_OUT은 Phoenix가 자동 재시도 — 상위로 전파하지 않음
-      }
-    );
+    return subscribeByApplicantIdWithStatuses(applicantId, statuses, onData, onError, pageSize);
   }
 
   async getByJobPostingId(jobPostingId: string): Promise<Application[]> {
-    try {
-      logger.info('공고별 지원서 조회', { jobPostingId });
-
-      const { data, error } = await supabase
-        .from(TABLES.APPLICATIONS)
-        .select(APPLICATION_COLUMNS)
-        .eq('job_posting_id', jobPostingId)
-        .order('created_at', { ascending: false });
-
-      if (error)
-        handleSupabaseError(error, { operation: '공고별 지원서 조회', table: TABLES.APPLICATIONS });
-
-      return rowsToApplications((data ?? []) as Record<string, unknown>[]);
-    } catch (error) {
-      rethrowOrHandle(error, '공고별 지원서 조회', { jobPostingId });
-    }
+    return executeGetByJobPostingId(jobPostingId);
   }
 
   async hasApplied(jobPostingId: string, applicantId: string): Promise<boolean> {
-    try {
-      const { data, error } = await supabase
-        .from(TABLES.APPLICATIONS)
-        .select('id, status')
-        .eq('job_posting_id', jobPostingId)
-        .eq('applicant_id', applicantId)
-        .maybeSingle();
-
-      if (error || !data) return false;
-
-      const row = data as Record<string, unknown>;
-      return ACTIVE_APPLICATION_STATUSES.has(row.status as ApplicationStatus);
-    } catch {
-      return false;
-    }
+    return executeHasApplied(jobPostingId, applicantId);
   }
 
   async getStatsByApplicantId(applicantId: string): Promise<Record<ApplicationStatus, number>> {
-    try {
-      const { data, error } = await supabase
-        .from(TABLES.APPLICATIONS)
-        .select('status')
-        .eq('applicant_id', applicantId);
-
-      if (error)
-        handleSupabaseError(error, { operation: '지원 통계 조회', table: TABLES.APPLICATIONS });
-
-      const stats: Record<ApplicationStatus, number> = {
-        applied: 0,
-        confirmed: 0,
-        rejected: 0,
-        cancelled: 0,
-        completed: 0,
-        cancellation_pending: 0,
-      };
-
-      for (const row of (data ?? []) as Record<string, unknown>[]) {
-        const status = row.status as ApplicationStatus;
-        if (status && status in stats) {
-          stats[status]++;
-        }
-      }
-
-      return stats;
-    } catch (error) {
-      rethrowOrHandle(error, '지원 통계 조회', { applicantId });
-    }
+    return executeGetStatsByApplicantId(applicantId);
   }
 
   async getCancellationRequests(
     jobPostingId: string,
     ownerId: string
   ): Promise<ApplicationWithJob[]> {
-    try {
-      logger.info('취소 요청 목록 조회', { jobPostingId, ownerId });
-
-      const jobData = await loadAndVerifyJobPostingAccess(
-        jobPostingId,
-        ownerId,
-        '취소 요청 목록 조회'
-      );
-
-      const { data, error } = await supabase
-        .from(TABLES.APPLICATIONS)
-        .select(APPLICATION_COLUMNS)
-        .eq('job_posting_id', jobPostingId)
-        .eq('status', STATUS.APPLICATION.CANCELLATION_PENDING)
-        .order('updated_at', { ascending: false });
-
-      if (error)
-        handleSupabaseError(error, {
-          operation: '취소 요청 목록 조회',
-          table: TABLES.APPLICATIONS,
-        });
-
-      const applications = rowsToApplications((data ?? []) as Record<string, unknown>[]);
-
-      return applications.map((app) => ({ ...app, jobPosting: jobData }));
-    } catch (error) {
-      rethrowOrHandle(error, '취소 요청 목록 조회', { jobPostingId });
-    }
+    return executeGetCancellationRequests(jobPostingId, ownerId);
   }
 
   // ==========================================================================
@@ -743,37 +527,7 @@ export class SupabaseApplicationRepository implements IApplicationRepository {
     ownerId: string,
     statusFilter?: ApplicationStatus | ApplicationStatus[]
   ): Promise<ApplicantListWithStats> {
-    try {
-      logger.info('지원자 목록 조회', { jobPostingId, ownerId, statusFilter });
-
-      const jobPosting = await loadAndVerifyJobPostingAccess(
-        jobPostingId,
-        ownerId,
-        '지원자 목록 조회'
-      );
-
-      const { data, error } = await supabase
-        .from(TABLES.APPLICATIONS)
-        .select(APPLICATION_COLUMNS)
-        .eq('job_posting_id', jobPostingId)
-        .order('created_at', { ascending: false });
-
-      if (error)
-        handleSupabaseError(error, { operation: '지원자 목록 조회', table: TABLES.APPLICATIONS });
-
-      const applications = rowsToApplications((data ?? []) as Record<string, unknown>[]);
-      const result = buildApplicantListWithStats(applications, jobPosting, statusFilter);
-
-      logger.info('지원자 목록 조회 완료', {
-        jobPostingId,
-        total: result.stats.total,
-        filtered: result.applications.length,
-      });
-
-      return result;
-    } catch (error) {
-      rethrowOrHandle(error, '지원자 목록 조회', { jobPostingId });
-    }
+    return executeFindByJobPostingWithStats(jobPostingId, ownerId, statusFilter);
   }
 
   subscribeByJobPosting(
@@ -782,59 +536,6 @@ export class SupabaseApplicationRepository implements IApplicationRepository {
     callbacks: SubscribeCallbacks,
     options?: { verifyOwnership?: boolean }
   ): UnsubscribeFn {
-    logger.info('지원자 목록 실시간 구독 시작', { jobPostingId, ownerId });
-
-    let cachedJobPosting: JobPosting | null = null;
-    let isOwnerVerified = false;
-
-    const handleUpdate = async () => {
-      try {
-        if (!isOwnerVerified) {
-          cachedJobPosting = await loadAndVerifyJobPostingAccess(
-            jobPostingId,
-            ownerId,
-            '지원자 실시간 구독'
-          );
-          if (options?.verifyOwnership === false) {
-            cachedJobPosting = await loadJobPosting(jobPostingId);
-          }
-          isOwnerVerified = true;
-        }
-
-        const { data, error } = await supabase
-          .from(TABLES.APPLICATIONS)
-          .select(APPLICATION_COLUMNS)
-          .eq('job_posting_id', jobPostingId)
-          .order('created_at', { ascending: false })
-          .limit(EMPLOYER_REALTIME_LIMIT);
-
-        if (error) {
-          handleSupabaseError(error, {
-            operation: '지원자 실시간 조회',
-            table: TABLES.APPLICATIONS,
-          });
-        }
-
-        const applications = rowsToApplications((data ?? []) as Record<string, unknown>[]);
-        const result = buildApplicantListWithStats(applications, cachedJobPosting as JobPosting);
-
-        callbacks.onUpdate(result);
-      } catch (error) {
-        logger.error('지원자 목록 실시간 구독 처리 실패', toError(error), { jobPostingId });
-        callbacks.onError?.(toError(error));
-      }
-    };
-
-    // 초기 로드
-    void handleUpdate();
-
-    // Realtime 구독: 변경 시 전체 목록 재조회
-    return createRealtimeSubscription(
-      TABLES.APPLICATIONS,
-      `job_posting_id=eq.${jobPostingId}`,
-      () => {
-        void handleUpdate();
-      }
-    );
+    return subscribeByJobPosting(jobPostingId, ownerId, callbacks, options);
   }
 }

--- a/uniqn-mobile/src/repositories/supabase/ApplicationRepositoryQueries.ts
+++ b/uniqn-mobile/src/repositories/supabase/ApplicationRepositoryQueries.ts
@@ -1,0 +1,407 @@
+/**
+ * UNIQN Mobile - Application Repository Queries
+ *
+ * @description ApplicationRepository에서 사용하는 조회/실시간 구독 standalone 함수
+ * 읽기 전용 쿼리(getById/getByApplicantId/...)와 Realtime 구독(subscribeXxx)
+ */
+
+import { supabase } from '@/lib/supabase';
+import { logger } from '@/utils/logger';
+import { toError, NetworkError, ERROR_CODES } from '@/errors';
+import { handleSupabaseError, createRealtimeSubscription } from '@/utils/supabase';
+import { STATUS } from '@/constants';
+import type { UnsubscribeFn } from '@/types/common';
+import type { Application, ApplicationStatus, JobPosting } from '@/types';
+import type { ApplicationWithJob, ApplicantListWithStats, SubscribeCallbacks } from '../interfaces';
+import {
+  TABLES,
+  ACTIVE_APPLICATION_STATUSES,
+  EMPLOYER_REALTIME_LIMIT,
+  APPLICATION_COLUMNS,
+  JOB_POSTING_COLUMNS,
+  toApplication,
+  rowsToApplications,
+  toJobPosting,
+  rethrowOrHandle,
+  loadJobPosting,
+  loadAndVerifyJobPostingAccess,
+  buildApplicantListWithStats,
+} from './ApplicationRepositoryHelpers';
+
+// ============================================================================
+// 조회 (Read)
+// ============================================================================
+
+export async function executeGetById(applicationId: string): Promise<ApplicationWithJob | null> {
+  try {
+    logger.info('지원 상세 조회', { applicationId });
+
+    const { data, error } = await supabase
+      .from(TABLES.APPLICATIONS)
+      .select(APPLICATION_COLUMNS)
+      .eq('id', applicationId)
+      .maybeSingle();
+
+    if (error)
+      handleSupabaseError(error, { operation: '지원 상세 조회', table: TABLES.APPLICATIONS });
+    if (!data) return null;
+
+    const application = toApplication(data as Record<string, unknown>);
+    if (!application) {
+      logger.warn('지원 상세 데이터 파싱 실패', { applicationId });
+      return null;
+    }
+
+    // 공고 정보 조인
+    const { data: jobData } = await supabase
+      .from(TABLES.JOB_POSTINGS)
+      .select(JOB_POSTING_COLUMNS)
+      .eq('id', application.jobPostingId)
+      .maybeSingle();
+
+    const jobPosting = jobData ? toJobPosting(jobData as Record<string, unknown>) : null;
+
+    return {
+      ...application,
+      ...(jobPosting ? { jobPosting } : {}),
+    };
+  } catch (error) {
+    rethrowOrHandle(error, '지원 상세 조회', { applicationId });
+  }
+}
+
+export async function executeGetByApplicantId(applicantId: string): Promise<ApplicationWithJob[]> {
+  try {
+    logger.info('내 지원 내역 조회', { applicantId });
+
+    const { data, error } = await supabase
+      .from(TABLES.APPLICATIONS)
+      .select(APPLICATION_COLUMNS)
+      .eq('applicant_id', applicantId)
+      .order('created_at', { ascending: false });
+
+    if (error)
+      handleSupabaseError(error, { operation: '내 지원 내역 조회', table: TABLES.APPLICATIONS });
+
+    const applications = rowsToApplications((data ?? []) as Record<string, unknown>[]);
+    if (applications.length === 0) return [];
+
+    // 공고 배치 조회
+    const jobPostingIds = [...new Set(applications.map((a) => a.jobPostingId))];
+    const { data: jobData } = await supabase
+      .from(TABLES.JOB_POSTINGS)
+      .select(JOB_POSTING_COLUMNS)
+      .in('id', jobPostingIds);
+
+    const jobMap = new Map<string, JobPosting>();
+    for (const row of (jobData ?? []) as Record<string, unknown>[]) {
+      const jp = toJobPosting(row);
+      if (jp) jobMap.set(jp.id, jp);
+    }
+
+    return applications.map((app) => {
+      const jp = jobMap.get(app.jobPostingId);
+      return jp ? { ...app, jobPosting: jp } : app;
+    });
+  } catch (error) {
+    rethrowOrHandle(error, '내 지원 내역 조회', { applicantId });
+  }
+}
+
+export async function executeGetByApplicantIdWithStatuses(
+  applicantId: string,
+  statuses: ApplicationStatus[],
+  pageSize: number = 50
+): Promise<Application[]> {
+  try {
+    logger.info('상태 필터 지원 내역 조회', { applicantId, statuses, pageSize });
+
+    const { data, error } = await supabase
+      .from(TABLES.APPLICATIONS)
+      .select(APPLICATION_COLUMNS)
+      .eq('applicant_id', applicantId)
+      .in('status', statuses)
+      .order('created_at', { ascending: false })
+      .limit(pageSize);
+
+    if (error)
+      handleSupabaseError(error, {
+        operation: '상태 필터 지원 내역 조회',
+        table: TABLES.APPLICATIONS,
+      });
+
+    return rowsToApplications((data ?? []) as Record<string, unknown>[]);
+  } catch (error) {
+    rethrowOrHandle(error, '상태 필터 지원 내역 조회', { applicantId, statuses });
+  }
+}
+
+export function subscribeByApplicantIdWithStatuses(
+  applicantId: string,
+  statuses: ApplicationStatus[],
+  onData: (applications: Application[]) => void,
+  onError: (error: Error) => void,
+  pageSize: number = 50
+): UnsubscribeFn {
+  logger.info('지원 상태 필터 실시간 구독 시작', { applicantId, statuses });
+
+  if (statuses.length === 0) {
+    onData([]);
+    return () => undefined;
+  }
+
+  // 초기 데이터 1회 fetch — 변경 이벤트가 오지 않아도 구독자가 빈 상태에서 탈출
+  void executeGetByApplicantIdWithStatuses(applicantId, statuses, pageSize)
+    .then(onData)
+    .catch((error) => onError(toError(error)));
+
+  return createRealtimeSubscription(
+    TABLES.APPLICATIONS,
+    `applicant_id=eq.${applicantId}`,
+    (payload) => {
+      try {
+        const row = (payload.new ?? payload.old) as Record<string, unknown> | undefined;
+        if (!row) return;
+
+        // Realtime은 개별 변경만 오므로, 전체 목록을 다시 조회
+        void executeGetByApplicantIdWithStatuses(applicantId, statuses, pageSize)
+          .then(onData)
+          .catch(onError);
+      } catch (error) {
+        onError(toError(error));
+      }
+    },
+    (status) => {
+      if (status === 'CHANNEL_ERROR') {
+        // 일시 장애 — 상위에 통지하되, Phoenix가 자동 재연결을 시도한다.
+        // 'RECOVERED' 신호가 오면 데이터를 재동기화한다.
+        // isRetryable=true로 소비자가 warn 수준으로 다운그레이드할 수 있도록 표시.
+        onError(
+          new NetworkError(ERROR_CODES.NETWORK_REALTIME_TRANSIENT, {
+            message: `Realtime 채널 에러: ${TABLES.APPLICATIONS}`,
+            severity: 'low',
+          })
+        );
+      } else if (status === 'RECOVERED') {
+        // 재연결 성공 — 끊긴 동안 놓친 변경을 반영하기 위해 전체 목록 재조회.
+        logger.info('Realtime 채널 복구 — 데이터 재동기화', { applicantId });
+        void executeGetByApplicantIdWithStatuses(applicantId, statuses, pageSize)
+          .then(onData)
+          .catch(onError);
+      }
+      // TIMED_OUT은 Phoenix가 자동 재시도 — 상위로 전파하지 않음
+    }
+  );
+}
+
+export async function executeGetByJobPostingId(jobPostingId: string): Promise<Application[]> {
+  try {
+    logger.info('공고별 지원서 조회', { jobPostingId });
+
+    const { data, error } = await supabase
+      .from(TABLES.APPLICATIONS)
+      .select(APPLICATION_COLUMNS)
+      .eq('job_posting_id', jobPostingId)
+      .order('created_at', { ascending: false });
+
+    if (error)
+      handleSupabaseError(error, { operation: '공고별 지원서 조회', table: TABLES.APPLICATIONS });
+
+    return rowsToApplications((data ?? []) as Record<string, unknown>[]);
+  } catch (error) {
+    rethrowOrHandle(error, '공고별 지원서 조회', { jobPostingId });
+  }
+}
+
+export async function executeHasApplied(
+  jobPostingId: string,
+  applicantId: string
+): Promise<boolean> {
+  try {
+    const { data, error } = await supabase
+      .from(TABLES.APPLICATIONS)
+      .select('id, status')
+      .eq('job_posting_id', jobPostingId)
+      .eq('applicant_id', applicantId)
+      .maybeSingle();
+
+    if (error || !data) return false;
+
+    const row = data as Record<string, unknown>;
+    return ACTIVE_APPLICATION_STATUSES.has(row.status as ApplicationStatus);
+  } catch {
+    return false;
+  }
+}
+
+export async function executeGetStatsByApplicantId(
+  applicantId: string
+): Promise<Record<ApplicationStatus, number>> {
+  try {
+    const { data, error } = await supabase
+      .from(TABLES.APPLICATIONS)
+      .select('status')
+      .eq('applicant_id', applicantId);
+
+    if (error)
+      handleSupabaseError(error, { operation: '지원 통계 조회', table: TABLES.APPLICATIONS });
+
+    const stats: Record<ApplicationStatus, number> = {
+      applied: 0,
+      confirmed: 0,
+      rejected: 0,
+      cancelled: 0,
+      completed: 0,
+      cancellation_pending: 0,
+    };
+
+    for (const row of (data ?? []) as Record<string, unknown>[]) {
+      const status = row.status as ApplicationStatus;
+      if (status && status in stats) {
+        stats[status]++;
+      }
+    }
+
+    return stats;
+  } catch (error) {
+    rethrowOrHandle(error, '지원 통계 조회', { applicantId });
+  }
+}
+
+export async function executeGetCancellationRequests(
+  jobPostingId: string,
+  ownerId: string
+): Promise<ApplicationWithJob[]> {
+  try {
+    logger.info('취소 요청 목록 조회', { jobPostingId, ownerId });
+
+    const jobData = await loadAndVerifyJobPostingAccess(
+      jobPostingId,
+      ownerId,
+      '취소 요청 목록 조회'
+    );
+
+    const { data, error } = await supabase
+      .from(TABLES.APPLICATIONS)
+      .select(APPLICATION_COLUMNS)
+      .eq('job_posting_id', jobPostingId)
+      .eq('status', STATUS.APPLICATION.CANCELLATION_PENDING)
+      .order('updated_at', { ascending: false });
+
+    if (error)
+      handleSupabaseError(error, {
+        operation: '취소 요청 목록 조회',
+        table: TABLES.APPLICATIONS,
+      });
+
+    const applications = rowsToApplications((data ?? []) as Record<string, unknown>[]);
+
+    return applications.map((app) => ({ ...app, jobPosting: jobData }));
+  } catch (error) {
+    rethrowOrHandle(error, '취소 요청 목록 조회', { jobPostingId });
+  }
+}
+
+// ============================================================================
+// 구인자 전용 (Employer)
+// ============================================================================
+
+export async function executeFindByJobPostingWithStats(
+  jobPostingId: string,
+  ownerId: string,
+  statusFilter?: ApplicationStatus | ApplicationStatus[]
+): Promise<ApplicantListWithStats> {
+  try {
+    logger.info('지원자 목록 조회', { jobPostingId, ownerId, statusFilter });
+
+    const jobPosting = await loadAndVerifyJobPostingAccess(
+      jobPostingId,
+      ownerId,
+      '지원자 목록 조회'
+    );
+
+    const { data, error } = await supabase
+      .from(TABLES.APPLICATIONS)
+      .select(APPLICATION_COLUMNS)
+      .eq('job_posting_id', jobPostingId)
+      .order('created_at', { ascending: false });
+
+    if (error)
+      handleSupabaseError(error, { operation: '지원자 목록 조회', table: TABLES.APPLICATIONS });
+
+    const applications = rowsToApplications((data ?? []) as Record<string, unknown>[]);
+    const result = buildApplicantListWithStats(applications, jobPosting, statusFilter);
+
+    logger.info('지원자 목록 조회 완료', {
+      jobPostingId,
+      total: result.stats.total,
+      filtered: result.applications.length,
+    });
+
+    return result;
+  } catch (error) {
+    rethrowOrHandle(error, '지원자 목록 조회', { jobPostingId });
+  }
+}
+
+export function subscribeByJobPosting(
+  jobPostingId: string,
+  ownerId: string,
+  callbacks: SubscribeCallbacks,
+  options?: { verifyOwnership?: boolean }
+): UnsubscribeFn {
+  logger.info('지원자 목록 실시간 구독 시작', { jobPostingId, ownerId });
+
+  let cachedJobPosting: JobPosting | null = null;
+  let isOwnerVerified = false;
+
+  const handleUpdate = async () => {
+    try {
+      if (!isOwnerVerified) {
+        cachedJobPosting = await loadAndVerifyJobPostingAccess(
+          jobPostingId,
+          ownerId,
+          '지원자 실시간 구독'
+        );
+        if (options?.verifyOwnership === false) {
+          cachedJobPosting = await loadJobPosting(jobPostingId);
+        }
+        isOwnerVerified = true;
+      }
+
+      const { data, error } = await supabase
+        .from(TABLES.APPLICATIONS)
+        .select(APPLICATION_COLUMNS)
+        .eq('job_posting_id', jobPostingId)
+        .order('created_at', { ascending: false })
+        .limit(EMPLOYER_REALTIME_LIMIT);
+
+      if (error) {
+        handleSupabaseError(error, {
+          operation: '지원자 실시간 조회',
+          table: TABLES.APPLICATIONS,
+        });
+      }
+
+      const applications = rowsToApplications((data ?? []) as Record<string, unknown>[]);
+      const result = buildApplicantListWithStats(applications, cachedJobPosting as JobPosting);
+
+      callbacks.onUpdate(result);
+    } catch (error) {
+      logger.error('지원자 목록 실시간 구독 처리 실패', toError(error), { jobPostingId });
+      callbacks.onError?.(toError(error));
+    }
+  };
+
+  // 초기 로드
+  void handleUpdate();
+
+  // Realtime 구독: 변경 시 전체 목록 재조회
+  return createRealtimeSubscription(
+    TABLES.APPLICATIONS,
+    `job_posting_id=eq.${jobPostingId}`,
+    () => {
+      void handleUpdate();
+    }
+  );
+}

--- a/uniqn-mobile/src/repositories/supabase/BoardRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/BoardRepository.ts
@@ -14,7 +14,7 @@
 
 import { supabase } from '@/lib/supabase';
 import { logger } from '@/utils/logger';
-import { toError, isAppError } from '@/errors';
+import { toError } from '@/errors';
 import { handleSupabaseError, runRpc } from '@/utils/supabase';
 import type {
   BoardComment,
@@ -43,13 +43,20 @@ import type {
 import {
   TABLES,
   POST_COLUMNS,
-  COMMENT_COLUMNS,
   VOTE_COLUMNS,
   toBoardPost,
-  toBoardComment,
   togglePostVoteFallback,
   toggleCommentReactionFallback,
+  rethrowRepositoryError,
 } from './BoardRepositoryHelpers';
+import {
+  executeGetComments,
+  executeGetCommentById,
+  executeCreateComment,
+  executeUpdateComment,
+  executeSetCommentStatus,
+  executeSetCommentPinned,
+} from './BoardRepositoryComments';
 import {
   executeGetMembershipsByUser,
   executeGetMembershipsByPost,
@@ -66,25 +73,6 @@ import {
 // ============================================================================
 // Repository Implementation
 // ============================================================================
-
-/**
- * 캐치 블록 공통 처리: AppError는 그대로 전파하고, 그 외 오류는 로깅 후
- * handleSupabaseError로 위임한다. handleSupabaseError가 항상 throw하므로
- * 반환 타입은 never.
- */
-function rethrowRepositoryError(
-  error: unknown,
-  logMessage: string,
-  operation: string,
-  table: string,
-  context?: Record<string, unknown>
-): never {
-  if (isAppError(error)) throw error;
-  logger.error(logMessage, toError(error), context);
-  handleSupabaseError(error, { operation, table });
-  // handleSupabaseError는 항상 throw하지만 타입 시스템상 도달 불가 보장을 위해 재throw
-  throw error;
-}
 
 export class SupabaseBoardRepository implements IBoardRepository {
   // ==========================================================================
@@ -351,109 +339,15 @@ export class SupabaseBoardRepository implements IBoardRepository {
   // ==========================================================================
 
   async getComments(postId: string): Promise<BoardComment[]> {
-    try {
-      const { data, error } = await supabase
-        .from(TABLES.BOARD_COMMENTS)
-        .select(COMMENT_COLUMNS)
-        .eq('post_id', postId)
-        .order('created_at', { ascending: true });
-
-      if (error) {
-        handleSupabaseError(error, { operation: '댓글 조회', table: TABLES.BOARD_COMMENTS });
-      }
-
-      return ((data ?? []) as Record<string, unknown>[]).map(toBoardComment);
-    } catch (error) {
-      rethrowRepositoryError(error, '댓글 조회 실패', '댓글 조회', TABLES.BOARD_COMMENTS, {
-        postId,
-      });
-    }
+    return executeGetComments(postId);
   }
 
   async getCommentById(postId: string, commentId: string): Promise<BoardComment | null> {
-    try {
-      const { data, error } = await supabase
-        .from(TABLES.BOARD_COMMENTS)
-        .select(COMMENT_COLUMNS)
-        .eq('id', commentId)
-        .eq('post_id', postId)
-        .maybeSingle();
-
-      if (error) {
-        handleSupabaseError(error, { operation: '댓글 단건 조회', table: TABLES.BOARD_COMMENTS });
-      }
-
-      return data ? toBoardComment(data as Record<string, unknown>) : null;
-    } catch (error) {
-      rethrowRepositoryError(
-        error,
-        '댓글 단건 조회 실패',
-        '댓글 단건 조회',
-        TABLES.BOARD_COMMENTS,
-        {
-          postId,
-          commentId,
-        }
-      );
-    }
+    return executeGetCommentById(postId, commentId);
   }
 
   async createComment(input: CreateBoardCommentInput): Promise<string> {
-    try {
-      const now = new Date().toISOString();
-
-      // 댓글 생성
-      const { data, error } = await supabase
-        .from(TABLES.BOARD_COMMENTS)
-        .insert({
-          post_id: input.postId,
-          parent_comment_id: input.parentCommentId ?? null,
-          body: input.body,
-          author_id: input.authorId,
-          author_name: input.authorName,
-          author_role: input.authorRole,
-          mentioned_user_ids: input.mentionedUserIds ?? [],
-          reaction_counts: {},
-          is_pinned: false,
-          pinned_at: null,
-          pinned_by: null,
-          status: 'active',
-          image_attachments: input.imageAttachments ?? [],
-          created_at: now,
-          updated_at: now,
-        })
-        .select('id')
-        .single();
-
-      if (error) {
-        handleSupabaseError(error, { operation: '댓글 생성', table: TABLES.BOARD_COMMENTS });
-      }
-
-      // 게시글 댓글 수 + 활동 시각 업데이트
-      const { data: postData } = await supabase
-        .from(TABLES.BOARD_POSTS)
-        .select('comment_count')
-        .eq('id', input.postId)
-        .single();
-
-      if (postData) {
-        await supabase
-          .from(TABLES.BOARD_POSTS)
-          .update({
-            comment_count:
-              (((postData as Record<string, unknown>).comment_count as number) ?? 0) + 1,
-            last_activity_at: now,
-            updated_at: now,
-          })
-          .eq('id', input.postId);
-      }
-
-      return (data as Record<string, unknown>).id as string;
-    } catch (error) {
-      rethrowRepositoryError(error, '댓글 생성 실패', '댓글 생성', TABLES.BOARD_COMMENTS, {
-        postId: input.postId,
-      });
-    }
+    return executeCreateComment(input);
   }
 
   async updateComment(
@@ -461,29 +355,7 @@ export class SupabaseBoardRepository implements IBoardRepository {
     commentId: string,
     input: UpdateBoardCommentInput
   ): Promise<void> {
-    try {
-      const updates: Record<string, unknown> = {
-        updated_at: new Date().toISOString(),
-      };
-
-      if (input.body !== undefined) updates.body = input.body;
-      if (input.imageAttachments !== undefined) updates.image_attachments = input.imageAttachments;
-
-      const { error } = await supabase
-        .from(TABLES.BOARD_COMMENTS)
-        .update(updates)
-        .eq('id', commentId)
-        .eq('post_id', postId);
-
-      if (error) {
-        handleSupabaseError(error, { operation: '댓글 수정', table: TABLES.BOARD_COMMENTS });
-      }
-    } catch (error) {
-      rethrowRepositoryError(error, '댓글 수정 실패', '댓글 수정', TABLES.BOARD_COMMENTS, {
-        postId,
-        commentId,
-      });
-    }
+    return executeUpdateComment(postId, commentId, input);
   }
 
   async setCommentStatus(
@@ -491,86 +363,7 @@ export class SupabaseBoardRepository implements IBoardRepository {
     commentId: string,
     status: BoardComment['status']
   ): Promise<void> {
-    try {
-      const placeholder =
-        status === 'hidden' ? '관리자에 의해 숨김된 댓글입니다.' : '삭제된 댓글입니다.';
-      const now = new Date().toISOString();
-
-      // 댓글 현재 상태 확인
-      const { data: commentData, error: fetchError } = await supabase
-        .from(TABLES.BOARD_COMMENTS)
-        .select('status')
-        .eq('id', commentId)
-        .eq('post_id', postId)
-        .maybeSingle();
-
-      if (fetchError) {
-        handleSupabaseError(fetchError, {
-          operation: '댓글 상태 조회',
-          table: TABLES.BOARD_COMMENTS,
-        });
-      }
-
-      if (!commentData) return;
-
-      const previousStatus =
-        ((commentData as Record<string, unknown>).status as string) ?? 'active';
-      if (previousStatus !== 'active' || status === 'active') return;
-
-      // 댓글 상태 변경
-      const { error: updateError } = await supabase
-        .from(TABLES.BOARD_COMMENTS)
-        .update({
-          status,
-          body: placeholder,
-          is_pinned: false,
-          pinned_at: null,
-          pinned_by: null,
-          image_attachments: [],
-          mentioned_user_ids: [],
-          updated_at: now,
-        })
-        .eq('id', commentId)
-        .eq('post_id', postId);
-
-      if (updateError) {
-        handleSupabaseError(updateError, {
-          operation: '댓글 상태 변경',
-          table: TABLES.BOARD_COMMENTS,
-        });
-      }
-
-      // 게시글 댓글 수 감소
-      const { data: postData } = await supabase
-        .from(TABLES.BOARD_POSTS)
-        .select('comment_count')
-        .eq('id', postId)
-        .single();
-
-      if (postData) {
-        const currentCount = ((postData as Record<string, unknown>).comment_count as number) ?? 0;
-        await supabase
-          .from(TABLES.BOARD_POSTS)
-          .update({
-            comment_count: Math.max(0, currentCount - 1),
-            last_activity_at: now,
-            updated_at: now,
-          })
-          .eq('id', postId);
-      }
-    } catch (error) {
-      rethrowRepositoryError(
-        error,
-        '댓글 상태 변경 실패',
-        '댓글 상태 변경',
-        TABLES.BOARD_COMMENTS,
-        {
-          postId,
-          commentId,
-          status,
-        }
-      );
-    }
+    return executeSetCommentStatus(postId, commentId, status);
   }
 
   async setCommentPinned(
@@ -579,35 +372,7 @@ export class SupabaseBoardRepository implements IBoardRepository {
     isPinned: boolean,
     actorId: string
   ): Promise<void> {
-    try {
-      const now = new Date().toISOString();
-      const { error } = await supabase
-        .from(TABLES.BOARD_COMMENTS)
-        .update({
-          is_pinned: isPinned,
-          pinned_at: isPinned ? now : null,
-          pinned_by: isPinned ? actorId : null,
-          updated_at: now,
-        })
-        .eq('id', commentId)
-        .eq('post_id', postId);
-
-      if (error) {
-        handleSupabaseError(error, { operation: '댓글 고정 설정', table: TABLES.BOARD_COMMENTS });
-      }
-    } catch (error) {
-      rethrowRepositoryError(
-        error,
-        '댓글 고정 설정 실패',
-        '댓글 고정 설정',
-        TABLES.BOARD_COMMENTS,
-        {
-          postId,
-          commentId,
-          isPinned,
-        }
-      );
-    }
+    return executeSetCommentPinned(postId, commentId, isPinned, actorId);
   }
 
   // ==========================================================================

--- a/uniqn-mobile/src/repositories/supabase/BoardRepositoryComments.ts
+++ b/uniqn-mobile/src/repositories/supabase/BoardRepositoryComments.ts
@@ -1,0 +1,267 @@
+/**
+ * UNIQN Mobile - Board Repository Comments
+ *
+ * @description BoardRepository에서 사용하는 댓글 CRUD standalone 함수
+ * getComments, getCommentById, createComment, updateComment, setCommentStatus, setCommentPinned
+ */
+
+import { supabase } from '@/lib/supabase';
+import { handleSupabaseError } from '@/utils/supabase';
+import type { BoardComment, CreateBoardCommentInput, UpdateBoardCommentInput } from '@/types/board';
+import {
+  TABLES,
+  COMMENT_COLUMNS,
+  toBoardComment,
+  rethrowRepositoryError,
+} from './BoardRepositoryHelpers';
+
+// ============================================================================
+// Comment Query Operations
+// ============================================================================
+
+export async function executeGetComments(postId: string): Promise<BoardComment[]> {
+  try {
+    const { data, error } = await supabase
+      .from(TABLES.BOARD_COMMENTS)
+      .select(COMMENT_COLUMNS)
+      .eq('post_id', postId)
+      .order('created_at', { ascending: true });
+
+    if (error) {
+      handleSupabaseError(error, { operation: '댓글 조회', table: TABLES.BOARD_COMMENTS });
+    }
+
+    return ((data ?? []) as Record<string, unknown>[]).map(toBoardComment);
+  } catch (error) {
+    rethrowRepositoryError(error, '댓글 조회 실패', '댓글 조회', TABLES.BOARD_COMMENTS, {
+      postId,
+    });
+  }
+}
+
+export async function executeGetCommentById(
+  postId: string,
+  commentId: string
+): Promise<BoardComment | null> {
+  try {
+    const { data, error } = await supabase
+      .from(TABLES.BOARD_COMMENTS)
+      .select(COMMENT_COLUMNS)
+      .eq('id', commentId)
+      .eq('post_id', postId)
+      .maybeSingle();
+
+    if (error) {
+      handleSupabaseError(error, { operation: '댓글 단건 조회', table: TABLES.BOARD_COMMENTS });
+    }
+
+    return data ? toBoardComment(data as Record<string, unknown>) : null;
+  } catch (error) {
+    rethrowRepositoryError(error, '댓글 단건 조회 실패', '댓글 단건 조회', TABLES.BOARD_COMMENTS, {
+      postId,
+      commentId,
+    });
+  }
+}
+
+// ============================================================================
+// Comment Mutation Operations
+// ============================================================================
+
+export async function executeCreateComment(input: CreateBoardCommentInput): Promise<string> {
+  try {
+    const now = new Date().toISOString();
+
+    // 댓글 생성
+    const { data, error } = await supabase
+      .from(TABLES.BOARD_COMMENTS)
+      .insert({
+        post_id: input.postId,
+        parent_comment_id: input.parentCommentId ?? null,
+        body: input.body,
+        author_id: input.authorId,
+        author_name: input.authorName,
+        author_role: input.authorRole,
+        mentioned_user_ids: input.mentionedUserIds ?? [],
+        reaction_counts: {},
+        is_pinned: false,
+        pinned_at: null,
+        pinned_by: null,
+        status: 'active',
+        image_attachments: input.imageAttachments ?? [],
+        created_at: now,
+        updated_at: now,
+      })
+      .select('id')
+      .single();
+
+    if (error) {
+      handleSupabaseError(error, { operation: '댓글 생성', table: TABLES.BOARD_COMMENTS });
+    }
+
+    // 게시글 댓글 수 + 활동 시각 업데이트
+    const { data: postData } = await supabase
+      .from(TABLES.BOARD_POSTS)
+      .select('comment_count')
+      .eq('id', input.postId)
+      .single();
+
+    if (postData) {
+      await supabase
+        .from(TABLES.BOARD_POSTS)
+        .update({
+          comment_count: (((postData as Record<string, unknown>).comment_count as number) ?? 0) + 1,
+          last_activity_at: now,
+          updated_at: now,
+        })
+        .eq('id', input.postId);
+    }
+
+    return (data as Record<string, unknown>).id as string;
+  } catch (error) {
+    rethrowRepositoryError(error, '댓글 생성 실패', '댓글 생성', TABLES.BOARD_COMMENTS, {
+      postId: input.postId,
+    });
+  }
+}
+
+export async function executeUpdateComment(
+  postId: string,
+  commentId: string,
+  input: UpdateBoardCommentInput
+): Promise<void> {
+  try {
+    const updates: Record<string, unknown> = {
+      updated_at: new Date().toISOString(),
+    };
+
+    if (input.body !== undefined) updates.body = input.body;
+    if (input.imageAttachments !== undefined) updates.image_attachments = input.imageAttachments;
+
+    const { error } = await supabase
+      .from(TABLES.BOARD_COMMENTS)
+      .update(updates)
+      .eq('id', commentId)
+      .eq('post_id', postId);
+
+    if (error) {
+      handleSupabaseError(error, { operation: '댓글 수정', table: TABLES.BOARD_COMMENTS });
+    }
+  } catch (error) {
+    rethrowRepositoryError(error, '댓글 수정 실패', '댓글 수정', TABLES.BOARD_COMMENTS, {
+      postId,
+      commentId,
+    });
+  }
+}
+
+export async function executeSetCommentStatus(
+  postId: string,
+  commentId: string,
+  status: BoardComment['status']
+): Promise<void> {
+  try {
+    const placeholder =
+      status === 'hidden' ? '관리자에 의해 숨김된 댓글입니다.' : '삭제된 댓글입니다.';
+    const now = new Date().toISOString();
+
+    // 댓글 현재 상태 확인
+    const { data: commentData, error: fetchError } = await supabase
+      .from(TABLES.BOARD_COMMENTS)
+      .select('status')
+      .eq('id', commentId)
+      .eq('post_id', postId)
+      .maybeSingle();
+
+    if (fetchError) {
+      handleSupabaseError(fetchError, {
+        operation: '댓글 상태 조회',
+        table: TABLES.BOARD_COMMENTS,
+      });
+    }
+
+    if (!commentData) return;
+
+    const previousStatus = ((commentData as Record<string, unknown>).status as string) ?? 'active';
+    if (previousStatus !== 'active' || status === 'active') return;
+
+    // 댓글 상태 변경
+    const { error: updateError } = await supabase
+      .from(TABLES.BOARD_COMMENTS)
+      .update({
+        status,
+        body: placeholder,
+        is_pinned: false,
+        pinned_at: null,
+        pinned_by: null,
+        image_attachments: [],
+        mentioned_user_ids: [],
+        updated_at: now,
+      })
+      .eq('id', commentId)
+      .eq('post_id', postId);
+
+    if (updateError) {
+      handleSupabaseError(updateError, {
+        operation: '댓글 상태 변경',
+        table: TABLES.BOARD_COMMENTS,
+      });
+    }
+
+    // 게시글 댓글 수 감소
+    const { data: postData } = await supabase
+      .from(TABLES.BOARD_POSTS)
+      .select('comment_count')
+      .eq('id', postId)
+      .single();
+
+    if (postData) {
+      const currentCount = ((postData as Record<string, unknown>).comment_count as number) ?? 0;
+      await supabase
+        .from(TABLES.BOARD_POSTS)
+        .update({
+          comment_count: Math.max(0, currentCount - 1),
+          last_activity_at: now,
+          updated_at: now,
+        })
+        .eq('id', postId);
+    }
+  } catch (error) {
+    rethrowRepositoryError(error, '댓글 상태 변경 실패', '댓글 상태 변경', TABLES.BOARD_COMMENTS, {
+      postId,
+      commentId,
+      status,
+    });
+  }
+}
+
+export async function executeSetCommentPinned(
+  postId: string,
+  commentId: string,
+  isPinned: boolean,
+  actorId: string
+): Promise<void> {
+  try {
+    const now = new Date().toISOString();
+    const { error } = await supabase
+      .from(TABLES.BOARD_COMMENTS)
+      .update({
+        is_pinned: isPinned,
+        pinned_at: isPinned ? now : null,
+        pinned_by: isPinned ? actorId : null,
+        updated_at: now,
+      })
+      .eq('id', commentId)
+      .eq('post_id', postId);
+
+    if (error) {
+      handleSupabaseError(error, { operation: '댓글 고정 설정', table: TABLES.BOARD_COMMENTS });
+    }
+  } catch (error) {
+    rethrowRepositoryError(error, '댓글 고정 설정 실패', '댓글 고정 설정', TABLES.BOARD_COMMENTS, {
+      postId,
+      commentId,
+      isPinned,
+    });
+  }
+}

--- a/uniqn-mobile/src/repositories/supabase/BoardRepositoryHelpers.ts
+++ b/uniqn-mobile/src/repositories/supabase/BoardRepositoryHelpers.ts
@@ -6,6 +6,8 @@
 
 import { z } from 'zod';
 import { supabase } from '@/lib/supabase';
+import { logger } from '@/utils/logger';
+import { toError, isAppError } from '@/errors';
 import { handleSupabaseError, safeParseJson } from '@/utils/supabase';
 import { BoardJobSummarySchema } from '@/schemas/boardMetadata.schema';
 import type {
@@ -184,6 +186,25 @@ export function toBoardReport(row: Record<string, unknown>): BoardReport {
 
 export function getMembershipId(postId: string, userId: string): string {
   return `${postId}_${userId}`;
+}
+
+/**
+ * 캐치 블록 공통 처리: AppError는 그대로 전파하고, 그 외 오류는 로깅 후
+ * handleSupabaseError로 위임한다. handleSupabaseError가 항상 throw하므로
+ * 반환 타입은 never.
+ */
+export function rethrowRepositoryError(
+  error: unknown,
+  logMessage: string,
+  operation: string,
+  table: string,
+  context?: Record<string, unknown>
+): never {
+  if (isAppError(error)) throw error;
+  logger.error(logMessage, toError(error), context);
+  handleSupabaseError(error, { operation, table });
+  // handleSupabaseError는 항상 throw하지만 타입 시스템상 도달 불가 보장을 위해 재throw
+  throw error;
 }
 
 // ============================================================================

--- a/uniqn-mobile/src/repositories/supabase/EmployerApplicationRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/EmployerApplicationRepository.ts
@@ -21,6 +21,7 @@ import {
   EmployerAppNotFoundError,
 } from '@/errors/BusinessErrors';
 import { handleSupabaseError, toCamelCase, paginatedQuery } from '@/utils/supabase';
+import type { IEmployerApplicationRepository } from '../interfaces';
 
 // ============================================================================
 // Types
@@ -194,7 +195,7 @@ function rowToApplication(row: Record<string, unknown>): EmployerApplication {
 // Repository
 // ============================================================================
 
-export class SupabaseEmployerApplicationRepository {
+export class SupabaseEmployerApplicationRepository implements IEmployerApplicationRepository {
   // ==========================================================================
   // 신청 생성 (유저)
   // ==========================================================================

--- a/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
@@ -40,6 +40,7 @@ import type {
   CreateJobPostingResult,
   JobPostingStats,
   JobPostingSubscriptionCallbacks,
+  ScheduleBoardSyncAction,
 } from '../interfaces';
 import {
   TABLE,
@@ -695,5 +696,33 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
         callbacks.onError?.(toError(error));
       }
     });
+  }
+
+  // ── Schedule Board Sync Outbox ────────────────────────────────────────────
+
+  async enqueueScheduleBoardSync(
+    jobPostingId: string,
+    action: ScheduleBoardSyncAction,
+    payload: Record<string, unknown> = {}
+  ): Promise<void> {
+    const { error } = await supabase.from('schedule_board_sync_outbox').insert({
+      job_posting_id: jobPostingId,
+      action,
+      payload,
+      status: 'pending',
+      retry_count: 0,
+    });
+
+    if (error) {
+      // outbox insert 실패는 main mutation을 롤백시키지 않음.
+      // 사용자 경험 보호 차원에서 warn 로그만 남기고, outbox failed_retry_limit
+      // 모니터링 + 수동 백필이 안전망. 이는 아키텍처 결정.
+      logger.warn('Schedule board sync enqueue 실패', {
+        component: 'JobPostingRepository',
+        jobPostingId,
+        action,
+        error: error.message,
+      });
+    }
   }
 }

--- a/uniqn-mobile/src/repositories/supabase/WalletRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/WalletRepository.ts
@@ -16,6 +16,7 @@ import {
   type DiamondProduct,
   type WalletSummary,
 } from '@/types/wallet';
+import type { IWalletRepository } from '../interfaces';
 
 const TABLES = {
   DIAMOND_PRODUCTS: 'diamond_products',
@@ -24,7 +25,7 @@ const TABLES = {
 const DIAMOND_PRODUCT_COLUMNS =
   'product_id, diamonds, bonus_diamonds, price_krw, display_order, active' as const;
 
-export const WalletRepository = {
+export const WalletRepository: IWalletRepository = {
   /**
    * 현재 사용자(또는 지정 사용자)의 지갑 요약 조회.
    *

--- a/uniqn-mobile/src/repositories/supabase/WorkLogRepositoryTransactions.ts
+++ b/uniqn-mobile/src/repositories/supabase/WorkLogRepositoryTransactions.ts
@@ -291,7 +291,7 @@ export async function executeProcessQRCheckInOut(
 
     return {
       action: result.action ?? action,
-      hasExistingCheckInTime: false,
+      hasExistingCheckInTime: !!result.check_in_time,
       workDuration: result.work_duration ?? 0,
     };
   } catch (error) {

--- a/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.outbox.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.outbox.test.ts
@@ -1,0 +1,83 @@
+/**
+ * U4: JobPostingRepository.enqueueScheduleBoardSync 검증
+ *
+ * outbox insert(snake_case 매핑)가 Service → Repository 로 이관됨.
+ * - camelCase 입력 → snake_case row 매핑
+ * - status='pending', retry_count=0 기본값
+ * - enqueue 실패가 throw 되지 않고 warn 로그만 남김 (main mutation 비롤백)
+ */
+
+import { SupabaseJobPostingRepository } from '../JobPostingRepository';
+
+const mockInsert = jest.fn();
+const mockFrom = jest.fn();
+const mockWarn = jest.fn();
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    rpc: jest.fn(),
+    channel: jest.fn(),
+  },
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: (...args: unknown[]) => mockWarn(...args),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('@sentry/react-native', () => ({
+  __esModule: true,
+  addBreadcrumb: jest.fn(),
+}));
+
+const repo = new SupabaseJobPostingRepository();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFrom.mockImplementation((table: string) => {
+    expect(table).toBe('schedule_board_sync_outbox');
+    return { insert: (...args: unknown[]) => mockInsert(...args) };
+  });
+});
+
+describe('JobPostingRepository.enqueueScheduleBoardSync', () => {
+  it('camelCase 입력을 snake_case outbox row 로 매핑한다', async () => {
+    mockInsert.mockResolvedValue({ error: null });
+
+    await repo.enqueueScheduleBoardSync('job-1', 'create', { ownerId: 'owner-1' });
+
+    expect(mockInsert).toHaveBeenCalledWith({
+      job_posting_id: 'job-1',
+      action: 'create',
+      payload: { ownerId: 'owner-1' },
+      status: 'pending',
+      retry_count: 0,
+    });
+  });
+
+  it('payload 미지정 시 빈 객체로 enqueue 한다', async () => {
+    mockInsert.mockResolvedValue({ error: null });
+
+    await repo.enqueueScheduleBoardSync('job-2', 'close');
+
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ job_posting_id: 'job-2', action: 'close', payload: {} })
+    );
+  });
+
+  it('enqueue 실패 시 throw 하지 않고 warn 로그만 남긴다', async () => {
+    mockInsert.mockResolvedValue({ error: { message: 'outbox down' } });
+
+    await expect(repo.enqueueScheduleBoardSync('job-3', 'delete')).resolves.toBeUndefined();
+
+    expect(mockWarn).toHaveBeenCalledWith(
+      'Schedule board sync enqueue 실패',
+      expect.objectContaining({ jobPostingId: 'job-3', action: 'delete', error: 'outbox down' })
+    );
+  });
+});

--- a/uniqn-mobile/src/repositories/supabase/__tests__/qrCheckinAtomic.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/qrCheckinAtomic.test.ts
@@ -68,6 +68,8 @@ describe('executeProcessQRCheckInOut — RPC 위임', () => {
     });
     expect(result.action).toBe('checkIn');
     expect(result.workDuration).toBe(0);
+    // U3: RPC가 check_in_time을 돌려주면 hasExistingCheckInTime=true로 도출
+    expect(result.hasExistingCheckInTime).toBe(true);
   });
 
   it('checkOut 호출 시 work_duration이 응답값을 그대로 반환', async () => {
@@ -92,6 +94,8 @@ describe('executeProcessQRCheckInOut — RPC 위임', () => {
 
     expect(result.action).toBe('checkOut');
     expect(result.workDuration).toBe(8.5);
+    // U3: RPC 응답에 check_in_time이 없으면 hasExistingCheckInTime=false
+    expect(result.hasExistingCheckInTime).toBe(false);
   });
 });
 

--- a/uniqn-mobile/src/schemas/__tests__/employerApplication.schema.test.ts
+++ b/uniqn-mobile/src/schemas/__tests__/employerApplication.schema.test.ts
@@ -1,0 +1,74 @@
+/**
+ * U4: 구인자 등록 신청 거부 입력 스키마 검증
+ *
+ * reject reason 자유 텍스트가 XSS 패턴을 차단하는지 + optional 동작 검증.
+ */
+
+import {
+  employerApplicationRejectReasonSchema,
+  rejectEmployerApplicationSchema,
+} from '../employerApplication.schema';
+
+describe('employerApplicationRejectReasonSchema', () => {
+  it('정상 사유를 통과시킨다', () => {
+    const result = employerApplicationRejectReasonSchema.safeParse('서류가 불충분합니다');
+    expect(result.success).toBe(true);
+  });
+
+  it('미지정(undefined)을 허용한다', () => {
+    const result = employerApplicationRejectReasonSchema.safeParse(undefined);
+    expect(result.success).toBe(true);
+  });
+
+  it('XSS 스크립트 태그를 거부한다', () => {
+    const result = employerApplicationRejectReasonSchema.safeParse('<script>alert(1)</script>');
+    expect(result.success).toBe(false);
+  });
+
+  it('javascript: 프로토콜을 거부한다', () => {
+    const result = employerApplicationRejectReasonSchema.safeParse('javascript:alert(1)');
+    expect(result.success).toBe(false);
+  });
+
+  it('500자 초과를 거부한다', () => {
+    const result = employerApplicationRejectReasonSchema.safeParse('가'.repeat(501));
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('rejectEmployerApplicationSchema', () => {
+  it('applicationId + 정상 reason + category 를 통과시킨다', () => {
+    const result = rejectEmployerApplicationSchema.safeParse({
+      applicationId: 'app-1',
+      reason: '중복 신청입니다',
+      category: 'duplicate',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('reason/category 미지정을 허용한다 (applicationId 만)', () => {
+    const result = rejectEmployerApplicationSchema.safeParse({ applicationId: 'app-1' });
+    expect(result.success).toBe(true);
+  });
+
+  it('applicationId 누락을 거부한다', () => {
+    const result = rejectEmployerApplicationSchema.safeParse({ reason: '사유' });
+    expect(result.success).toBe(false);
+  });
+
+  it('reason 에 XSS 가 있으면 거부한다', () => {
+    const result = rejectEmployerApplicationSchema.safeParse({
+      applicationId: 'app-1',
+      reason: '<img src=x onerror=alert(1)>',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('잘못된 category 를 거부한다', () => {
+    const result = rejectEmployerApplicationSchema.safeParse({
+      applicationId: 'app-1',
+      category: 'invalid_category',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/uniqn-mobile/src/schemas/__tests__/jobPosting.schema.test.ts
+++ b/uniqn-mobile/src/schemas/__tests__/jobPosting.schema.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../jobPosting.schema';
 import { serializeJobPostingV3 } from '@/domains/job-posting';
 import { JOB_POSTING_SCHEMA_VERSION } from '@/types/jobPosting';
+import { Constants } from '@/types/supabase';
 
 const createMockTimestamp = (seconds = 1700000000, nanoseconds = 0) => ({
   seconds,
@@ -607,5 +608,19 @@ describe('jobPosting schemas', () => {
         detailedAddress: 'Teheran-ro 123',
       });
     });
+  });
+});
+
+describe('jobFilterSchema posting_status SSOT drift guard', () => {
+  it('jobFilterSchema.status가 DB enum posting_status 전체 집합을 수용한다', () => {
+    for (const status of Constants.public.Enums.posting_status) {
+      const result = jobFilterSchema.safeParse({ status });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('DB enum에 없는 status는 거부한다', () => {
+    const result = jobFilterSchema.safeParse({ status: 'weird_status' });
+    expect(result.success).toBe(false);
   });
 });

--- a/uniqn-mobile/src/schemas/__tests__/workLog.schema.test.ts
+++ b/uniqn-mobile/src/schemas/__tests__/workLog.schema.test.ts
@@ -1,4 +1,49 @@
 import { parseWorkLogDocument } from '../workLog.schema';
+import { Constants } from '@/types/supabase';
+
+const baseWorkLog = {
+  id: 'wl-1',
+  staffId: 'staff-1',
+  jobPostingId: 'job-1',
+  date: '2026-05-30',
+  staffName: 'Alice',
+  staffNickname: null,
+  staffPhotoURL: null,
+  checkInTime: null,
+  checkOutTime: null,
+  status: 'completed',
+  role: 'dealer',
+  customRole: null,
+  notes: null,
+  timeSlot: null,
+  isFixedPosting: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('workLog.schema payroll_status read compatibility', () => {
+  it('payroll_status="failed"(DB enum) 레코드를 drop하지 않고 보존한다', () => {
+    const parsed = parseWorkLogDocument({ ...baseWorkLog, payrollStatus: 'failed' });
+
+    expect(parsed).not.toBeNull();
+    expect(parsed).toEqual(expect.objectContaining({ id: 'wl-1', payrollStatus: 'failed' }));
+  });
+
+  it('미지 enum 값도 레코드는 살아남고 payrollStatus는 undefined로 흡수된다', () => {
+    const parsed = parseWorkLogDocument({ ...baseWorkLog, payrollStatus: 'weird' });
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.id).toBe('wl-1');
+    expect(parsed?.payrollStatus).toBeUndefined();
+  });
+
+  it('payroll_status DB enum이 superset 스키마에 모두 포함된다 (drift 가드)', () => {
+    for (const dbValue of Constants.public.Enums.payroll_status) {
+      const parsed = parseWorkLogDocument({ ...baseWorkLog, payrollStatus: dbValue });
+      expect(parsed?.payrollStatus).toBe(dbValue);
+    }
+  });
+});
 
 describe('workLog.schema fixed compatibility', () => {
   it('parses canonical fixed worklogs with null date/timeSlot and keeps the fixed flag', () => {

--- a/uniqn-mobile/src/schemas/application.schema.ts
+++ b/uniqn-mobile/src/schemas/application.schema.ts
@@ -11,16 +11,16 @@ import { logger } from '@/utils/logger';
 import { timestampSchema, optionalTimestampSchema, optionalDurationSchema } from './common';
 import type { Application } from '@/types';
 import { VALID_STAFF_ROLES } from '@/types/role';
+import { Constants } from '@/types/supabase';
 
 /**
  * 지원 상태 스키마
+ *
+ * @description DB enum(application_status)을 단일출처로 파생 (인라인 하드코딩 제거, drift 가드).
  */
-export const applicationStatusSchema = z.enum(
-  ['applied', 'confirmed', 'rejected', 'cancelled', 'completed', 'cancellation_pending'],
-  {
-    error: '올바른 지원 상태가 아닙니다',
-  }
-);
+export const applicationStatusSchema = z.enum(Constants.public.Enums.application_status, {
+  error: '올바른 지원 상태가 아닙니다',
+});
 
 export type ApplicationStatusSchema = z.infer<typeof applicationStatusSchema>;
 

--- a/uniqn-mobile/src/schemas/employerApplication.schema.ts
+++ b/uniqn-mobile/src/schemas/employerApplication.schema.ts
@@ -1,0 +1,58 @@
+/**
+ * UNIQN Mobile - 구인자 등록 신청 스키마
+ *
+ * @description 관리자 거부 처리 입력 검증 (reason 자유 텍스트 XSS 방어)
+ * @version 1.0.0
+ */
+
+import { z } from 'zod';
+import { xssValidation } from '@/utils/security';
+
+// ============================================================================
+// Rejection Category Schema
+// ============================================================================
+
+/**
+ * 거부 분류 스키마 (DB rejection_category 컬럼과 동일 집합)
+ */
+export const employerApplicationRejectionCategorySchema = z.enum([
+  'duplicate',
+  'dummy',
+  'identity_mismatch',
+  'other',
+]);
+
+export type EmployerApplicationRejectionCategorySchema = z.infer<
+  typeof employerApplicationRejectionCategorySchema
+>;
+
+// ============================================================================
+// Rejection Reason Schema
+// ============================================================================
+
+/**
+ * 거부 사유 스키마 (선택)
+ * - 입력 시에만 검증: 최대 500자, XSS 패턴 차단
+ * - 대회공고 rejectionReasonSchema 와 달리 reason 은 optional (RPC p_reason nullable)
+ */
+export const employerApplicationRejectReasonSchema = z
+  .string()
+  .max(500, '거부 사유는 500자를 초과할 수 없습니다')
+  .trim()
+  .refine(xssValidation, { message: '위험한 문자열이 포함되어 있습니다' })
+  .optional();
+
+// ============================================================================
+// Request Schema
+// ============================================================================
+
+/**
+ * 거부 요청 입력 스키마 (admin)
+ */
+export const rejectEmployerApplicationSchema = z.object({
+  applicationId: z.string().min(1, '신청 ID가 필요합니다'),
+  reason: employerApplicationRejectReasonSchema,
+  category: employerApplicationRejectionCategorySchema.optional(),
+});
+
+export type RejectEmployerApplicationData = z.infer<typeof rejectEmployerApplicationSchema>;

--- a/uniqn-mobile/src/schemas/index.ts
+++ b/uniqn-mobile/src/schemas/index.ts
@@ -339,6 +339,18 @@ export type {
   ReportDocumentData,
 } from './report.schema';
 
+// 구인자 등록 신청 스키마
+export {
+  employerApplicationRejectionCategorySchema,
+  employerApplicationRejectReasonSchema,
+  rejectEmployerApplicationSchema,
+} from './employerApplication.schema';
+
+export type {
+  EmployerApplicationRejectionCategorySchema,
+  RejectEmployerApplicationData,
+} from './employerApplication.schema';
+
 // 게시판 메타데이터 스키마
 export { BoardJobSummarySchema, BoardPostMetadataSchema } from './boardMetadata.schema';
 

--- a/uniqn-mobile/src/schemas/jobPosting.schema.ts
+++ b/uniqn-mobile/src/schemas/jobPosting.schema.ts
@@ -15,6 +15,13 @@ import {
 } from '@/domains/job-posting';
 import { JOB_POSTING_SCHEMA_VERSION } from '@/types/jobPosting';
 import { isWithinUrgentDateLimit } from '@/utils/date';
+import { Constants } from '@/types/supabase';
+
+/**
+ * 공고 상태 SSOT — DB enum(posting_status)을 단일출처로 파생.
+ * 인라인 z.enum 중복 하드코딩 제거 (drift 가드).
+ */
+const POSTING_STATUS_VALUES = Constants.public.Enums.posting_status;
 
 export const postingTypeSchema = z.enum(['regular', 'fixed', 'tournament', 'urgent'], {
   error: 'Select a valid posting type',
@@ -104,19 +111,7 @@ export const dateTimeSchema = z.object({
 export type DateTimeData = z.infer<typeof dateTimeSchema>;
 
 export const jobFilterSchema = z.object({
-  status: z
-    .enum([
-      'draft',
-      'pending',
-      'approved',
-      'active',
-      'capacity_full',
-      'closed',
-      'cancelled',
-      'expired',
-      'rejected',
-    ])
-    .optional(),
+  status: z.enum(POSTING_STATUS_VALUES).optional(),
   roles: z.array(roleSchema).optional(),
   district: z.string().optional(),
   dateRange: z
@@ -471,17 +466,7 @@ export const jobPostingDocumentSchema = z
     schemaVersion: z.literal(JOB_POSTING_SCHEMA_VERSION),
     title: z.string(),
     description: z.string().optional(),
-    status: z.enum([
-      'draft',
-      'pending',
-      'approved',
-      'active',
-      'capacity_full',
-      'closed',
-      'cancelled',
-      'expired',
-      'rejected',
-    ]),
+    status: z.enum(POSTING_STATUS_VALUES),
     ownerId: z.string(),
     ownerName: z.string().optional(),
     workspaceId: z.string().uuid({ message: '올바른 워크스페이스 ID 가 아닙니다' }),

--- a/uniqn-mobile/src/schemas/schedule.schema.ts
+++ b/uniqn-mobile/src/schemas/schedule.schema.ts
@@ -28,8 +28,12 @@ export type ScheduleTypeSchema = z.infer<typeof scheduleTypeSchema>;
 
 /**
  * 정산 상태 스키마
+ *
+ * @description DB enum(payroll_status = ['pending','completed','failed'])과 UI 전용 값('processing')의
+ * superset. 'processing'은 UI 표시 전용이며 DB 컬럼에 직접 쓰지 않는다(읽기 호환 목적).
+ * read 경로에서 미지 enum 값에 레코드가 drop되지 않도록 호출부(workLog.schema)에서 .catch 흡수.
  */
-export const payrollStatusSchema = z.enum(['pending', 'processing', 'completed']);
+export const payrollStatusSchema = z.enum(['pending', 'processing', 'completed', 'failed']);
 
 export type PayrollStatusSchema = z.infer<typeof payrollStatusSchema>;
 

--- a/uniqn-mobile/src/schemas/workLog.schema.ts
+++ b/uniqn-mobile/src/schemas/workLog.schema.ts
@@ -153,7 +153,8 @@ export const workLogDocumentSchema = z
     customRole: z.string().nullable().optional(),
 
     // 정산 정보
-    payrollStatus: payrollStatusSchema.optional(),
+    // 미지 enum 값(DB enum 발산)에도 레코드가 drop되지 않도록 .catch(undefined)로 흡수
+    payrollStatus: payrollStatusSchema.optional().catch(undefined),
     payrollAmount: z.number().nullable().optional(),
     payrollDate: optionalTimestampSchema,
     payrollNotes: z.string().nullable().optional(),

--- a/uniqn-mobile/src/services/admin/employerApplicationService.ts
+++ b/uniqn-mobile/src/services/admin/employerApplicationService.ts
@@ -24,6 +24,7 @@ import type {
 } from '@/repositories';
 import { handleServiceError } from '@/errors/serviceErrorHandler';
 import { requireAdminUser } from '@/services/auth/authorizationService';
+import { rejectEmployerApplicationSchema } from '@/schemas/employerApplication.schema';
 
 // ============================================================================
 // Types
@@ -153,7 +154,8 @@ export async function rejectEmployerApplication(
 ): Promise<ApproveRejectResult> {
   await requireAdminUser();
 
-  const { applicationId, reason, category } = input;
+  // 거부 사유 자유 텍스트 XSS 방어 (시스템 경계 입력 검증)
+  const { applicationId, reason, category } = rejectEmployerApplicationSchema.parse(input);
 
   try {
     logger.info('구인자 신청 거부 처리', {

--- a/uniqn-mobile/src/services/jobs/__tests__/applicantManagementService.test.ts
+++ b/uniqn-mobile/src/services/jobs/__tests__/applicantManagementService.test.ts
@@ -551,6 +551,45 @@ describe('applicantManagementService', () => {
       expect(result.failedCount).toBe(1);
       expect(result.failedIds).toContain('app-2');
       expect(result.workLogIds).toHaveLength(2);
+
+      // U3: 실패 항목별 사유 구조화 (code/reason 캡처)
+      // app-2는 getById가 null → confirmApplication이 INFRA_NOT_FOUND로 throw
+      expect(result.failed).toHaveLength(1);
+      expect(result.failed[0]).toMatchObject({
+        applicationId: 'app-2',
+        code: ERROR_CODES.INFRA_NOT_FOUND,
+        reason: '존재하지 않는 지원자입니다.',
+      });
+    });
+
+    it('정원 마감 실패 사유를 code로 구분할 수 있어야 함', async () => {
+      const { BusinessError, ERROR_CODES: MockCodes } = jest.requireMock('@/errors');
+
+      mockGetById.mockImplementation(async (id: string) => createMockApplication({ id }));
+      mockConfirmApplicationWithHistory.mockImplementation(async (id: string) => {
+        if (id === 'app-2') {
+          throw new BusinessError(MockCodes.BUSINESS_MAX_CAPACITY_REACHED, {
+            userMessage: '모집 인원이 마감되었습니다',
+          });
+        }
+        return {
+          applicationId: id,
+          workLogIds: [`work-${id}`],
+          message: '확정 완료',
+          historyEntry: {},
+        };
+      });
+
+      const result = await bulkConfirmApplications(['app-1', 'app-2'], 'employer-1');
+
+      expect(result.successCount).toBe(1);
+      expect(result.failedCount).toBe(1);
+      const capacityFailures = result.failed.filter(
+        (f) => f.code === MockCodes.BUSINESS_MAX_CAPACITY_REACHED
+      );
+      expect(capacityFailures).toHaveLength(1);
+      expect(capacityFailures[0]?.applicationId).toBe('app-2');
+      expect(capacityFailures[0]?.reason).toBe('모집 인원이 마감되었습니다');
     });
 
     it('모두 실패 시 빈 workLogIds를 반환해야 함', async () => {
@@ -802,6 +841,105 @@ describe('applicantManagementService', () => {
 
       expect((result as Record<string, ApplicationStats>).floor.total).toBe(1);
       expect((result as Record<string, ApplicationStats>).floor.confirmed).toBe(1);
+    });
+
+    it('한 지원자가 여러 역할을 선택하면 각 역할에 모두 집계해야 함', async () => {
+      const mockResult: ApplicantListWithStats = {
+        applications: [
+          createMockApplication({
+            id: 'app-1',
+            status: 'confirmed',
+            assignments: [
+              {
+                dates: ['2024-02-01'],
+                roleIds: ['dealer', 'floor'],
+                timeSlot: '09:00-18:00',
+                isGrouped: false,
+              },
+            ],
+          }),
+        ] as Application[],
+        stats: createMockStats({ total: 1, confirmed: 1 }),
+      };
+
+      mockFindByJobPostingWithStats.mockResolvedValue(mockResult);
+
+      const result = await getApplicantStatsByRole('job-1', 'employer-1');
+
+      // dealer/floor 각각 1건씩 집계되어야 함 (primaryRole만 보던 기존 버그 회귀 가드)
+      expect(result.dealer.total).toBe(1);
+      expect(result.dealer.confirmed).toBe(1);
+      expect((result as Record<string, ApplicationStats>).floor.total).toBe(1);
+      expect((result as Record<string, ApplicationStats>).floor.confirmed).toBe(1);
+    });
+
+    it('여러 assignment에 걸친 역할을 모두 집계해야 함', async () => {
+      const mockResult: ApplicantListWithStats = {
+        applications: [
+          createMockApplication({
+            id: 'app-1',
+            status: 'applied',
+            assignments: [
+              {
+                dates: ['2024-02-01'],
+                roleIds: ['dealer'],
+                timeSlot: '09:00-18:00',
+                isGrouped: false,
+              },
+              {
+                dates: ['2024-02-02'],
+                roleIds: ['manager'],
+                timeSlot: '09:00-18:00',
+                isGrouped: false,
+              },
+            ],
+          }),
+        ] as Application[],
+        stats: createMockStats({ total: 1, applied: 1 }),
+      };
+
+      mockFindByJobPostingWithStats.mockResolvedValue(mockResult);
+
+      const result = await getApplicantStatsByRole('job-1', 'employer-1');
+
+      expect(result.dealer.total).toBe(1);
+      expect(result.dealer.applied).toBe(1);
+      expect(result.manager.total).toBe(1);
+      expect(result.manager.applied).toBe(1);
+    });
+
+    it('동일 역할이 여러 assignment에 중복되면 1회만 집계해야 함', async () => {
+      const mockResult: ApplicantListWithStats = {
+        applications: [
+          createMockApplication({
+            id: 'app-1',
+            status: 'confirmed',
+            assignments: [
+              {
+                dates: ['2024-02-01'],
+                roleIds: ['dealer'],
+                timeSlot: '09:00-18:00',
+                isGrouped: false,
+              },
+              {
+                dates: ['2024-02-02'],
+                roleIds: ['dealer'],
+                timeSlot: '19:00-22:00',
+                isGrouped: false,
+              },
+            ],
+          }),
+        ] as Application[],
+        stats: createMockStats({ total: 1, confirmed: 1 }),
+      };
+
+      mockFindByJobPostingWithStats.mockResolvedValue(mockResult);
+
+      const result = await getApplicantStatsByRole('job-1', 'employer-1');
+
+      // 중복 역할은 지원자 단위로 1회만 집계 (총합 왜곡 방지)
+      expect(result.dealer.total).toBe(1);
+      expect(result.dealer.confirmed).toBe(1);
     });
   });
 

--- a/uniqn-mobile/src/services/jobs/__tests__/jobManagementService.outbox.test.ts
+++ b/uniqn-mobile/src/services/jobs/__tests__/jobManagementService.outbox.test.ts
@@ -3,6 +3,10 @@
  *
  * 기존 syncScheduleBoardSafely (fire-and-forget)가 outbox insert로 교체되었음을 확인.
  * 6개 mutation이 각각 올바른 action으로 outbox에 row를 enqueue하는지 검증.
+ *
+ * U4: outbox insert(snake_case 매핑)가 Repository.enqueueScheduleBoardSync 로 이관됨.
+ * Service 는 Repository 메서드만 호출하므로, 모킹된 repo 의 enqueueScheduleBoardSync 가
+ * snake_case row 를 supabase mock 에 insert 하도록 하여 기존 assertion 을 유지한다.
  */
 
 import {
@@ -35,6 +39,22 @@ jest.mock('@/repositories', () => ({
     getStatsByOwnerId: jest.fn(),
     getById: jest.fn(),
     updateStatus: jest.fn(),
+    // U4: Service 는 repo 메서드만 호출. 실제 구현과 동일한 snake_case 매핑으로
+    // outbox row 를 mock 에 insert 하여 enqueue 의도 assertion 을 검증한다.
+    enqueueScheduleBoardSync: (
+      jobPostingId: string,
+      action: string,
+      payload: Record<string, unknown> = {}
+    ) => {
+      mockOutboxInsert({
+        job_posting_id: jobPostingId,
+        action,
+        payload,
+        status: 'pending',
+        retry_count: 0,
+      });
+      return Promise.resolve();
+    },
   },
 }));
 

--- a/uniqn-mobile/src/services/jobs/__tests__/jobManagementService.test.ts
+++ b/uniqn-mobile/src/services/jobs/__tests__/jobManagementService.test.ts
@@ -19,6 +19,7 @@ const mockGetStatsByOwnerId = jest.fn();
 const mockBulkUpdateStatus = jest.fn();
 const mockGetById = jest.fn();
 const mockUpdateStatus = jest.fn();
+const mockEnqueueScheduleBoardSync = jest.fn();
 const mockGetDefaultWorkspaceIdForOwner = jest.fn();
 
 jest.mock('@/repositories', () => ({
@@ -32,6 +33,7 @@ jest.mock('@/repositories', () => ({
     bulkUpdateStatus: (...args: unknown[]) => mockBulkUpdateStatus(...args),
     getById: (...args: unknown[]) => mockGetById(...args),
     updateStatus: (...args: unknown[]) => mockUpdateStatus(...args),
+    enqueueScheduleBoardSync: (...args: unknown[]) => mockEnqueueScheduleBoardSync(...args),
   },
 }));
 

--- a/uniqn-mobile/src/services/jobs/applicantManagementService.ts
+++ b/uniqn-mobile/src/services/jobs/applicantManagementService.ts
@@ -40,10 +40,23 @@ export interface ConfirmResult {
   message: string;
 }
 
+/** 일괄 확정 중 개별 실패 항목 (UI가 사유별로 구분 가능하도록 구조화) */
+export interface BulkConfirmFailure {
+  /** 실패한 지원 ID */
+  applicationId: string;
+  /** AppError 코드 (예: BUSINESS_MAX_CAPACITY_REACHED). 비-AppError 실패 시 undefined */
+  code?: string;
+  /** 사용자 노출용 실패 사유 메시지 */
+  reason: string;
+}
+
 export interface BulkConfirmResult {
   successCount: number;
   failedCount: number;
+  /** 실패한 지원 ID 목록 (호환용 — 사유는 failed 사용) */
   failedIds: string[];
+  /** 실패 항목별 사유 (정원마감 N건 등 구분용) */
+  failed: BulkConfirmFailure[];
   workLogIds: string[];
 }
 
@@ -175,6 +188,7 @@ export async function bulkConfirmApplications(
       successCount: 0,
       failedCount: 0,
       failedIds: [],
+      failed: [],
       workLogIds: [],
     };
 
@@ -186,7 +200,19 @@ export async function bulkConfirmApplications(
       } catch (error) {
         result.failedCount++;
         result.failedIds.push(applicationId);
-        logger.warn('일괄 확정 중 개별 확정 실패', { applicationId, error });
+        // AppError면 code/userMessage를 캡처해 UI가 사유별(정원마감 등) 구분 가능하게 한다.
+        const failure: BulkConfirmFailure = isAppError(error)
+          ? {
+              applicationId,
+              code: error.code,
+              reason: error.userMessage || error.message,
+            }
+          : {
+              applicationId,
+              reason: error instanceof Error ? error.message : String(error),
+            };
+        result.failed.push(failure);
+        logger.warn('일괄 확정 중 개별 확정 실패', { applicationId, code: failure.code, error });
       }
     }
 
@@ -230,13 +256,9 @@ export async function getApplicantStatsByRole(
     const { applicants } = await getApplicantsByJobPosting(jobPostingId, ownerId);
     const statsByRole: Record<string, ApplicationStats> = {};
 
-    applicants.forEach((application) => {
-      const primaryRole = application.assignments[0]?.roleIds?.[0] || 'other';
-      const effectiveRole =
-        primaryRole === 'other' && application.customRole ? application.customRole : primaryRole;
-
-      if (!statsByRole[effectiveRole]) {
-        statsByRole[effectiveRole] = {
+    const ensureBucket = (role: string): ApplicationStats => {
+      if (!statsByRole[role]) {
+        statsByRole[role] = {
           total: 0,
           applied: 0,
           confirmed: 0,
@@ -246,13 +268,27 @@ export async function getApplicantStatsByRole(
           cancellationPending: 0,
         };
       }
+      return statsByRole[role];
+    };
 
-      statsByRole[effectiveRole].total++;
+    applicants.forEach((application) => {
+      // 한 지원자가 여러 assignment·여러 역할을 선택할 수 있으므로 전체를 순회해
+      // 각 역할별로 카운트한다 (중복 역할은 1회만 집계).
+      const rawRoles = application.assignments.flatMap((assignment) => assignment.roleIds ?? []);
+      const effectiveRoles = (rawRoles.length > 0 ? rawRoles : ['other']).map((role) =>
+        role === 'other' && application.customRole ? application.customRole : role
+      );
+      const uniqueRoles = Array.from(new Set(effectiveRoles));
 
       const statsKey = STATUS_TO_STATS_KEY[application.status];
-      if (statsKey && statsKey !== 'total') {
-        statsByRole[effectiveRole][statsKey]++;
-      }
+
+      uniqueRoles.forEach((role) => {
+        const bucket = ensureBucket(role);
+        bucket.total++;
+        if (statsKey && statsKey !== 'total') {
+          bucket[statsKey]++;
+        }
+      });
     });
 
     logger.info('역할별 지원자 통계 조회 완료', { jobPostingId, statsByRole });

--- a/uniqn-mobile/src/services/jobs/jobManagementService.ts
+++ b/uniqn-mobile/src/services/jobs/jobManagementService.ts
@@ -2,10 +2,13 @@ import { logger } from '@/utils/logger';
 import { handleServiceError } from '@/errors/serviceErrorHandler';
 import { jobPostingRepository } from '@/repositories';
 import { workspaceService } from '@/services/workspace';
-import { supabase } from '@/lib/supabase';
 import { BusinessError, ERROR_CODES } from '@/errors';
 import type { TaxSettings } from '@/utils/settlement';
-import type { CreateJobPostingResult, JobPostingStats } from '@/repositories';
+import type {
+  CreateJobPostingResult,
+  JobPostingStats,
+  ScheduleBoardSyncAction,
+} from '@/repositories';
 import type {
   CreateJobPostingInput,
   JobPosting,
@@ -13,7 +16,7 @@ import type {
   UpdateJobPostingInput,
 } from '@/types';
 
-export type { CreateJobPostingResult, JobPostingStats };
+export type { CreateJobPostingResult, JobPostingStats, ScheduleBoardSyncAction };
 
 // =============================================================================
 // T-B7+B8: schedule_board_sync_outbox 패턴
@@ -21,34 +24,18 @@ export type { CreateJobPostingResult, JobPostingStats };
 // fire-and-forget syncScheduleBoardSafely 제거. 모든 board sync 의도를
 // outbox 테이블에 영속화하고 sync-schedule-board-outbox Edge Function이
 // poll → sync_schedule_board RPC 호출 → status 업데이트로 처리.
+//
+// U4: outbox insert(snake_case 매핑)는 Repository 로 이관. Service 는 enqueue
+// 의도만 표현하며, enqueue 실패가 main mutation 을 롤백시키지 않는 동작은
+// Repository 내부에서 동일하게 유지된다.
 // =============================================================================
-
-export type ScheduleBoardSyncAction = 'create' | 'update' | 'delete' | 'close' | 'reopen';
 
 export async function enqueueScheduleBoardSync(
   jobPostingId: string,
   action: ScheduleBoardSyncAction,
   payload: Record<string, unknown> = {}
 ): Promise<void> {
-  const { error } = await supabase.from('schedule_board_sync_outbox').insert({
-    job_posting_id: jobPostingId,
-    action,
-    payload,
-    status: 'pending',
-    retry_count: 0,
-  });
-
-  if (error) {
-    // outbox insert 실패는 main mutation을 롤백시키지 않음.
-    // 사용자 경험 보호 차원에서 warn 로그만 남기고, outbox failed_retry_limit
-    // 모니터링 + 수동 백필이 안전망. 이는 아키텍처 결정.
-    logger.warn('Schedule board sync enqueue 실패', {
-      component: 'jobManagementService',
-      jobPostingId,
-      action,
-      error: error.message,
-    });
-  }
+  await jobPostingRepository.enqueueScheduleBoardSync(jobPostingId, action, payload);
 }
 
 /**

--- a/uniqn-mobile/src/services/observability/tokenRefreshService.ts
+++ b/uniqn-mobile/src/services/observability/tokenRefreshService.ts
@@ -403,9 +403,13 @@ export function start(
   appStateSubscription = AppState.addEventListener('change', handleAppStateChange);
 
   // 초기 네트워크 상태 확인
-  NetInfo.fetch().then((netState) => {
-    isOnline = netState.isConnected === true && netState.isInternetReachable !== false;
-  });
+  NetInfo.fetch()
+    .then((netState) => {
+      isOnline = netState.isConnected === true && netState.isInternetReachable !== false;
+    })
+    .catch((error) => {
+      logger.warn('초기 네트워크 상태 조회 실패', { error: toError(error).message });
+    });
 
   // 초기 앱 상태
   appState = AppState.currentState;

--- a/uniqn-mobile/src/shared/status/types.ts
+++ b/uniqn-mobile/src/shared/status/types.ts
@@ -26,7 +26,8 @@ export type ApplicationStatus =
 
 export type ScheduleType = 'applied' | 'confirmed' | 'completed' | 'cancelled';
 
-export type PayrollStatus = 'pending' | 'processing' | 'completed';
+// DB enum payroll_status = ['pending','completed','failed']. 'processing'는 UI 표시 전용 값.
+export type PayrollStatus = 'pending' | 'processing' | 'completed' | 'failed';
 
 export const ATTENDANCE_STATUS_LABELS: Record<AttendanceStatus, string> = {
   not_started: '출근 전',
@@ -72,4 +73,5 @@ export const PAYROLL_STATUS_LABELS: Record<PayrollStatus, string> = {
   pending: '대기',
   processing: '처리 중',
   completed: '완료',
+  failed: '실패',
 };

--- a/uniqn-mobile/src/utils/__tests__/supabase.test.ts
+++ b/uniqn-mobile/src/utils/__tests__/supabase.test.ts
@@ -1,4 +1,5 @@
-import { toCamelCase, toSnakeCase } from '@/utils/supabase';
+import { handleSupabaseError, toCamelCase, toSnakeCase } from '@/utils/supabase';
+import { ERROR_CODES, isMaxCapacityReachedError } from '@/errors';
 
 describe('toCamelCase', () => {
   describe('기본 변환', () => {
@@ -112,6 +113,48 @@ describe('toCamelCase', () => {
         nestedObj: nested, // 중첩 객체는 변환 안 함 (키만 camelCase)
       });
     });
+  });
+});
+
+describe('handleSupabaseError — P0001 (plpgsql RAISE EXCEPTION)', () => {
+  it('P0001 + MAX_CAPACITY_REACHED → MaxCapacityReachedError (클라 사전검사와 동일 메시지)', () => {
+    try {
+      handleSupabaseError(
+        {
+          code: 'P0001',
+          message: 'MAX_CAPACITY_REACHED: 모집 인원 5명 초과',
+          details: '',
+          hint: '',
+        },
+        { operation: 'rpc:confirm_application', table: 'applications' }
+      );
+      throw new Error('should have thrown');
+    } catch (error) {
+      expect(isMaxCapacityReachedError(error)).toBe(true);
+      const appError = error as { code: string; userMessage: string };
+      expect(appError.code).toBe(ERROR_CODES.BUSINESS_MAX_CAPACITY_REACHED);
+      // userMessage는 클라 사전검사 경로(MaxCapacityReachedError 기본값)와 일원화
+      expect(appError.userMessage).toBe('모집 인원이 마감되었습니다');
+    }
+  });
+
+  it('P0001 이지만 MAX_CAPACITY 메시지 아님 → 정원마감 매핑 안 함 (기존 동작 유지)', () => {
+    try {
+      handleSupabaseError(
+        {
+          code: 'P0001',
+          message: 'SOME_OTHER_BUSINESS_ERROR: 다른 사유',
+          details: '',
+          hint: '',
+        },
+        { operation: 'rpc:other', table: 'applications' }
+      );
+      throw new Error('should have thrown');
+    } catch (error) {
+      expect(isMaxCapacityReachedError(error)).toBe(false);
+      const appError = error as { code: string };
+      expect(appError.code).toBe(ERROR_CODES.UNKNOWN);
+    }
   });
 });
 

--- a/uniqn-mobile/src/utils/supabase.ts
+++ b/uniqn-mobile/src/utils/supabase.ts
@@ -19,6 +19,7 @@ import { logger } from '@/utils/logger';
 import {
   AppError,
   BusinessError,
+  MaxCapacityReachedError,
   NetworkError,
   PermissionError,
   AuthError as AppAuthError,
@@ -95,6 +96,20 @@ export function handleSupabaseError(error: unknown, context: SupabaseErrorContex
   // PostgrestError 형태 ({ code, message, details, hint })
   if (isPostgrestError(error)) {
     metadata.supabaseCode = error.code;
+
+    // P0001 = plpgsql RAISE EXCEPTION (서버 RPC가 던지는 비즈니스 예외).
+    // 정원초과(`MAX_CAPACITY_REACHED: ...`)는 클라 사전검사(MaxCapacityReachedError)와
+    // 동일한 사용자 메시지로 일원화한다. POSTGREST_ERROR_MAP에는 P0001이 없으므로
+    // (없으면 UNKNOWN으로 raw 영문 노출) 매핑 조회 전에 우선 분기한다.
+    // 다른 P0001 메시지는 아래 일반 흐름(UNKNOWN/infrastructure)으로 처리한다.
+    if (error.code === 'P0001' && error.message.includes('MAX_CAPACITY')) {
+      throw new MaxCapacityReachedError({
+        message: error.message,
+        // userMessage 미지정 → ERROR_CODES 기반 기본 메시지('모집 인원이 마감되었습니다') 사용
+        // 으로 클라 사전검사 경로와 동일한 문구를 보장한다.
+      });
+    }
+
     const mapping = POSTGREST_ERROR_MAP[error.code];
 
     if (mapping) {
@@ -643,6 +658,12 @@ export function clearRealtimeRegistry(): void {
  * @param obj - camelCase 키를 가진 객체
  * @returns snake_case 키를 가진 새 객체 (원본 불변)
  *
+ * @remarks
+ * **계약: top-level 키만 변환한다(shallow, 재귀 없음).** 중첩 객체/배열의 내부 키는
+ * 변환하지 않으므로, JSONB 컬럼에 저장하는 값은 호출자가 직접 적절한 형태로 만들어야 한다.
+ * 권위(authority)는 camelCase이며, JSONB 컬럼 내부도 camelCase로 저장돼 있어야
+ * 읽기 시 Zod 파싱이 통과한다(읽기 경로는 JSONB 내부를 재귀 변환하지 않음).
+ *
  * @example
  * ```typescript
  * toSnakeCase({ userId: '1', createdAt: new Date() })
@@ -668,6 +689,12 @@ export function toSnakeCase(obj: Record<string, unknown>): Record<string, unknow
  *              Repository 레이어의 읽기 작업에서 사용.
  * @param obj - snake_case 키를 가진 객체
  * @returns camelCase 키를 가진 새 객체 (원본 불변)
+ *
+ * @remarks
+ * **계약: top-level 키만 변환한다(shallow, 재귀 없음).** JSONB 컬럼의 값은 객체/배열로
+ * 통째로 전달될 뿐 내부 키는 변환되지 않는다. 따라서 JSONB는 camelCase로 저장돼 있어야
+ * 후속 Zod 파싱이 통과한다(권위=camelCase). snake_case로 저장된 JSONB는 변환되지 않아
+ * 파싱에서 reject될 수 있다.
  *
  * @example
  * ```typescript


### PR DESCRIPTION
## 개요
앱 전체 워크플로우/의존성/정합성 멀티에이전트 리뷰 → **백로그 1단계 구현(C1~C9)** + **U9 800줄 파일 분할** + 사전존재 테스트 1건 해소. 12커밋, master(`5dabbd78c`) 위 fast-forward(충돌 0).

## 변경 그룹

### 정합성/안정성 (C1~C9)
- **C1** `fix(schema)` enum 발산 정리 — payroll/posting/application status를 generated Constants 단일출처 파생, workLog payrollStatus `.optional().catch()` (미지값 read 증발 방지)
- **C2** `fix(error)` P0001(plpgsql RAISE) → MaxCapacityReachedError 매핑 (정원초과 영문 raw 노출 차단) + toCamelCase 계약 JSDoc
- **C3** `fix(jobs)` QR 체크인 로그 정확성 / bulkConfirm 실패 구조화 / 역할통계 다중역할 전체집계
- **C4** `refactor(repo)` IWallet/IEmployerApplication 인터페이스 신설 + outbox insert 캡슐화 + reject reason XSS 검증
- **C6** `refactor(job-posting)` filledPositions 단일 권위 + divergence 관측
- **C7** `fix(auth)` NetInfo.fetch floating promise `.catch`
- **C5** `chore(deps)` 미사용 expo-intent-launcher 제거
- **C8** `refactor(ui)` FlashList @ts-expect-error 14곳 → AppFlashList<T> 래퍼 DRY
- **C9** `fix(jobs)` 일괄확정 실패 토스트 정원마감 사유 노출 (BulkConfirmResult `failed[]` 계약 확장)

### U9 — 800줄 파일 분할 (순수 이동)
- `refactor(repo)` BoardRepository 836→601 (댓글 CRUD 6 → BoardRepositoryComments, 공통 rethrowRepositoryError를 Helpers로 공유)
- `refactor(repo)` ApplicationRepository 840→541 (읽기8+구독2 → ApplicationRepositoryQueries, executeXxx/subscribeXxx 자유함수, 클래스 delegate만)
- export 경로·메서드 시그니처·index.ts 불변 → **호출부 변경 0**. fresh-context 적대 리뷰 line-by-line "PURE MOVE CONFIRMED"

### 회귀 가드
- `test(applicant)` C9 계약 변경(`failedIds`→`failed[]`)으로 stale 됐던 useApplicantManagement hook 테스트 mock 정합 + 정원마감 메시지 회귀 테스트 신규

## 검증
- tsc 0 / eslint 0 errors / **jest 4324 pass / 0 fail** / `npm run quality` EXIT 0

## Test plan
- [ ] CI e2e green 확인
- [ ] (배포 별도) 웹 Cloudflare 재배포 + 모바일 EAS OTA — 머지만으론 프로덕션 미반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)