### PR TITLE
fix(wallet): 환불 동시성·관측성 하드닝 — 이중환불 차단 + 실패 Sentry (P1)

### DIFF
--- a/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
@@ -470,13 +470,38 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
       // RPC 실패가 취소를 되돌리지 않도록 swallow + 경고 로깅(멱등이라 후속 재시도 가능).
       try {
         const refund = await WalletRepository.refundJobCancellation(jobPostingId, cur.ownerId);
-        if (refund.success && !('idempotent' in refund && refund.idempotent)) {
-          logger.info('공고 취소 환불 완료', { jobPostingId, refunded: refund.refunded_diamonds });
+        if (refund.success) {
+          if (!('idempotent' in refund && refund.idempotent)) {
+            logger.info('공고 취소 환불 완료', {
+              jobPostingId,
+              refunded: refund.refunded_diamonds,
+            });
+          }
+        } else if (refund.error === 'no_consumption_found') {
+          // 정상 no-op: 무과금(flag off)·미차감 공고는 환불 대상 없음 — 경보 아님.
+          logger.debug('공고 취소 — 환불 대상 차감 없음(no-op)', { jobPostingId });
+        } else {
+          // 예상치 못한 실패(unauthorized/invalid_args 등): 취소는 성립했으나 환불 미수행 → 관측 필요.
+          logger.warn('공고 취소 환불 미수행 — 취소 성립, 환불 후속 필요', {
+            jobPostingId,
+            error: refund.error,
+          });
+          Sentry.addBreadcrumb({
+            category: 'wallet.refund',
+            level: 'error',
+            message: 'refund_returned_failure_after_cancel',
+            data: { jobPostingId, error: refund.error },
+          });
         }
       } catch (refundError) {
+        // RPC transport/예외: 취소는 성립. 멱등이라 후속 재시도 안전하나 신호가 필요.
         logger.warn('공고 취소 환불 실패 — 취소는 성립, 환불 후속 필요', {
           jobPostingId,
           error: refundError instanceof Error ? refundError.message : String(refundError),
+        });
+        Sentry.captureException(refundError, {
+          tags: { domain: 'wallet', op: 'refund_after_cancel' },
+          extra: { jobPostingId, ownerId: cur.ownerId },
         });
       }
 

--- a/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.delete.refund.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/JobPostingRepository.delete.refund.test.ts
@@ -1,5 +1,6 @@
 // src/repositories/supabase/__tests__/JobPostingRepository.delete.refund.test.ts
 import { SupabaseJobPostingRepository } from '../JobPostingRepository';
+import * as Sentry from '@sentry/react-native';
 
 const mockRefund = jest.fn();
 jest.mock('@/repositories/supabase/WalletRepository', () => ({
@@ -27,7 +28,11 @@ jest.mock('@/utils/supabase', () => {
     },
   };
 });
-jest.mock('@sentry/react-native', () => ({ __esModule: true, addBreadcrumb: jest.fn() }));
+jest.mock('@sentry/react-native', () => ({
+  __esModule: true,
+  addBreadcrumb: jest.fn(),
+  captureException: jest.fn(),
+}));
 
 const mockParseJobPosting = jest.fn();
 jest.mock('@/schemas', () => {
@@ -107,5 +112,37 @@ describe('deleteWithTransaction → 환불 연결', () => {
     mockRefund.mockRejectedValue(new Error('refund down'));
 
     await expect(repo.deleteWithTransaction(POSTING, OWNER)).resolves.toBeUndefined();
+  });
+
+  it('환불 RPC throw 시 Sentry.captureException 으로 관측 신호 기록', async () => {
+    setupOwnerDelete();
+    mockRefund.mockRejectedValue(new Error('refund down'));
+
+    await repo.deleteWithTransaction(POSTING, OWNER);
+
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('환불 success:false(unauthorized 등 예상외)는 Sentry breadcrumb 로 관측 + 취소 성립', async () => {
+    setupOwnerDelete();
+    mockRefund.mockResolvedValue({ success: false, error: 'unauthorized' });
+
+    await expect(repo.deleteWithTransaction(POSTING, OWNER)).resolves.toBeUndefined();
+
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'refund_returned_failure_after_cancel' })
+    );
+  });
+
+  it('환불 no_consumption_found(무과금 no-op)는 경보 없이 통과', async () => {
+    setupOwnerDelete();
+    (Sentry.addBreadcrumb as jest.Mock).mockClear();
+    (Sentry.captureException as jest.Mock).mockClear();
+    mockRefund.mockResolvedValue({ success: false, error: 'no_consumption_found' });
+
+    await repo.deleteWithTransaction(POSTING, OWNER);
+
+    expect(Sentry.addBreadcrumb).not.toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 });

--- a/uniqn-mobile/supabase/migrations/20260602000010_refund_idempotency_lock.sql
+++ b/uniqn-mobile/supabase/migrations/20260602000010_refund_idempotency_lock.sql
@@ -1,0 +1,125 @@
+-- Fix-2: 환불 동시성 하드닝 — 이중환불 차단 + lost-update(캐시 drift) 해소
+--
+-- 근거: docs/planning/2026-06-02-monetization-review-findings.md
+--   - refund-idempotency-no-unique (P1): 잠금없는 SELECT-then-INSERT + refund UNIQUE 부재 → 동시 이중환불
+--   - refund-balance-lost-update (P1): 환불이 FOR UPDATE 없이 wallets 읽음 → 동시 차감/환불 시 캐시 drift
+--
+-- 현재 prod wallet_ledger 에 refund_job_cancelled row 0건이라 부분 UNIQUE 인덱스 생성 안전.
+-- ⚠️ 본문 변경 포함 — prod 미적용. CI(신규 스택 pgTAP) Red-Green 후 머지 시 반영.
+
+-- (1) DB 최종 방어선: 동일 posting 당 환불 1회 (부분 UNIQUE)
+CREATE UNIQUE INDEX IF NOT EXISTS uq_wallet_ledger_refund_job
+  ON public.wallet_ledger(user_id, ref_id, reason)
+  WHERE reason = 'refund_job_cancelled';
+
+-- (2) 환불 RPC: wallet FOR UPDATE 직렬화 + 멱등 선조회를 락 안으로 + ON CONFLICT graceful
+CREATE OR REPLACE FUNCTION public.refund_job_cancellation_atomically(p_posting_id uuid, p_owner_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_existing_refund   UUID;
+  v_first_consume_at  TIMESTAMPTZ;
+  v_hours_elapsed     NUMERIC;
+  v_refund_rate       NUMERIC;
+  v_refund_amount     INT;
+  v_diamond_amount    INT;
+  v_heart_amount      INT;
+  v_now               TIMESTAMPTZ := now();
+  v_caller            UUID        := auth.uid();
+  v_post_owner        UUID;
+  v_locked_heart      INT;
+  v_locked_diamond    INT;
+  v_inserted          INT := 0;
+BEGIN
+  IF p_posting_id IS NULL OR p_owner_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'invalid_args');
+  END IF;
+
+  -- [Fix-2] wallet 행 잠금 — consume/credit(둘 다 FOR UPDATE)과 직렬화하여 동시 환불/차감 캐시
+  --         drift(lost-update) 제거 + 이후 멱등 선조회를 임계영역 안으로 들임.
+  INSERT INTO public.wallets(user_id) VALUES (p_owner_id) ON CONFLICT (user_id) DO NOTHING;
+  SELECT heart_balance, diamond_balance INTO v_locked_heart, v_locked_diamond
+    FROM public.wallets WHERE user_id = p_owner_id FOR UPDATE;
+
+  -- 1) 멱등성 (락 보유 상태 — 동시 호출은 여기서 직렬화됨)
+  SELECT id INTO v_existing_refund FROM public.wallet_ledger
+    WHERE ref_id = p_posting_id
+      AND user_id = p_owner_id
+      AND reason = 'refund_job_cancelled'
+    LIMIT 1;
+  IF v_existing_refund IS NOT NULL THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true);
+  END IF;
+
+  -- 2a) posting 존재 + 비용 주체(owner) 일치 검증
+  SELECT owner_id INTO v_post_owner FROM public.job_postings WHERE id = p_posting_id;
+  IF v_post_owner IS NULL OR v_post_owner <> p_owner_id THEN
+    RETURN jsonb_build_object('success', false, 'error', 'unauthorized');
+  END IF;
+
+  -- 2b) caller 권한: service_role(NULL) / owner 본인 / JPC 협업자 만 허용
+  IF v_caller IS NOT NULL
+     AND v_caller <> p_owner_id
+     AND NOT public.is_posting_collaborator(p_posting_id, v_caller) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'unauthorized');
+  END IF;
+
+  -- 3) 차감 row 합산
+  SELECT
+    COALESCE(SUM(CASE WHEN currency_type='diamond' THEN -delta ELSE 0 END), 0)::int,
+    COALESCE(SUM(CASE WHEN currency_type='heart'   THEN -delta ELSE 0 END), 0)::int,
+    MIN(created_at)
+  INTO v_diamond_amount, v_heart_amount, v_first_consume_at
+  FROM public.wallet_ledger
+  WHERE ref_id = p_posting_id
+    AND user_id = p_owner_id
+    AND reason IN ('consume_job_posting','consume_job_extend','consume_job_upgrade');
+
+  IF v_first_consume_at IS NULL OR (v_diamond_amount + v_heart_amount) <= 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'no_consumption_found');
+  END IF;
+
+  -- 4) 환불 비율 계산 (Decision #1: 24h 내 100% / 이후 50%)
+  v_hours_elapsed := EXTRACT(EPOCH FROM (v_now - v_first_consume_at)) / 3600;
+  v_refund_rate := CASE WHEN v_hours_elapsed < 24 THEN 1.0 ELSE 0.5 END;
+  v_refund_amount := FLOOR((v_diamond_amount + v_heart_amount) * v_refund_rate)::int;
+
+  -- 5) 환불 ledger row (항상 owner 지갑, 잠긴 잔액 스냅샷 사용) — 동시 경합은 부분 UNIQUE 가 차단
+  INSERT INTO public.wallet_ledger(
+    user_id, currency_type, delta, reason, ref_id, ref_type,
+    balance_after_heart, balance_after_diamond, metadata
+  )
+  VALUES (
+    p_owner_id, 'diamond', v_refund_amount, 'refund_job_cancelled',
+    p_posting_id, 'job_posting',
+    v_locked_heart,
+    v_locked_diamond + v_refund_amount,
+    jsonb_build_object(
+      'original_diamond', v_diamond_amount,
+      'original_heart',   v_heart_amount,
+      'refund_rate',      v_refund_rate,
+      'hours_elapsed',    v_hours_elapsed,
+      'cancelled_by',     v_caller
+    )
+  )
+  ON CONFLICT (user_id, ref_id, reason) WHERE reason = 'refund_job_cancelled' DO NOTHING;
+
+  GET DIAGNOSTICS v_inserted = ROW_COUNT;
+  IF v_inserted = 0 THEN
+    -- 동시 환불이 먼저 커밋됨 → 이중환불 방지, 멱등 반환
+    RETURN jsonb_build_object('success', true, 'idempotent', true);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success',          true,
+    'refunded_diamonds', v_refund_amount,
+    'refund_rate',       v_refund_rate,
+    'hours_elapsed',     v_hours_elapsed,
+    'original_diamond',  v_diamond_amount,
+    'original_heart',    v_heart_amount
+  );
+END;
+$function$;

