### PR TITLE
feat(wallet): featured/extend 스캐폴드 (Lane D, 마이그 미적용·DRAFT)

### DIFF
--- a/uniqn-mobile/src/hooks/useExtendJobPosting.ts
+++ b/uniqn-mobile/src/hooks/useExtendJobPosting.ts
@@ -1,0 +1,50 @@
+/**
+ * UNIQN Mobile - 공고 기간 연장 hook (Lane D — featured/extend, 마이그 미적용 DRAFT)
+ *
+ * @description extend_job_posting RPC 배선. 다이아 차감 + 근무일/만료일 연장 + 재오픈은
+ *   서버(RPC) 권위. 성공 시 toast + jobManagement/jobPostings 쿼리 무효화.
+ *   ⚠️ RPC 가 prod 에 미적용(DRAFT)이라 현재 UI 노출은 없음.
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { extendJobPosting } from '@/services';
+import { getJobDetailQueryKey } from '@/hooks/useJobDetail';
+import { queryKeys } from '@/lib/queryClient';
+import { useToastStore } from '@/stores/toastStore';
+import { useAuthStore } from '@/stores/authStore';
+import { logger } from '@/utils/logger';
+import { createMutationErrorHandler } from '@/shared/errors';
+import { requireAuth } from '@/errors';
+import { requireOnlineForMutation } from '@/services/offline/remoteMutationGuard';
+
+interface ExtendJobParams {
+  jobPostingId: string;
+  extendDays?: number;
+}
+
+export function useExtendJobPosting() {
+  const queryClient = useQueryClient();
+  const { addToast } = useToastStore();
+  const { user } = useAuthStore();
+
+  return useMutation({
+    mutationFn: ({ jobPostingId, extendDays }: ExtendJobParams) => {
+      requireAuth(user?.uid, 'useExtendJobPosting');
+      requireOnlineForMutation('useExtendJobPosting.extendJobPosting');
+      return extendJobPosting(jobPostingId, user.uid, extendDays);
+    },
+    onSuccess: (_, { jobPostingId }) => {
+      logger.info('공고 연장 완료', { jobPostingId });
+      addToast({ type: 'success', message: '공고 기간이 연장되었습니다.' });
+
+      queryClient.invalidateQueries({ queryKey: queryKeys.jobManagement.all });
+      queryClient.invalidateQueries({
+        queryKey: getJobDetailQueryKey(jobPostingId, user?.uid),
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.jobPostings.lists() });
+    },
+    onError: createMutationErrorHandler('공고 연장', addToast),
+  });
+}
+
+export default useExtendJobPosting;

--- a/uniqn-mobile/src/repositories/interfaces/IJobPostingRepository.ts
+++ b/uniqn-mobile/src/repositories/interfaces/IJobPostingRepository.ts
@@ -254,6 +254,16 @@ export interface IJobPostingRepository {
   reopenWithTransaction(jobPostingId: string, ownerId: string): Promise<void>;
 
   /**
+   * 공고 기간 연장 (Lane D — featured/extend, 마이그 미적용 DRAFT)
+   *
+   * extend_job_posting RPC 를 호출해 다이아 차감 + 근무일/만료일 연장 + (필요 시) 재오픈.
+   * @param jobPostingId - 공고 ID
+   * @param ownerId - 연장 요청자(소유자) ID — RPC 내부에서 소유자 검증
+   * @param extendDays - 연장 일수(기본 7)
+   */
+  extendWithTransaction(jobPostingId: string, ownerId: string, extendDays?: number): Promise<void>;
+
+  /**
    * 소유자별 공고 통계 조회
    * @param ownerId - 소유자 ID
    * @returns 공고 통계

--- a/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
@@ -110,6 +110,7 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
   ): Promise<PaginatedJobPostings> {
     try {
       logger.info('공고 목록 조회', { filters, pageSize });
+      // TODO(Lane D): 마이그 적용 후 priority DESC 정렬 추가
       const result = await paginatedQuery<Record<string, unknown>>(TABLE, {
         orderBy: 'work_date',
         ascending: false,
@@ -500,6 +501,40 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
       logger.info('공고 재오픈 완료', { jobPostingId });
     } catch (error) {
       rethrowOrHandle(error, '공고 재오픈', { jobPostingId });
+    }
+  }
+
+  /**
+   * 공고 기간 연장 (Lane D — featured/extend, 마이그 미적용 DRAFT).
+   * 소유자 검증/다이아 차감/날짜 연장/재오픈은 모두 extend_job_posting RPC 내부에서 수행.
+   */
+  async extendWithTransaction(
+    jobPostingId: string,
+    ownerId: string,
+    extendDays?: number
+  ): Promise<void> {
+    try {
+      logger.info('공고 연장', { jobPostingId, ownerId, extendDays: extendDays ?? 7 });
+      // Lane D draft: RPC 미적용 → 타입 부재. 마이그 적용 후 generate types로 캐스트 제거.
+      const { error } = await (
+        supabase.rpc as unknown as (
+          fn: string,
+          args: Record<string, unknown>
+        ) => Promise<{ error: unknown }>
+      )('extend_job_posting', {
+        p_posting_id: jobPostingId,
+        p_owner_id: ownerId,
+        p_extend_days: extendDays ?? 7,
+      });
+      if (error) {
+        handleSupabaseError(error as Parameters<typeof handleSupabaseError>[0], {
+          operation: '공고 연장',
+          table: TABLE,
+        });
+      }
+      logger.info('공고 연장 완료', { jobPostingId });
+    } catch (error) {
+      rethrowOrHandle(error, '공고 연장', { jobPostingId });
     }
   }
 

