### PR TITLE
fix(wallet): 결제 도메인 P0/P1 보안 하드닝 — anon 발권·잔액 IDOR·owner 위조 차단

### DIFF
--- a/docs/planning/2026-06-02-monetization-review-findings.md
+++ b/docs/planning/2026-06-02-monetization-review-findings.md
@@ -1,0 +1,102 @@
+# 결제/수익모델 적대적 리뷰 결과 — 유료화 롤아웃 前 게이트
+
+> 작성: 2026-06-02 / 기준: master `ac2a06402` / 방식: 9차원 멀티에이전트 fan-out + critical 4차원 적대적 2차 검증(31 에이전트) + 메인 세션 prod ACL 재확인
+> 입력 프롬프트: `docs/planning/2026-06-02-monetization-full-review-prompt.md`
+
+## 한 줄 결론
+
+**유료화 ON 불가 (NO-GO).** 게다가 **현재 cost=0 상태에서도 살아있는 prod 보안 구멍 2건**(무인증 통화 발권 + 무인증 잔액 IDOR)이 발견됨 — 이는 유료화 타이밍과 무관하게 즉시 차단 대상. 원장/환불/충전 핵심 로직은 견고하나 권한(GRANT) 하드닝 누락 + 환불 동시성/관측성 + Lane D 적용 게이트가 ON 전 필수 해소 항목.
+
+---
+
+## 심각도별 findings (적대적 검증 후 보정 심각도)
+
+### 🔴 P0 — 유료화 ON 전 필수 + 일부는 지금 당장 prod 노출
+
+| ID | 제목 | file:line | 검증 | 비고 |
+|---|---|---|---|---|
+| **anon-credit-mint** | `credit_diamonds_atomically` anon EXECUTE — 공개 anon 키로 임의 user에 무한 다이아 발권(+첫충전 보너스 5💎까지) | `20260427000400_create_credit_diamonds_rpc.sql:102` (REVOKE PUBLIC,authenticated만) + `20260530000006_wallet_grants_hardening.sql`(credit 누락) | CONFIRMED ×2 + **메인 재확인** | **지금 prod 라이브.** auth 가드 0, SECDEF, p_user_id 신뢰. tx_id 매번 랜덤 주면 멱등 우회 |
+| **anon-grant-heart-mint** | `grant_heart_atomically` anon EXECUTE — 무인증 하트 발권(하트는 consume 우선차감 = regular 공고 무료화) | `20260427000500_create_grant_heart_rpc.sql:77` + `20260530000006`(누락) | CONFIRMED ×2 + **메인 재확인** | **지금 prod 라이브.** 일일제한은 `grant_daily_attendance` reason에만 — 임의 reason+대량 amount 우회. *심각도 분기: D1=P0 / D5=P1(cost=0이라 환금처 없음). 수정은 동일 REVOKE이므로 P0 게이트로 취급* |
+| **extend-idempotency-free-reextend** | (Lane D #160 DRAFT) extend RPC가 consume 멱등(ref_id=posting)과 충돌 — 첫 연장 후 동일 공고 무한 무료 연장·재오픈 | `20260530100100_create_extend_job_posting_rpc.sql:70-90,96-145` | CONFIRMED | **현재는 미적용이라 prod 무해.** #160 마이그 적용 = 즉시 BLOCKER. 적용 前 반드시 수정 |
+
+### 🟠 P1 — ON 전 필수 (일부 지금 노출)
+
+| ID | 제목 | file:line | 검증 | 비고 |
+|---|---|---|---|---|
+| **get_wallet_summary-anon-idor** | 무인증 anon이 임의 UUID의 잔액/누적구매액 조회(IDOR) — `v_caller IS NULL` 가드 단락 | `20260427000500_create_grant_heart_rpc.sql:121-135` + anon EXECUTE | PARTIAL→**P1 상향** + 메인 ACL 재확인 | **지금 prod 라이브.** claim_daily_attendance는 auth.uid 가드로 안전(REFUTED) |
+| **consume-arbitrary-user-burn** | `consume_diamonds_atomically`가 authenticated 개방 + p_user_id를 auth.uid로 강제 안 함 → 타인 잔액 소각 | `20260530000003_consume_idempotency.sql:14-113` | CONFIRMED | 차감만 가능(자기증식 불가) = griefing. 잔액 보유자 존재 시 즉시 발동 |
+| **payment-rpc-owner-not-bound** | `create_job_posting_with_payment`가 p_owner_id를 auth.uid로 검증 안 함 → 타인 비용 결제·공고 위조 | `20260530000002_create_payment_server_cost_calc.sql:12-129` | CONFIRMED | 차감은 cost=0이 게이트하나 **공고 위조는 지금도 실재**. 하드닝 마이그 주석이 "내부 auth 체크로 방어"라 했으나 본문에 없음 |
+| **webhook-no-environment-gate** | 웹훅이 `event.environment`(SANDBOX) 미필터 → 테스트 결제로 실 다이아 발권 | `revenuecat-webhook/index.ts:122-196` (58행에 필드 선언만) | CONFIRMED | sandbox/TestFlight 빌드가 prod RC 가리키면 무료 발권. 소프트런치 흔한 누출 |
+| **refund-idempotency-no-unique** | 환불 멱등이 잠금없는 SELECT-then-INSERT + refund row UNIQUE 부재 → 동시/재시도 이중환불 | `20260530000005_refund_collaborator_auth.sql:34-42,84-100` | CONFIRMED | paid ON 후 동시취소 시 원금 2배 적립. owner+협업자 둘 다 호출 가능(1s 스로틀 무력) |
+| **refund-balance-lost-update** | 환불이 `FOR UPDATE` 없이 wallets 읽음 + 트리거가 RPC 계산값 복사 → 동시 차감/환불 시 캐시 drift | `20260530000005_refund_collaborator_auth.sql:84-100` | CONFIRMED | 캐시가 SSOT와 영구 어긋남 → 과대 시 없는 다이아 소비 허용 |
+| **refund-failure-swallow** | 환불 실패 best-effort swallow가 Sentry/재시도/아웃박스 없이 warn만 + `success:false`는 무로깅 통과 | `JobPostingRepository.ts:471-481` | CONFIRMED | 취소 성립+환불 누락이 대시보드에 안 잡힘. RPC 멱등이나 재시도 신호 없음 |
+| **show-purchase-ui-dead-flag** | `show_purchase_ui` 플래그가 코드에서 0회 읽힘 — 충전 UI 서버 kill-switch 부재 | `purchaseSheetStore.ts:13`, `PurchaseSheet.tsx:18-22` | (D4, 미검증) | RC 사고 시 서버 플래그로 즉시 차단 불가 |
+| **rc-keys-missing-on-master** | RC 공개 SDK 키가 master eas.json에 없음 — 미push 브랜치 `worktree-wallet-rc-env`(ab8d20674)에만 | `eas.json:7-13` vs `ab8d20674` | CONFIRMED | master로 빌드하면 isAvailable()=false → 충전 전면불가. OTA 불가(네이티브). **배포 하드 블로커** |
+| **native-dep-eas / webhook-secret-e2e / store-iap-prereq** | EAS 신규빌드 강제·webhook secret e2e 미검증·스토어 IAP/ASC/Play 미연동 시 충전불가 또는 돈만받고 미적립 | `package.json:98` / `index.ts:97-104` / `PurchaseSheet.tsx:83-90` | CONFIRMED | 외부설정 게이트 (아래 체크리스트) |
+| **extend-no-monetization-gate** | (Lane D) extend/consume RPC에 server-side flag 가드 부재 → 적용 즉시 무조건 과금 | `20260530100100:70-90` | CONFIRMED | cost=0 불변이 UI 미배선에만 의존, DB 미보장 |
+
+### 🟡 P2 — ON 전 권장 / 정합·관측 부채
+
+- **cancellation-blind-deduct**(→P2): 웹훅이 CANCELLATION/BILLING_ISSUE 일괄 차감 + `cancel_reason` 미검사. *소비성 결제에서 CANCELLATION=환불은 정상(원 주장 일부 REFUTED)*, 진짜 결함은 BILLING_ISSUE/BILLING_ERROR 미구분. `index.ts:38,186-196`
+- **refund-amount-by-current-product**: 환불 차감액이 원거래 ledger delta가 아닌 현재 `diamond_products` 값 기준 → 시드 ON CONFLICT 변경 시 drift + 음수 잔액 floor 부재. `index.ts:160-187`
+- **refund-keeps-first-bonus**(+5💎): 첫구매 전액환불 후 보너스 5💎 잔존(lifetime 미차감, 계정당 1회 한정). *D2=P1 / D1=P2 분기.* `20260427000400:50-91`
+- **refund-heart-to-diamond**: 무료 하트로 낸 비용을 만료없는 다이아로 환불(주석상 의도된 정책, 향후 환금기능 시 abuse). `20260530000005:64-100`
+- **wallet-tables-dml-grants**: wallet 4테이블에 anon/authenticated DML GRANT 잔존(현재 RLS default-deny로 차단되나 force RLS off). `20260427000100:6-9`
+- **webhook-non-constant-time**: secret `===` 비교 timing-safe 아님(실익 낮음). `index.ts:106`
+- **first-purchase-bonus-hardcoded**: 보너스가 플래그 아닌 상수 5💎(SSOT 위반). `20260427000400:52`
+- **web-paywall-charge-deadend**: 웹 "충전하기" CTA가 막다른 안내로 연결(전환 누수). `create.tsx:158-169`
+- **extend-date-multisource / extend-refund-min-rate**(Lane D): 날짜 권위 컬럼 다중 평행이동 / 환불비율 MIN(consume) 기준. 적용 前 도메인 확정
+- **purchase-ui-visible-rollout-zero**: 키없는 빌드에서 충전시트 자기모순 안내. `PurchaseSheet.tsx:21,73-78`
+
+### 🟢 P3 — 백로그
+
+consume 멱등 선조회 락밖(unique 인덱스가 방어) / 폴링 false-timeout(self-heal) / rollout `abs(hashtext)` INT_MIN 편향(2^-32) / display-vs-charge 스냅샷(서버권위라 무손실) / useRevenueCatSession uid변경 logOut 처닝 / refund-rate per-row(dormant) / enum SSOT 수기복제 2벌(현 drift 0)
+
+---
+
+## OK로 확인된 항목 (긍정 검증)
+
+- **원장 멱등/오버드로/만료 로직 자체**: consume `uq_wallet_ledger_consume_ref` + 선조회 가드 + `GREATEST(0,...)` floor 견고
+- **충전 멱등성**: 웹훅 `event.id` UNIQUE + 첫충전 보너스 `lifetime=0` 가드로 이중지급 방어
+- **플래그 4단 게이트**: enabled→paid_types→rollout%→base 정확. prod `paid_types 전부 false + rollout 0` → **cost=0 이중안전 실측 확인**. 환불은 실제 ledger 합산 기반이라 flag 전환 비대칭 면역
+- **웹 안전성**: web 번들에 `react-native-purchases` 네이티브 import 0건(Metro 플랫폼 해상도 + `import type` 소거), isAvailable()=false graceful degrade
+- **enum 발산 read 증발**: wallet 도메인은 ledger 직접 read 경로 0건(잔액=캐시 컬럼) + read 필드 전부 `z.string()` → payroll_status류 증발 클래스 구조적 차단
+- **types/supabase.ts**: prod 스키마 일치(get_posting_cost 반영, p_cost_diamonds 완전 제거)
+- **Lane D DRAFT prod 영향 0**: 마이그 미적용·UI 미배선·라이브 orderBy=work_date 유지. 클라 캐스트는 RPC 시그니처 정확 일치(types 재생성 후 제거 가능)
+
+---
+
+## 유료화 ON 가능 여부 판정: **NO-GO**
+
+ON 게이트 (모두 충족 필요):
+1. **P0/P1 보안 하드닝** (아래 Fix-1) — 일부는 cost=0인 지금도 prod 노출이므로 **즉시 권장**
+2. **환불 동시성/관측성 P1** (Fix-2) — paid_types ON 전 필수
+3. **웹훅 environment 게이트 + secret e2e 검증** (Fix-3)
+4. **배포 준비** (Fix-4): rc-env 키 머지 + 신규 EAS 스토어 빌드 + 외부설정 체크리스트
+5. **Lane D**: extend P0/P1 해소 전 #160 마이그 **적용 금지**
+
+---
+
+## 외부 설정 / 배포 체크리스트 (사용자 작업)
+
+- [ ] Supabase secret `REVENUECAT_WEBHOOK_SECRET`(bare) 설정 + RC 대시보드 Bearer 동일값 대조
+- [ ] App Store Connect IAP 6종(`uniqn_diamonds_*`) 등록 + 가격 + 심사통과
+- [ ] Play Console 인앱상품 6종 active
+- [ ] RC 대시보드 ASC API키 + Play 서비스계정 연동 (미연동 시 getOfferings 빈목록)
+- [ ] RC Offering `default`에 6 패키지 attach 확인
+- [ ] `worktree-wallet-rc-env`(ab8d20674) master 머지 (eas.json+.env.example 2파일 11줄, 클린)
+- [ ] 신규 EAS production 빌드(store 프로파일) → 스토어 submit → 심사 (OTA 불가, 리드타임 크리티컬 패스)
+- [ ] EAS dev build + sandbox 실구매 1회 e2e: 결제→웹훅→credit→잔액 반영 통과 (현재 미수행)
+- [ ] 구버전(1.0.2) 보급 전 rollout 상향 금지
+
+---
+
+## 제안 수정 PR 계획 (★ 사용자 승인 후 별도 브랜치 + CI green)
+
+- **Fix-1 (P0/P1 권한 하드닝, DB 마이그)**: 신규 마이그로 `credit_diamonds_atomically`·`grant_heart_atomically`·`fn_expire_heart_lots`·`get_wallet_summary`·`claim_daily_attendance` anon REVOKE + `consume`/`create_payment` 진입부 auth.uid 바인딩 가드 + get_wallet_summary `v_caller IS NULL` 가드 교정 + wallet 4테이블 DML REVOKE/force RLS. pgTAP 회귀. **MCP apply_migration 전용**
+- **Fix-2 (환불 동시성/관측성)**: refund ledger 부분 UNIQUE 인덱스 + `ON CONFLICT DO NOTHING`(또는 advisory lock), 환불 `FOR UPDATE`, swallow catch에 Sentry + `success:false` 분기 로깅
+- **Fix-3 (웹훅)**: SANDBOX 게이트 + BILLING_ISSUE/cancel_reason 구분 + 상수시간 비교
+- **Fix-4 (배포/플래그)**: rc-env 키 머지, `show_purchase_ui` kill-switch 코드 연결(또는 dead config 제거)
+- **Lane D 후속**: #160 적용 前 extend 멱등(P0) + monetization 게이트(P1) 수정
+
+> ⚠️ 본 리뷰 동안 적용한 변경 없음(읽기 전용). 플래그·마이그·배포·외부설정 무변경, prod cost=0 유지.

--- a/uniqn-mobile/supabase/migrations/20260602000000_wallet_grants_hardening_p0.sql
+++ b/uniqn-mobile/supabase/migrations/20260602000000_wallet_grants_hardening_p0.sql
@@ -1,0 +1,31 @@
+-- Fix-1a: 결제 도메인 P0/P1 권한 하드닝 (anon 통화 발권 + 잔액 IDOR + 타인 소각 벡터 차단)
+--
+-- 근거: docs/planning/2026-06-02-monetization-review-findings.md (유료화 롤아웃 前 적대적 리뷰)
+-- 선행 하드닝 20260530000006 이 누락한 함수들의 anon EXECUTE 회수 + consume authenticated 회수.
+-- Supabase ALTER DEFAULT PRIVILEGES 가 신규 함수에 anon/authenticated EXECUTE 를 자동부여하므로
+-- REVOKE ... FROM PUBLIC 만으로는 anon 명시권한이 잔존한다(20260530000006 주석 참조).
+--
+-- ⚠️ 본문(로직) 변경 없음 — GRANT 만 조정. 모든 함수가 SECURITY DEFINER 라
+--    래퍼(create_job_posting_with_payment)/cron/webhook 의 내부 호출은 definer(postgres) 권한으로
+--    동작하므로 EXECUTE 회수의 영향을 받지 않는다. (직접 RPC 호출 경로만 봉쇄.)
+
+-- [P0] 무인증 다이아 발권 차단 — webhook(service_role) 전용. 공개 anon 키로 임의 user 무한 적립 차단.
+REVOKE EXECUTE ON FUNCTION public.credit_diamonds_atomically(uuid, integer, text, text) FROM anon, PUBLIC;
+
+-- [P0] 무인증 하트 발권 차단 — claim_daily_attendance 래퍼(SECDEF) / service_role 전용.
+REVOKE EXECUTE ON FUNCTION public.grant_heart_atomically(uuid, integer, wallet_reason, uuid, integer) FROM anon, PUBLIC;
+
+-- [P1→P2] 무인증 만료 트리거 차단 — pg_cron(service_role/postgres) 전용. 인자 없이 전체 만료 처리하는 내부 함수.
+REVOKE EXECUTE ON FUNCTION public.fn_expire_heart_lots() FROM anon, authenticated, PUBLIC;
+
+-- [P1] 무인증 잔액 IDOR 차단 — anon(auth.uid()=NULL) 이 본문 권한가드를 단락시켜 임의 UUID 의
+--      diamond/lifetime_purchased 잔액을 조회하던 경로를 봉쇄. authenticated 교차조회는 본문
+--      `v_caller IS NOT NULL AND v_uid <> v_caller` 가드가 PERMISSION_DENIED 로 이미 차단하므로 유지.
+REVOKE EXECUTE ON FUNCTION public.get_wallet_summary(uuid) FROM anon, PUBLIC;
+
+-- [P1] 타인 잔액 소각 차단 — consume 는 create_job_posting_with_payment(SECDEF) 래퍼 경유로만 호출됨
+--      (직접 .rpc('consume_diamonds_atomically') 클라 코드 0건). 직접 호출 봉쇄로 타인 차감 벡터 제거.
+REVOKE EXECUTE ON FUNCTION public.consume_diamonds_atomically(uuid, integer, wallet_reason, uuid, text) FROM anon, authenticated, PUBLIC;
+
+-- [P3] 무인증 출석 호출 차단 — 본문에 NOT_AUTHENTICATED 가드가 있으나 anon 공격표면 축소.
+REVOKE EXECUTE ON FUNCTION public.claim_daily_attendance() FROM anon, PUBLIC;

--- a/uniqn-mobile/supabase/migrations/20260602000001_create_payment_authz_guard.sql
+++ b/uniqn-mobile/supabase/migrations/20260602000001_create_payment_authz_guard.sql
@@ -1,0 +1,161 @@
+-- Fix-1b: create_job_posting_with_payment_atomically 호출자 인가 가드 복원
+--
+-- 근거: docs/planning/2026-06-02-monetization-review-findings.md (payment-rpc-owner-not-bound, P1)
+-- 문제: SECURITY DEFINER 가 job_postings 의 jp_insert RLS(역할 체크) 를 우회하고, p_owner_id 를
+--       auth.uid() 로 검증하지 않아 임의 authenticated 사용자가 타인 비용으로 결제·공고 위조 가능.
+-- 사실: 생성 플로우는 항상 ownerId = caller(auth.uid) (useJobManagement → createJobPosting(input, user.uid))
+--       이고 workspace 도 owner 자신 것에서 해결되므로(getDefaultWorkspaceIdForOwner), caller=owner 바인딩이
+--       legit 플로우를 깨지 않는다. 협업자 비대칭(P0-2)은 취소/환불 경로에만 적용(생성 대리 없음).
+--
+-- 가드(본문 외 로직 변경 없음 — INSERT/cost/consume 본문은 현행 보존):
+--   - service_role(백엔드, auth.uid()=NULL)은 신뢰 → 통과
+--   - authenticated 는 employer/admin 역할이어야(jp_insert RLS 동치) + 본인(p_owner_id=auth.uid) 공고만
+--     (admin 은 대리 생성 허용 — 기존 RLS 가 admin 역할에 임의 owner INSERT 허용한 것과 동치)
+--   - payload.workspace_id 가 있으면 p_owner_id 소유 워크스페이스여야(타 워크스페이스 침투 차단)
+
+CREATE OR REPLACE FUNCTION public.create_job_posting_with_payment_atomically(
+  p_owner_id uuid,
+  p_posting_payload jsonb,
+  p_reason wallet_reason DEFAULT 'consume_job_posting'::wallet_reason
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_posting_id        UUID;
+  v_type              TEXT;
+  v_cost              INT;
+  v_consume_result    JSONB;
+  v_diamonds_consumed INT := 0;
+  v_heart_consumed    INT := 0;
+  v_defaults          JSONB;
+  v_final_payload     JSONB;
+  v_inserted          INT := 0;
+  v_resolved_workspace_id UUID;
+  v_caller            UUID := (SELECT auth.uid());
+  v_role              TEXT := public.get_my_role();
+  v_payload_ws        UUID;
+BEGIN
+  IF p_owner_id IS NULL THEN
+    RAISE EXCEPTION 'INVALID_OWNER_ID: cannot be NULL';
+  END IF;
+  IF p_posting_payload IS NULL THEN
+    RAISE EXCEPTION 'INVALID_PAYLOAD: cannot be NULL';
+  END IF;
+
+  -- [Fix-1b] 호출자 인가 (service_role/백엔드는 v_caller NULL → 통과)
+  IF v_caller IS NOT NULL THEN
+    -- 역할 게이트: jp_insert RLS (admin|employer) 동치
+    IF v_role NOT IN ('admin', 'employer') THEN
+      RAISE EXCEPTION 'PERMISSION_DENIED: role % cannot create job postings', v_role;
+    END IF;
+    -- owner 위조 차단: 본인 공고만 (admin 은 대리 생성 허용)
+    IF v_role <> 'admin' AND v_caller <> p_owner_id THEN
+      RAISE EXCEPTION 'PERMISSION_DENIED: caller cannot create posting for another owner';
+    END IF;
+    -- 타 워크스페이스 침투 차단: payload.workspace_id 가 있으면 p_owner_id 소유여야
+    v_payload_ws := NULLIF(p_posting_payload->>'workspace_id', '')::uuid;
+    IF v_payload_ws IS NOT NULL
+       AND NOT EXISTS (
+         SELECT 1 FROM public.workspaces WHERE id = v_payload_ws AND owner_id = p_owner_id
+       ) THEN
+      RAISE EXCEPTION 'PERMISSION_DENIED: workspace not owned by owner';
+    END IF;
+  END IF;
+
+  -- 멱등 posting_id: payload.id가 있으면 그것을, 없으면 신규 생성
+  v_posting_id := COALESCE((p_posting_payload->>'id')::uuid, gen_random_uuid());
+  v_type := COALESCE(p_posting_payload->>'posting_type', 'regular');
+
+  -- workspace_id 자동 주입: 페이로드에 없으면 owner 의 1번째 workspace 에서 lookup (M5 호환)
+  IF NOT (p_posting_payload ? 'workspace_id') OR (p_posting_payload->>'workspace_id') IS NULL THEN
+    SELECT id INTO v_resolved_workspace_id
+    FROM public.workspaces
+    WHERE owner_id = p_owner_id
+    ORDER BY created_at ASC
+    LIMIT 1;
+
+    IF v_resolved_workspace_id IS NULL THEN
+      RAISE EXCEPTION 'WORKSPACE_NOT_FOUND: owner % has no workspace — backfill 누락', p_owner_id;
+    END IF;
+  END IF;
+
+  -- 서버 권위 비용 (flag off → 0)
+  v_cost := public._calc_posting_cost(v_type, p_owner_id);
+
+  -- INSERT 본문 보존 (현행 20260427000601과 동일한 defaults + populate_record)
+  v_defaults := jsonb_build_object(
+    'id',                v_posting_id,
+    'schema_version',    3,
+    'status',            'draft',
+    'posting_type',      'regular',
+    'created_at',        now(),
+    'updated_at',        now(),
+    'location',          '{}'::jsonb,
+    'schedule',          '{}'::jsonb,
+    'role_catalog',      '[]'::jsonb,
+    'compensation',      '{}'::jsonb,
+    'questions',         jsonb_build_object('items', '[]'::jsonb),
+    'stats',             jsonb_build_object(
+                           'filledPositions', 0,
+                           'totalApplicants', 0,
+                           'activeApplicants', 0,
+                           'confirmedApplicants', 0,
+                           'cancellationPendingApplicants', 0
+                         ),
+    'total_positions',   0,
+    'filled_positions',  0,
+    'view_count',        0,
+    'is_featured',       false
+  );
+
+  v_final_payload := v_defaults
+                     || p_posting_payload
+                     || jsonb_build_object('id', v_posting_id, 'owner_id', p_owner_id);
+
+  -- workspace_id 자동 주입 적용 (M5 호환): payload에 없을 때만 resolved 값 병합
+  IF v_resolved_workspace_id IS NOT NULL THEN
+    v_final_payload := v_final_payload || jsonb_build_object('workspace_id', v_resolved_workspace_id);
+  END IF;
+
+  INSERT INTO public.job_postings
+  SELECT * FROM jsonb_populate_record(NULL::public.job_postings, v_final_payload)
+  ON CONFLICT (id) DO NOTHING;
+  GET DIAGNOSTICS v_inserted = ROW_COUNT;
+
+  -- 멱등: 이미 존재(재시도)면 차감 없이 기존 결과 반환
+  IF v_inserted = 0 THEN
+    RETURN jsonb_build_object(
+      'success', true,
+      'posting_id', v_posting_id,
+      'idempotent', true,
+      'diamonds_consumed', 0,
+      'hearts_consumed', 0,
+      'total_consumed', 0
+    );
+  END IF;
+
+  -- 신규 삽입에 한해 차감 (cost>0). consume은 ref_id=posting_id로 멱등(T3).
+  IF v_cost > 0 THEN
+    v_consume_result := public.consume_diamonds_atomically(
+      p_owner_id, v_cost, p_reason, v_posting_id, 'job_posting'
+    );
+    v_diamonds_consumed := COALESCE((v_consume_result->>'diamond_consumed')::int, 0);
+    v_heart_consumed    := COALESCE((v_consume_result->>'heart_consumed')::int, 0);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'posting_id', v_posting_id,
+    'diamonds_consumed', v_diamonds_consumed,
+    'hearts_consumed', v_heart_consumed,
+    'total_consumed', v_diamonds_consumed + v_heart_consumed
+  );
+END;
+$function$;
+
+-- 권한: 직접 호출은 authenticated(본문 가드가 인가) + service_role. anon 차단 유지.
+REVOKE EXECUTE ON FUNCTION public.create_job_posting_with_payment_atomically(uuid, jsonb, wallet_reason) FROM anon, PUBLIC;
+GRANT EXECUTE ON FUNCTION public.create_job_posting_with_payment_atomically(uuid, jsonb, wallet_reason) TO authenticated, service_role;

--- a/uniqn-mobile/supabase/tests/create_payment_authz.test.sql
+++ b/uniqn-mobile/supabase/tests/create_payment_authz.test.sql
@@ -1,0 +1,133 @@
+-- ============================================================
+-- Fix-1b: create_job_posting_with_payment_atomically 호출자 인가 가드
+-- (20260602000001_create_payment_authz_guard)
+-- auth.uid()/get_my_role() 를 request.jwt.claims 로 시뮬레이션해 가드 동작 검증.
+-- 근거: docs/planning/2026-06-02-monetization-review-findings.md
+-- 안전: BEGIN/ROLLBACK
+-- ============================================================
+BEGIN;
+SELECT plan(6);
+
+-- 공통 픽스처: owner(+workspace), attacker, admin
+DO $$
+DECLARE
+  v_owner    uuid := gen_random_uuid();
+  v_ws       uuid := gen_random_uuid();
+  v_attacker uuid := gen_random_uuid();
+  v_admin    uuid := gen_random_uuid();
+BEGIN
+  INSERT INTO auth.users (id, email, aud, role, encrypted_password, raw_app_meta_data, raw_user_meta_data, created_at, updated_at) VALUES
+    (v_owner,    '__sql_fixture_authz_owner@test.local',    'authenticated','authenticated','', '{"role":"employer"}'::jsonb, '{"name":"O"}'::jsonb, now(), now()),
+    (v_attacker, '__sql_fixture_authz_attacker@test.local', 'authenticated','authenticated','', '{"role":"employer"}'::jsonb, '{"name":"A"}'::jsonb, now(), now()),
+    (v_admin,    '__sql_fixture_authz_admin@test.local',    'authenticated','authenticated','', '{"role":"admin"}'::jsonb,    '{"name":"AD"}'::jsonb, now(), now());
+  INSERT INTO public.users (id, email, name, role, is_active, created_at, updated_at) VALUES
+    (v_owner,    '__sql_fixture_authz_owner@test.local',    'fixture','employer', true, now(), now()),
+    (v_attacker, '__sql_fixture_authz_attacker@test.local', 'fixture','employer', true, now(), now()),
+    (v_admin,    '__sql_fixture_authz_admin@test.local',    'fixture','admin',    true, now(), now());
+  INSERT INTO public.workspaces (id, name, owner_id, created_at, updated_at)
+  VALUES (v_ws, '__sql_fixture_authz_ws', v_owner, now(), now());
+
+  PERFORM set_config('test.owner', v_owner::text, false);
+  PERFORM set_config('test.ws', v_ws::text, false);
+  PERFORM set_config('test.attacker', v_attacker::text, false);
+  PERFORM set_config('test.admin', v_admin::text, false);
+END $$;
+
+-- (1)(2) owner 본인 생성 — 성공
+DO $$
+DECLARE
+  v_owner uuid := current_setting('test.owner')::uuid;
+  v_pid   uuid := gen_random_uuid();
+  v_res   jsonb;
+BEGIN
+  PERFORM set_config('request.jwt.claims',
+    jsonb_build_object('sub', v_owner::text, 'app_metadata', jsonb_build_object('role','employer'))::text, true);
+  v_res := public.create_job_posting_with_payment_atomically(
+    v_owner,
+    jsonb_build_object('id', v_pid, 'workspace_id', current_setting('test.ws')::uuid,
+                       'title', '__authz self', 'posting_type', 'regular', 'status', 'active'),
+    'consume_job_posting'::wallet_reason);
+  PERFORM set_config('request.jwt.claims', '', true);
+  PERFORM set_config('test.self_pid', v_pid::text, false);
+  PERFORM set_config('test.self_res', v_res::text, false);
+END $$;
+SELECT is((current_setting('test.self_res')::jsonb)->>'success', 'true', 'owner self-create succeeds');
+SELECT is(
+  (SELECT count(*)::int FROM public.job_postings WHERE id = current_setting('test.self_pid')::uuid), 1,
+  'owner self-create inserts posting');
+
+-- (3)(4) attacker(caller<>owner) 가 owner 비용으로 생성 시도 — 차단
+DO $$
+DECLARE
+  v_owner    uuid := current_setting('test.owner')::uuid;
+  v_attacker uuid := current_setting('test.attacker')::uuid;
+  v_pid      uuid := gen_random_uuid();
+  v_blocked  boolean := false;
+BEGIN
+  PERFORM set_config('request.jwt.claims',
+    jsonb_build_object('sub', v_attacker::text, 'app_metadata', jsonb_build_object('role','employer'))::text, true);
+  BEGIN
+    PERFORM public.create_job_posting_with_payment_atomically(
+      v_owner,
+      jsonb_build_object('id', v_pid, 'workspace_id', current_setting('test.ws')::uuid,
+                         'title', '__authz forge', 'posting_type', 'regular', 'status', 'active'),
+      'consume_job_posting'::wallet_reason);
+  EXCEPTION WHEN OTHERS THEN
+    v_blocked := (SQLERRM LIKE '%PERMISSION_DENIED%');
+  END;
+  PERFORM set_config('request.jwt.claims', '', true);
+  PERFORM set_config('test.forge_blocked', v_blocked::text, false);
+  PERFORM set_config('test.forge_pid', v_pid::text, false);
+END $$;
+SELECT is(current_setting('test.forge_blocked'), 'true', 'attacker (caller<>owner) blocked with PERMISSION_DENIED');
+SELECT is(
+  (SELECT count(*)::int FROM public.job_postings WHERE id = current_setting('test.forge_pid')::uuid), 0,
+  'attacker forge created no posting');
+
+-- (5) staff 역할 — 차단
+DO $$
+DECLARE
+  v_owner uuid := current_setting('test.owner')::uuid;
+  v_pid   uuid := gen_random_uuid();
+  v_blocked boolean := false;
+BEGIN
+  PERFORM set_config('request.jwt.claims',
+    jsonb_build_object('sub', v_owner::text, 'app_metadata', jsonb_build_object('role','staff'))::text, true);
+  BEGIN
+    PERFORM public.create_job_posting_with_payment_atomically(
+      v_owner,
+      jsonb_build_object('id', v_pid, 'workspace_id', current_setting('test.ws')::uuid,
+                         'title', '__authz staff', 'posting_type', 'regular', 'status', 'active'),
+      'consume_job_posting'::wallet_reason);
+  EXCEPTION WHEN OTHERS THEN
+    v_blocked := (SQLERRM LIKE '%PERMISSION_DENIED%');
+  END;
+  PERFORM set_config('request.jwt.claims', '', true);
+  PERFORM set_config('test.staff_blocked', v_blocked::text, false);
+END $$;
+SELECT is(current_setting('test.staff_blocked'), 'true', 'staff role blocked from creating posting');
+
+-- (6) admin 대리 생성 (caller<>owner, role=admin) — 허용 (jp_insert RLS 동치)
+DO $$
+DECLARE
+  v_owner uuid := current_setting('test.owner')::uuid;
+  v_admin uuid := current_setting('test.admin')::uuid;
+  v_pid   uuid := gen_random_uuid();
+  v_res   jsonb;
+BEGIN
+  PERFORM set_config('request.jwt.claims',
+    jsonb_build_object('sub', v_admin::text, 'app_metadata', jsonb_build_object('role','admin'))::text, true);
+  v_res := public.create_job_posting_with_payment_atomically(
+    v_owner,
+    jsonb_build_object('id', v_pid, 'workspace_id', current_setting('test.ws')::uuid,
+                       'title', '__authz admin proxy', 'posting_type', 'regular', 'status', 'active'),
+    'consume_job_posting'::wallet_reason);
+  PERFORM set_config('request.jwt.claims', '', true);
+  PERFORM set_config('test.admin_pid', v_pid::text, false);
+END $$;
+SELECT is(
+  (SELECT count(*)::int FROM public.job_postings WHERE id = current_setting('test.admin_pid')::uuid), 1,
+  'admin proxy-create allowed (RLS parity)');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/uniqn-mobile/supabase/tests/wallet_grants_hardening.test.sql
+++ b/uniqn-mobile/supabase/tests/wallet_grants_hardening.test.sql
@@ -1,0 +1,49 @@
+-- ============================================================
+-- Fix-1a: 결제 도메인 권한 하드닝 (20260602000000_wallet_grants_hardening_p0)
+-- anon/authenticated 의 발권·소각·만료·IDOR 직접호출 차단 + 정상 경로 보존 검증.
+-- 근거: docs/planning/2026-06-02-monetization-review-findings.md
+-- 안전: BEGIN/ROLLBACK (권한 조회만, 변이 없음)
+-- ============================================================
+BEGIN;
+SELECT plan(15);
+
+-- [P0/P1] anon 직접호출 전면 차단
+SELECT ok(NOT has_function_privilege('anon', 'public.credit_diamonds_atomically(uuid,integer,text,text)', 'EXECUTE'),
+  'anon cannot EXECUTE credit_diamonds_atomically (no anon diamond minting)');
+SELECT ok(NOT has_function_privilege('anon', 'public.grant_heart_atomically(uuid,integer,wallet_reason,uuid,integer)', 'EXECUTE'),
+  'anon cannot EXECUTE grant_heart_atomically (no anon heart minting)');
+SELECT ok(NOT has_function_privilege('anon', 'public.fn_expire_heart_lots()', 'EXECUTE'),
+  'anon cannot EXECUTE fn_expire_heart_lots');
+SELECT ok(NOT has_function_privilege('anon', 'public.get_wallet_summary(uuid)', 'EXECUTE'),
+  'anon cannot EXECUTE get_wallet_summary (IDOR closed)');
+SELECT ok(NOT has_function_privilege('anon', 'public.consume_diamonds_atomically(uuid,integer,wallet_reason,uuid,text)', 'EXECUTE'),
+  'anon cannot EXECUTE consume_diamonds_atomically');
+SELECT ok(NOT has_function_privilege('anon', 'public.claim_daily_attendance()', 'EXECUTE'),
+  'anon cannot EXECUTE claim_daily_attendance');
+
+-- [P0/P1] authenticated 직접호출 차단 (발권/소각/만료는 래퍼·cron·service_role 전용)
+SELECT ok(NOT has_function_privilege('authenticated', 'public.credit_diamonds_atomically(uuid,integer,text,text)', 'EXECUTE'),
+  'authenticated cannot EXECUTE credit_diamonds_atomically');
+SELECT ok(NOT has_function_privilege('authenticated', 'public.grant_heart_atomically(uuid,integer,wallet_reason,uuid,integer)', 'EXECUTE'),
+  'authenticated cannot EXECUTE grant_heart_atomically');
+SELECT ok(NOT has_function_privilege('authenticated', 'public.consume_diamonds_atomically(uuid,integer,wallet_reason,uuid,text)', 'EXECUTE'),
+  'authenticated cannot EXECUTE consume_diamonds_atomically directly (wrapper-only)');
+SELECT ok(NOT has_function_privilege('authenticated', 'public.fn_expire_heart_lots()', 'EXECUTE'),
+  'authenticated cannot EXECUTE fn_expire_heart_lots');
+
+-- 정상 경로 보존: authenticated 본인 잔액조회/출석/공고생성은 유지
+SELECT ok(has_function_privilege('authenticated', 'public.get_wallet_summary(uuid)', 'EXECUTE'),
+  'authenticated CAN EXECUTE get_wallet_summary (own balance preserved)');
+SELECT ok(has_function_privilege('authenticated', 'public.claim_daily_attendance()', 'EXECUTE'),
+  'authenticated CAN EXECUTE claim_daily_attendance (own attendance preserved)');
+SELECT ok(has_function_privilege('authenticated', 'public.create_job_posting_with_payment_atomically(uuid,jsonb,wallet_reason)', 'EXECUTE'),
+  'authenticated CAN EXECUTE create_job_posting_with_payment (posting creation preserved)');
+
+-- service_role(webhook/cron/backend) 는 발권 함수 유지
+SELECT ok(has_function_privilege('service_role', 'public.credit_diamonds_atomically(uuid,integer,text,text)', 'EXECUTE'),
+  'service_role CAN EXECUTE credit_diamonds_atomically (webhook credit preserved)');
+SELECT ok(has_function_privilege('service_role', 'public.grant_heart_atomically(uuid,integer,wallet_reason,uuid,integer)', 'EXECUTE'),
+  'service_role CAN EXECUTE grant_heart_atomically');
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## 배경

유료화 롤아웃 前 결제/수익모델 9차원 적대적 리뷰(31 에이전트 + prod ACL 실측)에서 **현재 cost=0 상태에서도 살아있는 prod 보안 홀**을 적발. 전체 findings: `docs/planning/2026-06-02-monetization-review-findings.md`.

선행 하드닝 마이그 `20260530000006` 이 consume/create/refund 만 anon REVOKE 하고 **credit·grant_heart·expire·get_wallet_summary 4종을 누락**한 것이 근본 원인.

## 변경

### Fix-1a — 권한 하드닝 (`20260602000000`, ✅ prod 적용 완료)
순수 GRANT 조정(본문 무변경). 모든 함수 SECDEF라 래퍼/cron/webhook 내부 호출 무영향.

| 함수 | 조치 | 차단 |
|---|---|---|
| `credit_diamonds_atomically` | anon REVOKE | **P0** 무인증 다이아 발권 |
| `grant_heart_atomically` | anon REVOKE | **P0** 무인증 하트 발권 |
| `get_wallet_summary` | anon REVOKE | **P1** 무인증 잔액 IDOR (authenticated 본인조회 유지) |
| `consume_diamonds_atomically` | authenticated REVOKE | **P1** 타인 잔액 소각 (래퍼 전용) |
| `fn_expire_heart_lots` | anon/authenticated REVOKE | 무인증 만료 트리거 |
| `claim_daily_attendance` | anon REVOKE | 공격표면 축소 |

prod ACL 15개 단언 실측 확인 + pgTAP 회귀 테스트(`wallet_grants_hardening.test.sql`).

### Fix-1b — create_payment 호출자 인가 가드 (`20260602000001`, ⚠️ prod 미적용)
SECDEF가 `jp_insert` RLS(역할 체크)를 우회 + p_owner_id 미검증 → 타인 비용 결제·공고 위조 가능(**P1**).
- service_role(auth.uid NULL) 통과 / authenticated 는 employer·admin 역할 + 본인 공고만(admin 대리 허용=RLS 동치) / payload.workspace_id 는 owner 소유 검증.
- INSERT/cost/consume 본문 보존. 본문 변경이라 **prod 미적용 — 이 PR CI(신규 스택 pgTAP) Red-Green 검증 후 머지 시 반영**.
- pgTAP authz 테스트(jwt 클레임 시뮬레이션, 6 단언).

## 검증
- [x] Fix-1a: prod ACL 실측 (anon/authenticated/service_role EXECUTE 매트릭스 의도대로)
- [x] jwt 클레임 시뮬레이션 동작 확인 (auth.uid()/get_my_role())
- [ ] CI: pgTAP green (Fix-1b 포함 — Docker 로컬 미가동으로 CI에 위임)
- [ ] tsc/lint (SQL-only 변경, TS 무영향)

## 안전
플래그/배포/외부설정 무변경. prod cost=0 유지. Fix-1a는 라이브 홀이라 즉시 적용(REVOKE, 무위험), Fix-1b는 핫패스 본문이라 CI 게이트 경유.

🤖 Generated with [Claude Code](https://claude.com/claude-code)