### PR TITLE
fix(jobPosting): capacity_full 공고를 구직자 브라우즈 목록에 노출

### DIFF
--- a/uniqn-mobile/app/(app)/jobs/[id]/index.tsx
+++ b/uniqn-mobile/app/(app)/jobs/[id]/index.tsx
@@ -238,7 +238,9 @@ export default function JobDetailScreen() {
             </View>
           ) : job.status !== STATUS.JOB_POSTING.ACTIVE ? (
             <Button disabled fullWidth>
-              마감된 공고입니다
+              {job.status === STATUS.JOB_POSTING.CAPACITY_FULL
+                ? '정원이 마감되었어요'
+                : '마감된 공고입니다'}
             </Button>
           ) : (
             <View>

--- a/uniqn-mobile/app/jobs/[id].tsx
+++ b/uniqn-mobile/app/jobs/[id].tsx
@@ -165,7 +165,9 @@ export default function PublicJobDetailAliasRoute() {
         <SafeAreaView edges={['bottom']}>
           {job.status !== STATUS.JOB_POSTING.ACTIVE ? (
             <Button disabled fullWidth>
-              마감된 공고입니다
+              {job.status === STATUS.JOB_POSTING.CAPACITY_FULL
+                ? '정원이 마감되었어요'
+                : '마감된 공고입니다'}
             </Button>
           ) : (
             <View>

--- a/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
@@ -120,7 +120,15 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
         filters: (q) => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           let qr: any = q;
-          qr = qr.eq('status', filters?.status ?? STATUS.JOB_POSTING.ACTIVE);
+          // 명시적 status 가 없으면 구직자 브라우즈 기본값: active + capacity_full.
+          // capacity_full(정원 마감)은 spec §4/§6 + 공개 RLS(M4)상 "정원 마감" 라벨로
+          // 사용자에게 노출되어야 한다. active 만 필터하면 정원이 찬 공고가 목록에서
+          // 사라진다(pitfall_enum_divergence_read_disappearance).
+          if (filters?.status) {
+            qr = qr.eq('status', filters.status);
+          } else {
+            qr = qr.in('status', [STATUS.JOB_POSTING.ACTIVE, STATUS.JOB_POSTING.CAPACITY_FULL]);
+          }
           if (filters?.roles?.length) qr = qr.overlaps('role_keys', filters.roles.slice(0, 10));
           if (filters?.district) qr = qr.eq('location->>district', filters.district);
           if (filters?.ownerId) qr = qr.eq('owner_id', filters.ownerId);

--- a/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.getList.capacity.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.getList.capacity.test.ts
@@ -1,0 +1,106 @@
+/**
+ * JobPostingRepository.getList — capacity_full 공개 가시성 contract test
+ *
+ * @description 구직자 브라우즈 목록(명시 status 없음)은 active + capacity_full 을
+ *              조회해야 한다(spec §4/§6 + 공개 RLS M4: 정원 마감은 "정원 마감" 라벨로
+ *              사용자에게 노출). active 만 필터하면 정원이 찬 공고가 목록에서 증발한다.
+ *              명시 status 가 주어지면 그 status 만 .eq 로 필터한다.
+ *
+ * contract level (Supabase 호출 패턴) 만 검증.
+ */
+
+import { SupabaseJobPostingRepository } from '../JobPostingRepository';
+
+const mockFrom = jest.fn();
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    rpc: jest.fn(),
+    channel: jest.fn(),
+  },
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('@/utils/supabase', () => {
+  const actual = jest.requireActual('@/utils/supabase');
+  return {
+    ...actual,
+    handleSupabaseError: (error: { message?: string } | null) => {
+      if (error) throw new Error(`supabase: ${error.message ?? 'unknown'}`);
+    },
+  };
+});
+
+jest.mock('@sentry/react-native', () => ({
+  __esModule: true,
+  addBreadcrumb: jest.fn(),
+}));
+
+function makeChain(returnValue: { data: unknown; error: unknown }) {
+  const chain: Record<string, unknown> = {};
+  for (const m of [
+    'select',
+    'eq',
+    'in',
+    'is',
+    'order',
+    'limit',
+    'range',
+    'gte',
+    'lte',
+    'gt',
+    'lt',
+    'neq',
+    'contains',
+    'overlaps',
+    'or',
+    'not',
+    'filter',
+    'match',
+    'returns',
+  ]) {
+    chain[m] = jest.fn(() => chain);
+  }
+  (chain as { then?: unknown }).then = function then<TResult1 = unknown, TResult2 = never>(
+    onfulfilled?: ((value: unknown) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): PromiseLike<TResult1 | TResult2> {
+    return Promise.resolve(returnValue).then(onfulfilled, onrejected);
+  };
+  return chain as Record<string, jest.Mock> & PromiseLike<unknown>;
+}
+
+beforeEach(() => {
+  mockFrom.mockReset();
+});
+
+describe('JobPostingRepository.getList — capacity_full 가시성', () => {
+  const repo = new SupabaseJobPostingRepository();
+
+  it('명시 status 가 없으면 active + capacity_full 을 .in 으로 조회한다 (정원 마감 노출)', async () => {
+    const chain = makeChain({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+
+    await repo.getList();
+
+    expect(chain.in).toHaveBeenCalledWith('status', ['active', 'capacity_full']);
+    // 기본 경로에서는 status 를 .eq 로 좁히지 않는다
+    const statusEqCalls = chain.eq.mock.calls.filter((c) => c[0] === 'status');
+    expect(statusEqCalls).toHaveLength(0);
+  });
+
+  it('명시 status 가 주어지면 그 status 만 .eq 로 필터한다', async () => {
+    const chain = makeChain({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+
+    await repo.getList({ status: 'closed' as never });
+
+    expect(chain.eq).toHaveBeenCalledWith('status', 'closed');
+    const statusInCalls = chain.in.mock.calls.filter((c) => c[0] === 'status');
+    expect(statusInCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
구직자 공고 목록에서 **정원 마감(capacity_full) 공고가 사라지던 read 누락**을 수정합니다. #161(구인자 목록 누락)과 동일 클래스의 후속 — applicant-facing 경로.

`getList`(공개 목록)가 명시 status 없을 때 `status = active` 로만 필터해 capacity_full 을 제외했습니다. 그러나 **spec §4/§6 + 공개 RLS M4(`20260529100300`)는 capacity_full 을 "정원 마감" 회색 라벨로 사용자에게 노출하도록 규정** — RLS·라벨(shared `postingSurfaceModel`)은 준비됐으나 클라이언트 쿼리만 누락된 비대칭이었습니다 (`pitfall_enum_divergence_read_disappearance`).

## Changes
- `JobPostingRepository.getList`: 명시 status 없으면 `.in('status', [active, capacity_full])`. 명시 status 가 주어지면 기존 `.eq` 단일 필터 유지(블라스트 반경 최소 — search/urgent 등 explicit-active 호출자 무영향).
- 지원 게이팅은 이미 `status !== active` 로 차단됨. capacity_full 일 때 버튼 문구를 **"정원이 마감되었어요"**로 구분(기존 "마감된 공고입니다"는 closed 와 혼동) — 상세 2화면(`app/(app)/jobs/[id]/index.tsx`, `app/jobs/[id].tsx`).
- `getList` capacity_full 가시성 contract 테스트 추가.

## Test plan
- [x] jest: jobService/repo/useJobPostings 56/56 + 신규 getList capacity 2/2
- [x] 신규 테스트 RED-GREEN: 구버전 `.eq('status', active)` 면 실패하는 회귀 가드
- [x] tsc 0 / eslint 0 (변경 파일)
- [ ] CI: type-check / e2e green (구직자 목록에 capacity_full 카드 "정원 마감" 라벨 노출)

## 비고
- 마이그레이션 불필요 (공개 RLS 는 M4 에서 이미 capacity_full 허용).
- search/urgent(`jobService:184/209`)는 status=active 명시 — "지원 가능" 의도라 active-only 유지(분리).

---
Generated with [Claude Code](https://claude.com/claude-code)