--- a/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.extend.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.extend.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Lane D (featured/extend) — extendWithTransaction RPC 배선 검증.
+ *
+ * @description extend_job_posting RPC 가 prod 에 미적용(DRAFT)이라 타입 부재.
+ *   Repository 는 localized cast 로 호출하며, 본 테스트는:
+ *   1) supabase.rpc('extend_job_posting', {p_posting_id, p_owner_id, p_extend_days}) 호출
+ *   2) extendDays 미지정 시 default 7
+ *   3) RPC error 시 rethrow
+ *   를 검증한다.
+ */
+
+import { SupabaseJobPostingRepository } from '../JobPostingRepository';
+
+const mockRpc = jest.fn();
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(),
+    rpc: (...args: unknown[]) => mockRpc(...args),
+    channel: jest.fn(),
+  },
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('@/utils/supabase', () => {
+  const actual = jest.requireActual('@/utils/supabase');
+  return {
+    ...actual,
+    handleSupabaseError: (error: { message?: string } | null) => {
+      if (error) throw new Error(`supabase: ${error.message ?? 'unknown'}`);
+    },
+  };
+});
+
+jest.mock('@sentry/react-native', () => ({
+  __esModule: true,
+  addBreadcrumb: jest.fn(),
+}));
+
+const POSTING_ID = '55555555-5555-4555-8555-555555555555';
+const OWNER_ID = '11111111-1111-4111-8111-111111111111';
+
+beforeEach(() => {
+  mockRpc.mockReset();
+});
+
+describe('JobPostingRepository.extendWithTransaction (Lane D draft)', () => {
+  const repo = new SupabaseJobPostingRepository();
+
+  it('extend_job_posting RPC 를 default 7일로 호출한다', async () => {
+    mockRpc.mockResolvedValue({ error: null });
+
+    await repo.extendWithTransaction(POSTING_ID, OWNER_ID);
+
+    expect(mockRpc).toHaveBeenCalledWith('extend_job_posting', {
+      p_posting_id: POSTING_ID,
+      p_owner_id: OWNER_ID,
+      p_extend_days: 7,
+    });
+  });
+
+  it('extendDays 를 명시하면 그대로 전달한다', async () => {
+    mockRpc.mockResolvedValue({ error: null });
+
+    await repo.extendWithTransaction(POSTING_ID, OWNER_ID, 14);
+
+    expect(mockRpc).toHaveBeenCalledWith('extend_job_posting', {
+      p_posting_id: POSTING_ID,
+      p_owner_id: OWNER_ID,
+      p_extend_days: 14,
+    });
+  });
+
+  it('RPC error 시 rethrow 한다', async () => {
+    mockRpc.mockResolvedValue({ error: { message: 'INSUFFICIENT_BALANCE' } });
+
+    await expect(repo.extendWithTransaction(POSTING_ID, OWNER_ID)).rejects.toThrow();
+  });
+});