--- a/uniqn-mobile/supabase/tests/refund_idempotency.test.sql
+++ b/uniqn-mobile/supabase/tests/refund_idempotency.test.sql
@@ -1,0 +1,72 @@
+-- ============================================================
+-- Fix-2: 환불 멱등성/이중환불 차단 (20260602000010_refund_idempotency_lock)
+-- 부분 UNIQUE 인덱스 존재 + 동일 posting 재환불 시 idempotent(이중 적립 없음) 검증.
+-- 근거: docs/planning/2026-06-02-monetization-review-findings.md
+-- 안전: BEGIN/ROLLBACK. auth.uid() = request.jwt.claim.sub
+-- ============================================================
+BEGIN;
+SELECT plan(5);
+
+-- (1) DB 최종 방어선: 부분 UNIQUE 인덱스 존재
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname='public' AND tablename='wallet_ledger'
+      AND indexname='uq_wallet_ledger_refund_job'
+  ),
+  'partial UNIQUE index uq_wallet_ledger_refund_job exists'
+);
+
+DO $$
+DECLARE
+  v_owner uuid := gen_random_uuid();
+  v_ws    uuid := gen_random_uuid();
+  v_pid   uuid := gen_random_uuid();
+BEGIN
+  INSERT INTO auth.users (id, email, aud, role, encrypted_password, raw_app_meta_data, raw_user_meta_data, created_at, updated_at)
+  VALUES (v_owner, '__sql_fixture_rfidem_owner@test.local', 'authenticated','authenticated','', '{"role":"employer"}'::jsonb, '{"name":"RI"}'::jsonb, now(), now());
+  INSERT INTO public.users (id, email, name, role, is_active, created_at, updated_at)
+  VALUES (v_owner, '__sql_fixture_rfidem_owner@test.local', 'fixture','employer', true, now(), now());
+  INSERT INTO public.workspaces (id, name, owner_id, created_at, updated_at)
+  VALUES (v_ws, '__sql_fixture_rfidem_ws', v_owner, now(), now());
+  INSERT INTO public.wallets(user_id, diamond_balance) VALUES (v_owner, 0) ON CONFLICT (user_id) DO NOTHING;
+  INSERT INTO public.job_postings (id, owner_id, workspace_id, title, total_positions, filled_positions, status, posting_type, created_at, updated_at)
+  VALUES (v_pid, v_owner, v_ws, '__sql_fixture: rf idem', 1, 0, 'active', 'urgent', now(), now());
+  -- 10 다이아 차감 (1시간 전 → <24h → 100% 환불)
+  INSERT INTO public.wallet_ledger(user_id, currency_type, delta, reason, ref_id, ref_type,
+                                    balance_after_heart, balance_after_diamond, created_at)
+  VALUES (v_owner, 'diamond', -10, 'consume_job_posting', v_pid, 'job_posting', 0, 0, now() - interval '1 hour');
+
+  PERFORM set_config('test.owner', v_owner::text, false);
+  PERFORM set_config('test.pid',   v_pid::text,   false);
+END $$;
+
+SELECT set_config('request.jwt.claim.sub', current_setting('test.owner'), false);
+
+-- (2) 1차 환불 → 성공, 10 다이아 (100%)
+SELECT is(
+  (public.refund_job_cancellation_atomically(
+     current_setting('test.pid')::uuid, current_setting('test.owner')::uuid))->>'refunded_diamonds',
+  '10', 'first refund credits 10 diamonds (100% within 24h)');
+
+-- (3) 2차 환불(동일 posting) → idempotent:true (재적립 없음)
+SELECT is(
+  (public.refund_job_cancellation_atomically(
+     current_setting('test.pid')::uuid, current_setting('test.owner')::uuid))->>'idempotent',
+  'true', 'second refund on same posting returns idempotent');
+
+-- (4) refund_job_cancelled ledger row 는 정확히 1건 (이중환불 차단)
+SELECT is(
+  (SELECT count(*)::int FROM public.wallet_ledger
+   WHERE ref_id = current_setting('test.pid')::uuid
+     AND user_id = current_setting('test.owner')::uuid
+     AND reason = 'refund_job_cancelled'),
+  1, 'exactly one refund ledger row (no double-refund)');
+
+-- (5) 캐시 잔액 = 0(차감 후) + 10(환불) = 10, 20 아님(이중적립 없음)
+SELECT is(
+  (SELECT diamond_balance FROM public.wallets WHERE user_id = current_setting('test.owner')::uuid),
+  10, 'wallet diamond_balance = 10 (single refund credit, no drift)');
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## 배경
유료화 롤아웃 前 적대적 리뷰(`docs/planning/2026-06-02-monetization-review-findings.md`)에서 환불 경로 P1 3건 적발. paid_types ON 후 발동(현재 cost=0이라 잠복).