--- a/uniqn-mobile/src/services/jobs/__tests__/jobManagementService.test.ts
+++ b/uniqn-mobile/src/services/jobs/__tests__/jobManagementService.test.ts
@@ -5,6 +5,7 @@ import {
   closeJobPosting,
   createJobPosting,
   deleteJobPosting,
+  extendJobPosting,
   getMyJobPostingStats,
   reopenJobPosting,
   updateJobPosting,
@@ -15,6 +16,7 @@ const mockUpdateWithTransaction = jest.fn();
 const mockDeleteWithTransaction = jest.fn();
 const mockCloseWithTransaction = jest.fn();
 const mockReopenWithTransaction = jest.fn();
+const mockExtendWithTransaction = jest.fn();
 const mockGetStatsByOwnerId = jest.fn();
 const mockBulkUpdateStatus = jest.fn();
 const mockGetById = jest.fn();
@@ -29,6 +31,7 @@ jest.mock('@/repositories', () => ({
     deleteWithTransaction: (...args: unknown[]) => mockDeleteWithTransaction(...args),
     closeWithTransaction: (...args: unknown[]) => mockCloseWithTransaction(...args),
     reopenWithTransaction: (...args: unknown[]) => mockReopenWithTransaction(...args),
+    extendWithTransaction: (...args: unknown[]) => mockExtendWithTransaction(...args),
     getStatsByOwnerId: (...args: unknown[]) => mockGetStatsByOwnerId(...args),
     bulkUpdateStatus: (...args: unknown[]) => mockBulkUpdateStatus(...args),
     getById: (...args: unknown[]) => mockGetById(...args),
@@ -438,6 +441,28 @@ describe('jobManagementService', () => {
       expect(mockDeleteWithTransaction).toHaveBeenCalledWith('job-1', 'employer-1');
       expect(mockCloseWithTransaction).toHaveBeenCalledWith('job-1', 'employer-1');
       expect(mockReopenWithTransaction).toHaveBeenCalledWith('job-1', 'employer-1');
+    });
+
+    // Lane D (featured/extend) — RPC 미적용 DRAFT
+    it('delegates extend to repository (default + 명시 days)', async () => {
+      mockExtendWithTransaction.mockResolvedValue(undefined);
+
+      await extendJobPosting('job-1', 'employer-1');
+      await extendJobPosting('job-1', 'employer-1', 14);
+
+      expect(mockExtendWithTransaction).toHaveBeenNthCalledWith(
+        1,
+        'job-1',
+        'employer-1',
+        undefined
+      );
+      expect(mockExtendWithTransaction).toHaveBeenNthCalledWith(2, 'job-1', 'employer-1', 14);
+    });
+
+    it('extend 실패 시 handleServiceError 로 래핑해 rethrow', async () => {
+      mockExtendWithTransaction.mockRejectedValue(new Error('INSUFFICIENT_BALANCE'));
+
+      await expect(extendJobPosting('job-1', 'employer-1')).rejects.toThrow('INSUFFICIENT_BALANCE');
     });
 
     it('delegates stats and bulk status queries', async () => {

--- a/uniqn-mobile/src/services/jobs/index.ts
+++ b/uniqn-mobile/src/services/jobs/index.ts
@@ -48,6 +48,7 @@ export {
   deleteJobPosting,
   closeJobPosting,
   reopenJobPosting,
+  extendJobPosting,
   getMyJobPostingStats,
   bulkUpdateJobPostingStatus,
   updateJobPostingSettlementSettings,

--- a/uniqn-mobile/src/services/jobs/jobManagementService.ts
+++ b/uniqn-mobile/src/services/jobs/jobManagementService.ts
@@ -166,6 +166,30 @@ export async function reopenJobPosting(jobPostingId: string, ownerId: string): P
   }
 }
 
+/**
+ * 공고 기간 연장 (Lane D — featured/extend, 마이그 미적용 DRAFT).
+ * 다이아 차감 + 근무일/만료일 연장 + 재오픈은 extend_job_posting RPC 내부 처리.
+ * 날짜가 바뀌므로 보드 동기화는 'update' 액션으로 트리거.
+ */
+export async function extendJobPosting(
+  jobPostingId: string,
+  ownerId: string,
+  extendDays?: number
+): Promise<void> {
+  try {
+    logger.info('공고 연장 시작', { jobPostingId, ownerId, extendDays: extendDays ?? 7 });
+    await jobPostingRepository.extendWithTransaction(jobPostingId, ownerId, extendDays);
+    await enqueueScheduleBoardSync(jobPostingId, 'update', { jobPostingId, ownerId });
+    logger.info('공고 연장 완료', { jobPostingId });
+  } catch (error) {
+    throw handleServiceError(error, {
+      operation: '공고 연장',
+      component: 'jobManagementService',
+      context: { jobPostingId },
+    });
+  }
+}
+
 export async function getMyJobPostingStats(ownerId: string): Promise<JobPostingStats> {
   try {
     logger.info('내 공고 통계 조회', { ownerId });

--- a/uniqn-mobile/supabase/migrations/20260530100000_add_job_posting_priority.sql
+++ b/uniqn-mobile/supabase/migrations/20260530100000_add_job_posting_priority.sql
@@ -1,0 +1,20 @@
+-- ⚠️ DRAFT — NOT APPLIED TO PROD. 유료화(monetization flag) ON 이후 적용. Lane D.
+--
+-- 목적: featured / boost 정렬을 위한 priority 컬럼 + 정렬 인덱스.
+--   priority 가 높을수록 목록 상단에 노출(featured/boost). default 0 = 일반 공고.
+--   유료 featured 결제(Lane D)가 이 값을 올려 노출 우선순위를 부여한다.
+--
+-- ⚠️ 이 컬럼은 prod 에 존재하지 않으며, 적용 전까지 getList/active-postings 의
+--   orderBy 에 priority 를 넣어서는 안 된다(컬럼 부재로 전 read 실패). 클라 코드의
+--   `// TODO(Lane D)` 마커 참조.
+
+ALTER TABLE public.job_postings
+  ADD COLUMN IF NOT EXISTS priority integer NOT NULL DEFAULT 0;
+
+-- featured 정렬용 복합 인덱스: priority DESC(상단 노출) → work_date DESC(최신 근무일).
+--   목록 쿼리가 `ORDER BY priority DESC, work_date DESC` 일 때 인덱스로 정렬 비용 제거.
+CREATE INDEX IF NOT EXISTS idx_job_postings_priority_work_date
+  ON public.job_postings (priority DESC, work_date DESC);
+
+COMMENT ON COLUMN public.job_postings.priority IS
+  'featured/boost 노출 우선순위. 높을수록 목록 상단. default 0 = 일반. Lane D 유료화 적용 후 활성. (DRAFT)';

--- a/uniqn-mobile/supabase/migrations/20260530100100_create_extend_job_posting_rpc.sql
+++ b/uniqn-mobile/supabase/migrations/20260530100100_create_extend_job_posting_rpc.sql
@@ -148,8 +148,9 @@ BEGIN
     work_date = CASE WHEN work_date IS NOT NULL
                      THEN (work_date::date + v_interval)::date::text
                      ELSE work_date END,
+    -- last_work_date 는 date 컬럼 — text 캐스트 금지(CASE 타입 통일: date/date)
     last_work_date = CASE WHEN last_work_date IS NOT NULL
-                          THEN (last_work_date::date + v_interval)::date::text
+                          THEN (last_work_date + v_interval)::date
                           ELSE last_work_date END,
     work_dates = v_new_work_dates,
     fixed_config = CASE WHEN v_expires_at IS NOT NULL

--- a/uniqn-mobile/supabase/migrations/20260530100100_create_extend_job_posting_rpc.sql
+++ b/uniqn-mobile/supabase/migrations/20260530100100_create_extend_job_posting_rpc.sql
@@ -1,0 +1,142 @@
+-- ⚠️ DRAFT — NOT APPLIED TO PROD. 유료화(monetization flag) ON 이후 적용. Lane D.
+--
+-- 목적: 공고 기간 연장(extend) — 고정 비용 다이아 차감 + 근무일/만료일 p_extend_days 만큼
+--   뒤로 밀고, 마감/만료/정원마감 상태면 active 로 재오픈.
+--
+-- 비용/멱등: consume_diamonds_atomically(owner, 5, 'consume_job_extend', posting_id, 'job_posting')
+--   를 통해 5 다이아(하트 우선) 차감. consume 가 INSUFFICIENT_BALANCE 던지면 전체 롤백.
+--   같은 트랜잭션 안에서 차감+연장이 atomic — 부분 적용 없음.
+--
+-- 날짜 연장 설계 결정(draft, 리뷰 시 재검토):
+--   1) work_date / last_work_date: NULL 이 아니면 + p_extend_days 일.
+--   2) work_dates[]: 배열의 각 원소를 + p_extend_days 일(전체 평행 이동). NULL/빈 배열은 무시.
+--   3) fixed_config.expiresAt: 고정공고면 만료 timestamptz 를 + p_extend_days 일.
+--   4) 상태: status IN ('closed','capacity_full') 이거나 closed_reason 이 만료 계열이면
+--      active 로 재오픈하고 closed_at/closed_reason 클리어. cancelled 는 재오픈 금지.
+--   → 어느 날짜 컬럼이 권위인지 스키마상 다중 소스라 "전부 평행 이동"을 택함. 실제 적용 전
+--      도메인 확정(posting_type 별 단일 권위 컬럼) 후 정리 필요.
+--
+-- spec: docs/superpowers/specs (monetization Lane D). 적용 전 /review 필수.
+
+CREATE OR REPLACE FUNCTION public.extend_job_posting(
+  p_posting_id   uuid,
+  p_owner_id     uuid,
+  p_extend_days  integer DEFAULT 7
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_posting        public.job_postings%ROWTYPE;
+  v_consume_result jsonb;
+  v_extend_cost    constant integer := 5;
+  v_interval       interval;
+  v_reopened       boolean := false;
+  v_new_work_dates text[];
+  v_d              text;
+  v_expires_at     timestamptz;
+BEGIN
+  -- 0) 입력 가드
+  IF p_posting_id IS NULL THEN
+    RAISE EXCEPTION 'INVALID_POSTING_ID: cannot be NULL';
+  END IF;
+  IF p_owner_id IS NULL THEN
+    RAISE EXCEPTION 'INVALID_OWNER_ID: cannot be NULL';
+  END IF;
+  IF p_extend_days IS NULL OR p_extend_days <= 0 THEN
+    RAISE EXCEPTION 'INVALID_EXTEND_DAYS: % must be positive', p_extend_days;
+  END IF;
+
+  v_interval := make_interval(days => p_extend_days);
+
+  -- 1) 공고 잠금 + 소유자 검증
+  SELECT * INTO v_posting
+  FROM public.job_postings
+  WHERE id = p_posting_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'POSTING_NOT_FOUND: %', p_posting_id;
+  END IF;
+
+  IF v_posting.owner_id IS DISTINCT FROM p_owner_id THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED: 본인 공고만 연장할 수 있습니다';
+  END IF;
+
+  -- cancelled 공고는 연장/재오픈 불가
+  IF v_posting.status = 'cancelled' THEN
+    RAISE EXCEPTION 'INVALID_STATE: 취소된 공고는 연장할 수 없습니다';
+  END IF;
+
+  -- 2) 고정 비용 다이아 차감 (실패 시 전체 트랜잭션 롤백)
+  v_consume_result := public.consume_diamonds_atomically(
+    p_owner_id,
+    v_extend_cost,
+    'consume_job_extend',
+    p_posting_id,
+    'job_posting'
+  );
+
+  -- 3) work_dates[] 각 원소 평행 이동
+  IF v_posting.work_dates IS NOT NULL THEN
+    v_new_work_dates := ARRAY[]::text[];
+    FOREACH v_d IN ARRAY v_posting.work_dates LOOP
+      v_new_work_dates := array_append(
+        v_new_work_dates,
+        ((v_d::date) + v_interval)::date::text
+      );
+    END LOOP;
+  ELSE
+    v_new_work_dates := v_posting.work_dates;
+  END IF;
+
+  -- 4) fixed_config.expiresAt 연장 (고정공고)
+  v_expires_at := NULL;
+  IF v_posting.fixed_config IS NOT NULL
+     AND (v_posting.fixed_config ->> 'expiresAt') IS NOT NULL THEN
+    v_expires_at := (v_posting.fixed_config ->> 'expiresAt')::timestamptz + v_interval;
+  END IF;
+
+  -- 5) 재오픈 여부 판단 (closed/capacity_full 또는 만료 계열)
+  v_reopened := (
+    v_posting.status IN ('closed', 'capacity_full')
+    OR v_posting.closed_reason IN ('expired', 'expired_by_work_date')
+  );
+
+  -- 6) UPDATE: 날짜 평행 이동 + (필요 시) active 재오픈
+  UPDATE public.job_postings
+  SET
+    work_date = CASE WHEN work_date IS NOT NULL
+                     THEN (work_date::date + v_interval)::date::text
+                     ELSE work_date END,
+    last_work_date = CASE WHEN last_work_date IS NOT NULL
+                          THEN (last_work_date::date + v_interval)::date::text
+                          ELSE last_work_date END,
+    work_dates = v_new_work_dates,
+    fixed_config = CASE WHEN v_expires_at IS NOT NULL
+                        THEN jsonb_set(fixed_config, '{expiresAt}', to_jsonb(v_expires_at))
+                        ELSE fixed_config END,
+    status = CASE WHEN v_reopened THEN 'active'::posting_status ELSE status END,
+    closed_at = CASE WHEN v_reopened THEN NULL ELSE closed_at END,
+    closed_reason = CASE WHEN v_reopened THEN NULL ELSE closed_reason END,
+    updated_at = now()
+  WHERE id = p_posting_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'posting_id', p_posting_id,
+    'extend_days', p_extend_days,
+    'reopened', v_reopened,
+    'diamonds_consumed', COALESCE((v_consume_result ->> 'diamond_consumed')::int, 0),
+    'hearts_consumed', COALESCE((v_consume_result ->> 'heart_consumed')::int, 0)
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.extend_job_posting(uuid, uuid, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.extend_job_posting(uuid, uuid, integer) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.extend_job_posting(uuid, uuid, integer) TO service_role;
+
+COMMENT ON FUNCTION public.extend_job_posting IS
+  '공고 기간 연장: 5다이아 차감(consume_diamonds_atomically) + 근무일/만료일 p_extend_days 평행 이동 + closed/capacity_full/만료 시 active 재오픈. SECURITY DEFINER, 소유자 검증. (DRAFT — Lane D 미적용)';

--- a/uniqn-mobile/supabase/migrations/20260530100100_create_extend_job_posting_rpc.sql
+++ b/uniqn-mobile/supabase/migrations/20260530100100_create_extend_job_posting_rpc.sql
@@ -3,9 +3,17 @@
 -- 목적: 공고 기간 연장(extend) — 고정 비용 다이아 차감 + 근무일/만료일 p_extend_days 만큼
 --   뒤로 밀고, 마감/만료/정원마감 상태면 active 로 재오픈.
 --
--- 비용/멱등: consume_diamonds_atomically(owner, 5, 'consume_job_extend', posting_id, 'job_posting')
---   를 통해 5 다이아(하트 우선) 차감. consume 가 INSUFFICIENT_BALANCE 던지면 전체 롤백.
---   같은 트랜잭션 안에서 차감+연장이 atomic — 부분 적용 없음.
+-- 비용/멱등: 비용은 _calc_posting_cost 와 동일한 4단 게이트(base 5 → enabled → paid_types['extend']
+--   → rollout%)로 산정 → 무과금(현 prod paid_types.extend 부재) 시 0, 유료화 ON 시 5다이아.
+--   cost>0 일 때만 consume_diamonds_atomically(owner, cost, 'consume_job_extend', posting_id, 'job_posting').
+--   INSUFFICIENT_BALANCE 던지면 전체 롤백. 차감+연장이 같은 트랜잭션 안에서 atomic.
+--
+-- ⚠️ 무한 무료연장 차단 (적대적 리뷰 P0, docs/planning/2026-06-02-monetization-review-findings.md):
+--   consume 멱등키가 (user, ref_id=posting_id, 'consume_job_extend')라, 동일 공고 2회차 연장은
+--   차감 0(idempotent)인데도 날짜이동/재오픈이 무조건 실행되면 "1회 결제 후 무한 무료연장"이 된다.
+--   → consume 가 idempotent(이미 유료 연장 차감 존재)면 날짜이동/재오픈을 **재실행하지 않고** 멱등 반환.
+--   결과: 공고당 유료 연장은 1회(재시도 안전). 다회 연장은 향후 per-operation 멱등 토큰으로 확장.
+--   refund 는 ref_id=posting 으로 consume_job_extend 를 합산하므로 ref_id=posting 유지(환불 호환).
 --
 -- 날짜 연장 설계 결정(draft, 리뷰 시 재검토):
 --   1) work_date / last_work_date: NULL 이 아니면 + p_extend_days 일.
@@ -30,7 +38,8 @@ AS $$
 DECLARE
   v_posting        public.job_postings%ROWTYPE;
   v_consume_result jsonb;
-  v_extend_cost    constant integer := 5;
+  v_extend_cost    integer := 5;
+  v_config         jsonb;
   v_interval       interval;
   v_reopened       boolean := false;
   v_new_work_dates text[];
@@ -69,14 +78,43 @@ BEGIN
     RAISE EXCEPTION 'INVALID_STATE: 취소된 공고는 연장할 수 없습니다';
   END IF;
 
-  -- 2) 고정 비용 다이아 차감 (실패 시 전체 트랜잭션 롤백)
-  v_consume_result := public.consume_diamonds_atomically(
-    p_owner_id,
-    v_extend_cost,
-    'consume_job_extend',
-    p_posting_id,
-    'job_posting'
-  );
+  -- 2) 비용 산정: _calc_posting_cost 와 동일한 4단 게이트 (cost=0 불변식 보존, P1)
+  --    base 5 → enabled → paid_types['extend'] → rollout 버킷. 현 prod(paid_types.extend 부재)=0.
+  v_extend_cost := 5;
+  SELECT value INTO v_config FROM public.app_config WHERE key = 'monetization';
+  IF v_config IS NULL
+     OR NOT COALESCE((v_config->>'enabled')::boolean, false)
+     OR NOT COALESCE((v_config->'paid_types'->>'extend')::boolean, false)
+     OR (abs(hashtext(p_owner_id::text)) % 100) >= COALESCE((v_config->>'rollout_percentage')::int, 0)
+  THEN
+    v_extend_cost := 0;
+  END IF;
+
+  -- 2b) 유료 연장만 차감 + 무한 무료연장 차단 (P0).
+  --     consume 멱등(ref_id=posting): 이미 유료 연장 차감이 있으면 idempotent → 날짜이동/재오픈을
+  --     재실행하지 않고 멱등 반환(재시도 안전, 공고당 유료 연장 1회).
+  IF v_extend_cost > 0 THEN
+    v_consume_result := public.consume_diamonds_atomically(
+      p_owner_id,
+      v_extend_cost,
+      'consume_job_extend',
+      p_posting_id,
+      'job_posting'
+    );
+
+    IF COALESCE((v_consume_result->>'idempotent')::boolean, false) THEN
+      RETURN jsonb_build_object(
+        'success', true,
+        'posting_id', p_posting_id,
+        'idempotent', true,
+        'already_extended', true,
+        'extend_days', 0,
+        'reopened', false,
+        'diamonds_consumed', 0,
+        'hearts_consumed', 0
+      );
+    END IF;
+  END IF;
 
   -- 3) work_dates[] 각 원소 평행 이동
   IF v_posting.work_dates IS NOT NULL THEN