## 변경

### DB `20260602000010_refund_idempotency_lock.sql` (⚠️ prod 미적용 — CI pgTAP 후 머지 반영)
- **부분 UNIQUE 인덱스** `(user_id, ref_id, reason) WHERE reason='refund_job_cancelled'` — DB 최종 방어선(동시 이중환불 차단). prod refund row 0건이라 생성 안전.
- **refund RPC**: `wallets FOR UPDATE` 조기 락 → consume/credit(둘 다 FOR UPDATE)과 직렬화하여 **lost-update 캐시 drift 해소**. 멱등 선조회를 임계영역 안으로. INSERT `ON CONFLICT DO NOTHING` + ROW_COUNT → 경합 시 graceful `idempotent` 반환. **auth/rate/sum 로직 보존**(기존 refund_collaborator pgTAP 3건 유지).

### 클라 `JobPostingRepository.deleteWithTransaction` 환불 swallow
- catch → `Sentry.captureException` (취소 성립·환불 누락 관측 신호)
- `refund.success===false` 분기: `unauthorized` 등 예상외 → `warn`+breadcrumb / `no_consumption_found`(무과금 no-op) → 무경보

## 검증
- [x] tsc 0, lint 0
- [x] jest: 인접 스위트 281 pass + 환불 관측성 4 신규 (Sentry breadcrumb/captureException, no-op 무경보)
- [ ] CI: pgTAP green — `refund_idempotency.test.sql`(인덱스 존재 + 재환불 idempotent + 이중적립 없음 5단언), 기존 refund_collaborator 3단언

## 리뷰 메모
- refund-heart-to-diamond(P2)·refund-rate-MIN-basis(P2/P3)는 정책/도메인 결정 필요 → 본 PR 범위 밖(findings 문서 참조).
- 본문 변경이라 Fix-1a(순수 REVOKE, 적용 완료)와 달리 prod 미적용. CI 게이트 경유.

🤖 Generated with [Claude Code](https://claude.com/claude-code)