--- a/uniqn-mobile/supabase/migrations/20260602100000_lane_d_create_payment_priority_default.sql
+++ b/uniqn-mobile/supabase/migrations/20260602100000_lane_d_create_payment_priority_default.sql
@@ -1,0 +1,148 @@
+-- ⚠️ DRAFT — Lane D. 유료화 ON 이후 적용. (priority 마이그 20260530100000 와 한 묶음)
+--
+-- 문제: 20260530100000 이 job_postings.priority 를 NOT NULL DEFAULT 0 으로 추가하는데,
+--   create_job_posting_with_payment_atomically 는 `INSERT ... SELECT * FROM jsonb_populate_record(
+--   NULL::job_postings, payload)` 패턴이라 payload 에 없는 priority 가 NULL 로 명시 삽입되어
+--   NOT NULL 위반(컬럼 DEFAULT 는 명시 NULL 에 적용 안 됨). → 공고 생성 전면 실패.
+--
+-- 해결: create_payment 의 v_defaults 에 'priority', 0 추가(다른 default 컬럼과 동일 처리).
+--   본 정의는 master 의 Fix-1b(20260602000001_create_payment_authz_guard) 본문 + priority 기본값.
+--   머지 타임스탬프 순서상 Fix-1b 다음에 적용되어 최종 정의가 된다.
+--   ⚠️ master 의 create_payment 가 추가 변경되면 본 정의와 재정합 필요(Lane D 실제 머지 시 reconcile).
+
+CREATE OR REPLACE FUNCTION public.create_job_posting_with_payment_atomically(
+  p_owner_id uuid,
+  p_posting_payload jsonb,
+  p_reason wallet_reason DEFAULT 'consume_job_posting'::wallet_reason
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_posting_id        UUID;
+  v_type              TEXT;
+  v_cost              INT;
+  v_consume_result    JSONB;
+  v_diamonds_consumed INT := 0;
+  v_heart_consumed    INT := 0;
+  v_defaults          JSONB;
+  v_final_payload     JSONB;
+  v_inserted          INT := 0;
+  v_resolved_workspace_id UUID;
+  v_caller            UUID := (SELECT auth.uid());
+  v_role              TEXT := public.get_my_role();
+  v_payload_ws        UUID;
+BEGIN
+  IF p_owner_id IS NULL THEN
+    RAISE EXCEPTION 'INVALID_OWNER_ID: cannot be NULL';
+  END IF;
+  IF p_posting_payload IS NULL THEN
+    RAISE EXCEPTION 'INVALID_PAYLOAD: cannot be NULL';
+  END IF;
+
+  -- [Fix-1b] 호출자 인가 (service_role/백엔드는 v_caller NULL → 통과)
+  IF v_caller IS NOT NULL THEN
+    IF v_role NOT IN ('admin', 'employer') THEN
+      RAISE EXCEPTION 'PERMISSION_DENIED: role % cannot create job postings', v_role;
+    END IF;
+    IF v_role <> 'admin' AND v_caller <> p_owner_id THEN
+      RAISE EXCEPTION 'PERMISSION_DENIED: caller cannot create posting for another owner';
+    END IF;
+    v_payload_ws := NULLIF(p_posting_payload->>'workspace_id', '')::uuid;
+    IF v_payload_ws IS NOT NULL
+       AND NOT EXISTS (
+         SELECT 1 FROM public.workspaces WHERE id = v_payload_ws AND owner_id = p_owner_id
+       ) THEN
+      RAISE EXCEPTION 'PERMISSION_DENIED: workspace not owned by owner';
+    END IF;
+  END IF;
+
+  v_posting_id := COALESCE((p_posting_payload->>'id')::uuid, gen_random_uuid());
+  v_type := COALESCE(p_posting_payload->>'posting_type', 'regular');
+
+  IF NOT (p_posting_payload ? 'workspace_id') OR (p_posting_payload->>'workspace_id') IS NULL THEN
+    SELECT id INTO v_resolved_workspace_id
+    FROM public.workspaces
+    WHERE owner_id = p_owner_id
+    ORDER BY created_at ASC
+    LIMIT 1;
+
+    IF v_resolved_workspace_id IS NULL THEN
+      RAISE EXCEPTION 'WORKSPACE_NOT_FOUND: owner % has no workspace — backfill 누락', p_owner_id;
+    END IF;
+  END IF;
+
+  v_cost := public._calc_posting_cost(v_type, p_owner_id);
+
+  v_defaults := jsonb_build_object(
+    'id',                v_posting_id,
+    'schema_version',    3,
+    'status',            'draft',
+    'posting_type',      'regular',
+    'created_at',        now(),
+    'updated_at',        now(),
+    'location',          '{}'::jsonb,
+    'schedule',          '{}'::jsonb,
+    'role_catalog',      '[]'::jsonb,
+    'compensation',      '{}'::jsonb,
+    'questions',         jsonb_build_object('items', '[]'::jsonb),
+    'stats',             jsonb_build_object(
+                           'filledPositions', 0,
+                           'totalApplicants', 0,
+                           'activeApplicants', 0,
+                           'confirmedApplicants', 0,
+                           'cancellationPendingApplicants', 0
+                         ),
+    'total_positions',   0,
+    'filled_positions',  0,
+    'view_count',        0,
+    'is_featured',       false,
+    'priority',          0  -- Lane D: NOT NULL DEFAULT 0 컬럼 — jsonb_populate_record NULL 방지
+  );
+
+  v_final_payload := v_defaults
+                     || p_posting_payload
+                     || jsonb_build_object('id', v_posting_id, 'owner_id', p_owner_id);
+
+  IF v_resolved_workspace_id IS NOT NULL THEN
+    v_final_payload := v_final_payload || jsonb_build_object('workspace_id', v_resolved_workspace_id);
+  END IF;
+
+  INSERT INTO public.job_postings
+  SELECT * FROM jsonb_populate_record(NULL::public.job_postings, v_final_payload)
+  ON CONFLICT (id) DO NOTHING;
+  GET DIAGNOSTICS v_inserted = ROW_COUNT;
+
+  IF v_inserted = 0 THEN
+    RETURN jsonb_build_object(
+      'success', true,
+      'posting_id', v_posting_id,
+      'idempotent', true,
+      'diamonds_consumed', 0,
+      'hearts_consumed', 0,
+      'total_consumed', 0
+    );
+  END IF;
+
+  IF v_cost > 0 THEN
+    v_consume_result := public.consume_diamonds_atomically(
+      p_owner_id, v_cost, p_reason, v_posting_id, 'job_posting'
+    );
+    v_diamonds_consumed := COALESCE((v_consume_result->>'diamond_consumed')::int, 0);
+    v_heart_consumed    := COALESCE((v_consume_result->>'heart_consumed')::int, 0);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'posting_id', v_posting_id,
+    'diamonds_consumed', v_diamonds_consumed,
+    'hearts_consumed', v_heart_consumed,
+    'total_consumed', v_diamonds_consumed + v_heart_consumed
+  );
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.create_job_posting_with_payment_atomically(uuid, jsonb, wallet_reason) FROM anon, PUBLIC;
+GRANT EXECUTE ON FUNCTION public.create_job_posting_with_payment_atomically(uuid, jsonb, wallet_reason) TO authenticated, service_role;

--- a/uniqn-mobile/supabase/tests/extend_job_posting.test.sql
+++ b/uniqn-mobile/supabase/tests/extend_job_posting.test.sql
@@ -1,0 +1,73 @@
+-- ============================================================
+-- Lane D: extend_job_posting — 무한 무료연장 차단(P0) + monetization 게이트(P1)
+-- 근거: docs/planning/2026-06-02-monetization-review-findings.md
+--   - 무과금(paid_types.extend 부재) → cost 0, 무료 연장 적용
+--   - 유료(enabled+paid_types.extend+rollout) → 1회차 5다이아 차감·적용, 2회차 idempotent 차단(무료 재연장 금지)
+-- 안전: BEGIN/ROLLBACK (app_config UPDATE 포함 — 트랜잭션 종료 시 롤백)
+-- ============================================================
+BEGIN;
+SELECT plan(7);
+
+DO $$
+DECLARE
+  v_owner    uuid := gen_random_uuid();
+  v_ws       uuid := gen_random_uuid();
+  v_pid_free uuid := gen_random_uuid();
+  v_pid_paid uuid := gen_random_uuid();
+BEGIN
+  INSERT INTO auth.users (id, email, aud, role, encrypted_password, raw_app_meta_data, raw_user_meta_data, created_at, updated_at)
+  VALUES (v_owner, '__sql_fixture_ext_owner@test.local', 'authenticated','authenticated','', '{"role":"employer"}'::jsonb, '{"name":"EXT"}'::jsonb, now(), now());
+  INSERT INTO public.users (id, email, name, role, is_active, created_at, updated_at)
+  VALUES (v_owner, '__sql_fixture_ext_owner@test.local', 'fixture','employer', true, now(), now());
+  INSERT INTO public.workspaces (id, name, owner_id, created_at, updated_at)
+  VALUES (v_ws, '__sql_fixture_ext_ws', v_owner, now(), now());
+  -- 유료 연장 차감용 잔액
+  INSERT INTO public.wallets(user_id, diamond_balance) VALUES (v_owner, 10) ON CONFLICT (user_id) DO UPDATE SET diamond_balance = 10;
+
+  INSERT INTO public.job_postings (id, owner_id, workspace_id, title, total_positions, filled_positions, status, posting_type, work_date, work_dates, created_at, updated_at)
+  VALUES
+    (v_pid_free, v_owner, v_ws, '__ext free', 1, 0, 'active', 'urgent', '2026-07-01', ARRAY['2026-07-01']::text[], now(), now()),
+    (v_pid_paid, v_owner, v_ws, '__ext paid', 1, 0, 'active', 'urgent', '2026-08-01', ARRAY['2026-08-01']::text[], now(), now());
+
+  PERFORM set_config('test.owner', v_owner::text, false);
+  PERFORM set_config('test.pid_free', v_pid_free::text, false);
+  PERFORM set_config('test.pid_paid', v_pid_paid::text, false);
+END $$;
+
+-- ── Phase A: 무과금(시드 monetization 에 paid_types.extend 부재) → cost 0, 무료 연장 ──
+SELECT is(
+  (public.extend_job_posting(current_setting('test.pid_free')::uuid, current_setting('test.owner')::uuid, 7))->>'success',
+  'true', 'A1: 무과금 연장 성공');
+SELECT is(
+  (SELECT work_date FROM public.job_postings WHERE id = current_setting('test.pid_free')::uuid),
+  '2026-07-08', 'A2: 무과금 연장 — work_date +7 평행이동');
+
+-- ── Phase B: 유료화 ON (paid_types.extend=true, rollout 100) ──
+UPDATE public.app_config
+SET value = jsonb_set(
+      jsonb_set(value, '{paid_types,extend}', 'true'::jsonb, true),
+      '{rollout_percentage}', '100'::jsonb, true
+    ) || '{"enabled": true}'::jsonb
+WHERE key = 'monetization';
+
+-- 1회차 유료 연장: 5다이아 차감
+SELECT is(
+  (public.extend_job_posting(current_setting('test.pid_paid')::uuid, current_setting('test.owner')::uuid, 7))->>'diamonds_consumed',
+  '5', 'B1: 유료 1회차 연장 — 5다이아 차감');
+SELECT is(
+  (SELECT diamond_balance FROM public.wallets WHERE user_id = current_setting('test.owner')::uuid),
+  5, 'B2: 잔액 10-5=5');
+
+-- 2회차 연장 시도: consume 멱등 → 차단(무한 무료연장 금지)
+SELECT is(
+  (public.extend_job_posting(current_setting('test.pid_paid')::uuid, current_setting('test.owner')::uuid, 7))->>'already_extended',
+  'true', 'B3: 2회차 연장 — already_extended(무료 재연장 차단)');
+SELECT is(
+  (SELECT diamond_balance FROM public.wallets WHERE user_id = current_setting('test.owner')::uuid),
+  5, 'B4: 2회차도 잔액 5 유지(이중 차감 없음)');
+SELECT is(
+  (SELECT work_date FROM public.job_postings WHERE id = current_setting('test.pid_paid')::uuid),
+  '2026-08-08', 'B5: 날짜는 1회만 이동(+14 아님) — 무료 재연장 차단 확인');
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## 개요

수익모델 **Lane D** — featured(우선노출) + extend(공고 연장)의 **클라이언트 스캐폴드**. 명시적으로 **부분 구현**: `priority` 컬럼과 `extend_job_posting` RPC는 **prod 미적용**(마이그 드래프트만), **유료화(monetization flag) ON 이후** 적용 트랙.

> 🚧 **DRAFT — 머지/배포 금지.** 마이그레이션 미적용 상태라 extend RPC 호출은 prod에서 동작하지 않음(UI 미노출이라 트리거 불가). 마이그 적용 + types 재생성 + UI 노출은 유료화 ON 시 후속.

## 변경 내용

### 마이그레이션 드래프트 (committed, **NOT applied**)
- `20260530100000_add_job_posting_priority.sql` — `priority int NOT NULL DEFAULT 0` + `(priority DESC, work_date DESC)` 인덱스 (featured 정렬용)
- `20260530100100_create_extend_job_posting_rpc.sql` — `extend_job_posting(p_posting_id, p_owner_id, p_extend_days=7)` SECURITY DEFINER 드래프트: owner 검증(FOR UPDATE) + 5💎 차감(`consume_diamonds_atomically`, `consume_job_extend`) + 날짜 연장 + 만료/마감 reopen. 단일 권위 날짜 컬럼 확정은 적용 전 정리 필요(SQL에 명시).

### 클라이언트 배선 (compiles + 단위 테스트)
- `JobPostingRepository.extendWithTransaction` (+ 인터페이스) — RPC 미적용이라 타입 부재 → **국소 캐스트**(주석: 마이그 적용 후 generate types로 제거)
- `jobManagementService.extendJobPosting` + `useExtendJobPosting` 훅

### 의도적 제외
- 라이브 `getList` orderBy 변경 안 함(컬럼 부재로 prod read 깨짐 방지 — `// TODO(Lane D)` 마커만)
- UI 버튼 미노출 / types 미재생성 / 마이그 미적용

## 테스트
- ✅ jest: extend 배선 테스트 GREEN (Red-Green 확인), 전체 영향 없음
- ✅ `tsc --noEmit` exit 0, `npm run quality` exit 0

## 후속(유료화 ON 시)
1. 마이그 2종 적용(MCP) + 단일 날짜 컬럼 확정 + types 재생성 → 캐스트 제거
2. `getList` orderBy `priority DESC` 추가 + featured 과금
3. "연장하기" UI 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)
