### PR TITLE
fix(webhook): RevenueCat 웹훅 하드닝 — SANDBOX 게이트 + BILLING 오분류 + 상수시간 비교

### DIFF
--- a/uniqn-mobile/supabase/functions/revenuecat-webhook/__tests__/eventClassifier.test.ts
+++ b/uniqn-mobile/supabase/functions/revenuecat-webhook/__tests__/eventClassifier.test.ts
@@ -1,0 +1,94 @@
+/**
+ * revenuecat-webhook eventClassifier 단위 테스트 (Deno-free → jest-expo).
+ * 근거: docs/planning/2026-06-02-monetization-review-findings.md
+ */
+import { classifyEvent, timingSafeEqualStr } from '../eventClassifier.ts';
+
+describe('classifyEvent', () => {
+  const base = { allowSandbox: false } as const;
+
+  it('INITIAL_PURCHASE (prod) → credit', () => {
+    expect(
+      classifyEvent({ ...base, type: 'INITIAL_PURCHASE', environment: 'PRODUCTION' }).action
+    ).toBe('credit');
+  });
+
+  it('NON_RENEWING_PURCHASE → credit', () => {
+    expect(classifyEvent({ ...base, type: 'NON_RENEWING_PURCHASE' }).action).toBe('credit');
+  });
+
+  it('REFUND → refund', () => {
+    expect(classifyEvent({ ...base, type: 'REFUND' }).action).toBe('refund');
+  });
+
+  it('CANCELLATION (소비성 환불 신호) → refund', () => {
+    expect(
+      classifyEvent({ ...base, type: 'CANCELLATION', cancelReason: 'CUSTOMER_SUPPORT' }).action
+    ).toBe('refund');
+  });
+
+  it('CANCELLATION + BILLING_ERROR (갱신 청구실패, 환불 아님) → ignore', () => {
+    const r = classifyEvent({ ...base, type: 'CANCELLATION', cancelReason: 'BILLING_ERROR' });
+    expect(r.action).toBe('ignore');
+    expect(r.reason).toBe('billing_error_not_refund');
+  });
+
+  it('BILLING_ISSUE (청구 실패 통보) → ignore (차감 금지)', () => {
+    const r = classifyEvent({ ...base, type: 'BILLING_ISSUE' });
+    expect(r.action).toBe('ignore');
+    expect(r.reason).toBe('ignored_type');
+  });
+
+  it('RENEWAL → ignore', () => {
+    expect(classifyEvent({ ...base, type: 'RENEWAL' }).action).toBe('ignore');
+  });
+
+  it('SANDBOX 결제 + allowSandbox=false → ignore (실 발권 차단)', () => {
+    const r = classifyEvent({
+      type: 'INITIAL_PURCHASE',
+      environment: 'SANDBOX',
+      allowSandbox: false,
+    });
+    expect(r.action).toBe('ignore');
+    expect(r.reason).toBe('sandbox');
+  });
+
+  it('SANDBOX 결제 + allowSandbox=true → credit (테스트 환경 허용)', () => {
+    expect(
+      classifyEvent({ type: 'INITIAL_PURCHASE', environment: 'SANDBOX', allowSandbox: true }).action
+    ).toBe('credit');
+  });
+
+  it('SANDBOX 게이트는 환불에도 우선 적용 → ignore', () => {
+    expect(
+      classifyEvent({ type: 'REFUND', environment: 'SANDBOX', allowSandbox: false }).action
+    ).toBe('ignore');
+  });
+
+  it('알 수 없는 타입 → unknown', () => {
+    expect(classifyEvent({ ...base, type: 'SOME_FUTURE_EVENT' }).action).toBe('unknown');
+  });
+});
+
+describe('timingSafeEqualStr', () => {
+  it('동일 문자열 → true', () => {
+    expect(timingSafeEqualStr('Bearer abc123', 'Bearer abc123')).toBe(true);
+  });
+
+  it('다른 문자열(동일 길이) → false', () => {
+    expect(timingSafeEqualStr('Bearer abc123', 'Bearer abc124')).toBe(false);
+  });
+
+  it('길이 다름 → false', () => {
+    expect(timingSafeEqualStr('Bearer abc', 'Bearer abc123')).toBe(false);
+  });
+
+  it('둘 다 빈 문자열 → true', () => {
+    expect(timingSafeEqualStr('', '')).toBe(true);
+  });
+
+  it('유니코드 안전 (멀티바이트)', () => {
+    expect(timingSafeEqualStr('키秘密', '키秘密')).toBe(true);
+    expect(timingSafeEqualStr('키秘密', '키秘x')).toBe(false);
+  });
+});

--- a/uniqn-mobile/supabase/functions/revenuecat-webhook/eventClassifier.ts
+++ b/uniqn-mobile/supabase/functions/revenuecat-webhook/eventClassifier.ts
@@ -1,0 +1,100 @@
+/**
+ * revenuecat-webhook 이벤트 분류 + 인증 헬퍼 (순수 로직)
+ *
+ * idp-binding 헬퍼와 동일하게 **Deno-free** (no `Deno.*`, no top-level `jsr:` import) 로
+ * 작성하여 프로젝트 jest-expo 하네스에서 단위 테스트가 가능하다.
+ *
+ * 근거: docs/planning/2026-06-02-monetization-review-findings.md
+ *   - webhook-no-environment-gate (P1): SANDBOX 결제로 실 다이아 발권
+ *   - cancellation-blind-deduct (P2): BILLING_ISSUE / BILLING_ERROR 를 환불로 오분류해 오차감
+ *   - webhook-non-constant-time-compare (P2): secret === 비교 타이밍 사이드채널
+ */
+
+// 잔액 증가 이벤트
+export const CREDIT_TYPES = new Set<string>(['INITIAL_PURCHASE', 'NON_RENEWING_PURCHASE']);
+
+// 잔액 감소(환불) 이벤트.
+//   - REFUND: 확정 환불 → 차감
+//   - CANCELLATION: 소비성 결제에서는 환불 신호 → 차감 (단 cancel_reason=BILLING_ERROR 제외)
+// BILLING_ISSUE 는 제거됨 — '갱신 청구 실패' 신호로 환불/취소가 아니라 무시 대상.
+export const REFUND_TYPES = new Set<string>(['REFUND', 'CANCELLATION']);
+
+// 무시할 이벤트 (구독 미사용 / 단순 정보 / 청구 실패)
+export const IGNORE_TYPES = new Set<string>([
+  'RENEWAL',
+  'EXPIRATION',
+  'PRODUCT_CHANGE',
+  'TRANSFER',
+  'SUBSCRIBER_ALIAS',
+  'NON_SUBSCRIPTION_PURCHASE', // 일부 RC 버전 별칭
+  'TEST',
+  // BILLING_ISSUE: 갱신 청구 실패 통보 — 기지급 소비분 회수가 아님. 차감 금지(무시).
+  'BILLING_ISSUE',
+]);
+
+export type EventAction = 'credit' | 'refund' | 'ignore' | 'unknown';
+
+export interface ClassifyInput {
+  type: string;
+  environment?: string | null;
+  cancelReason?: string | null;
+  allowSandbox: boolean;
+}
+
+export interface ClassifyResult {
+  action: EventAction;
+  reason?: string;
+}
+
+/**
+ * RC 이벤트를 credit/refund/ignore/unknown 으로 분류한다.
+ * 우선순위: SANDBOX 게이트 → IGNORE → CREDIT → REFUND/CANCELLATION → unknown.
+ */
+export function classifyEvent(input: ClassifyInput): ClassifyResult {
+  const { type, environment, cancelReason, allowSandbox } = input;
+
+  // 1) SANDBOX 게이트 — 테스트 결제(무과금)로 실 재화가 발권되지 않도록 차단.
+  //    sandbox 빌드가 prod RC 프로젝트를 가리킬 때의 누출 경로를 봉쇄.
+  if (environment === 'SANDBOX' && !allowSandbox) {
+    return { action: 'ignore', reason: 'sandbox' };
+  }
+
+  if (IGNORE_TYPES.has(type)) {
+    return { action: 'ignore', reason: 'ignored_type' };
+  }
+
+  if (CREDIT_TYPES.has(type)) {
+    return { action: 'credit' };
+  }
+
+  if (type === 'REFUND') {
+    return { action: 'refund' };
+  }
+
+  if (type === 'CANCELLATION') {
+    // 소비성 다이아: CANCELLATION 은 환불 처리 신호 → 차감. 단 갱신 청구실패(BILLING_ERROR)는 환불 아님.
+    if (cancelReason === 'BILLING_ERROR') {
+      return { action: 'ignore', reason: 'billing_error_not_refund' };
+    }
+    return { action: 'refund' };
+  }
+
+  return { action: 'unknown' };
+}
+
+/**
+ * 상수시간 문자열 비교 — 인증 secret 비교의 타이밍 사이드채널 완화.
+ * 길이가 달라도 가능한 만큼 시간을 소비한 뒤 false 반환.
+ */
+export function timingSafeEqualStr(a: string, b: string): boolean {
+  const enc = new TextEncoder();
+  const ab = enc.encode(a);
+  const bb = enc.encode(b);
+  const len = Math.max(ab.length, bb.length);
+  // 길이 차이는 즉시 diff 에 반영(누설 불가피한 정보)하되, 루프는 항상 len 만큼 수행.
+  let diff = ab.length ^ bb.length;
+  for (let i = 0; i < len; i++) {
+    diff |= (ab[i] ?? 0) ^ (bb[i] ?? 0);
+  }
+  return diff === 0;
+}

--- a/uniqn-mobile/supabase/functions/revenuecat-webhook/index.ts
+++ b/uniqn-mobile/supabase/functions/revenuecat-webhook/index.ts
@@ -16,37 +16,22 @@
 // 멱등성: event.id를 wallet_ledger.revenuecat_transaction_id에 저장 (UNIQUE).
 //   RC가 재시도해도 RPC가 idempotent 응답.
 //
-// 환불: REFUND/BILLING_ISSUE/CANCELLATION 이벤트는 음수 diamonds로 RPC 호출.
+// 환불: REFUND, CANCELLATION(소비성 환불 신호, BILLING_ERROR 제외) 이벤트는 음수 diamonds로 RPC 호출.
+//   BILLING_ISSUE 는 '갱신 청구 실패' 신호라 무시. SANDBOX 환경 결제는 실 재화 발권 금지(게이트).
 //   별도 event.id이므로 새로운 ledger row (refund_purchase reason)가 생성됨.
 //
-// Spec §5, Plan Phase 2
+// Spec §5, Plan Phase 2 / 하드닝: docs/planning/2026-06-02-monetization-review-findings.md
 // =============================================================================
 
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 import { createClient } from 'jsr:@supabase/supabase-js@2';
+import { classifyEvent, timingSafeEqualStr } from './eventClassifier.ts';
 
 const responseHeaders = {
   'Content-Type': 'application/json',
 };
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
-// 잔액 증가 이벤트
-const CREDIT_TYPES = new Set<string>(['INITIAL_PURCHASE', 'NON_RENEWING_PURCHASE']);
-
-// 잔액 감소 이벤트 (환불 / 결제 실패 / 사용자 취소)
-const REFUND_TYPES = new Set<string>(['REFUND', 'BILLING_ISSUE', 'CANCELLATION']);
-
-// 무시할 이벤트 (구독 미사용 / 단순 정보)
-const IGNORE_TYPES = new Set<string>([
-  'RENEWAL',
-  'EXPIRATION',
-  'PRODUCT_CHANGE',
-  'TRANSFER',
-  'SUBSCRIBER_ALIAS',
-  'NON_SUBSCRIPTION_PURCHASE', // 일부 RC 버전 별칭
-  'TEST',
-]);
 
 interface RevenueCatEvent {
   type: string;
@@ -103,7 +88,8 @@ Deno.serve(async (req: Request) => {
     });
   }
   const authHeader = req.headers.get('Authorization');
-  if (!authHeader || authHeader !== `Bearer ${expectedSecret}`) {
+  // 상수시간 비교 — secret 비교의 타이밍 사이드채널 완화 (=== 단축평가 회피)
+  if (!authHeader || !timingSafeEqualStr(authHeader, `Bearer ${expectedSecret}`)) {
     return unauthorized();
   }
 
@@ -122,13 +108,21 @@ Deno.serve(async (req: Request) => {
   const event = payload.event;
   const eventType = event.type;
 
-  // 3) 무시 이벤트는 200으로 OK 응답 (RC가 retry 안 하도록)
-  if (IGNORE_TYPES.has(eventType)) {
-    return ok({ ignored: true, type: eventType });
-  }
+  // 3) 이벤트 분류: SANDBOX 게이트 + IGNORE(BILLING_ISSUE 포함) + credit/refund/unknown
+  const allowSandbox = Deno.env.get('REVENUECAT_ALLOW_SANDBOX') === 'true';
+  const decision = classifyEvent({
+    type: eventType,
+    environment: event.environment ?? null,
+    cancelReason: event.cancel_reason ?? null,
+    allowSandbox,
+  });
 
-  // 4) 알려지지 않은 이벤트도 200 (RC retry 폭주 방지) + 로그
-  if (!CREDIT_TYPES.has(eventType) && !REFUND_TYPES.has(eventType)) {
+  // 무시 대상(SANDBOX/구독/청구실패/BILLING_ERROR 취소 등)은 200 OK (RC retry 방지)
+  if (decision.action === 'ignore') {
+    return ok({ ignored: true, type: eventType, reason: decision.reason });
+  }
+  // 알려지지 않은 이벤트도 200 (RC retry 폭주 방지) + 로그
+  if (decision.action === 'unknown') {
     console.warn(`unknown_event_type: ${eventType}`);
     return ok({ ignored: true, type: eventType, reason: 'unknown_type' });
   }
@@ -183,7 +177,7 @@ Deno.serve(async (req: Request) => {
     return badRequest('invalid_product_amount', { product_id: event.product_id });
   }
 
-  const isRefund = REFUND_TYPES.has(eventType);
+  const isRefund = decision.action === 'refund';
   const diamondsToCredit = isRefund ? -totalDiamonds : totalDiamonds;
 
   // 8) credit_diamonds_atomically 호출 (음수=환불, 양수=구매)


### PR DESCRIPTION
## 배경
유료화 롤아웃 前 적대적 리뷰(`docs/planning/2026-06-02-monetization-review-findings.md`) 충전 풀사이클 차원 발견.

## 변경 (`supabase/functions/revenuecat-webhook/`)
분류·비교 로직을 **Deno-free `eventClassifier.ts`** 로 추출(프로젝트 jest 커버리지 확보), `index.ts` 는 헬퍼 사용.

1. **SANDBOX 게이트 (P1, webhook-no-environment-gate)** — `event.environment==='SANDBOX'` 결제는 `REVENUECAT_ALLOW_SANDBOX`(기본 off)가 아니면 `ignore`. sandbox/TestFlight 빌드가 prod RC 프로젝트를 가리킬 때 무료 테스트 결제로 실 다이아가 발권되는 누출 차단.
2. **BILLING 오분류 (P2, cancellation-blind-deduct)** — `BILLING_ISSUE`(갱신 청구 실패 통보)를 REFUND→IGNORE 로 이동. `CANCELLATION` 의 `cancel_reason==='BILLING_ERROR'`(환불 아님)도 제외. 소비성 결제의 정상 `CANCELLATION`(환불)은 차감 유지.
3. **상수시간 secret 비교 (P2, webhook-non-constant-time-compare)** — `authHeader !== \`Bearer …\`` → `timingSafeEqualStr` 로 교체(타이밍 사이드채널 완화).

## 검증
- [x] `eventClassifier.ts`: `deno check` 0
- [x] jest 16 단언 (credit/refund/ignore 분류, SANDBOX 게이트, BILLING_ERROR 제외, timingSafe)
- [x] `index.ts` dangling 참조 0 (CREDIT/REFUND/IGNORE_TYPES → 헬퍼로 이동)
- index.ts `deno check` 의 `npm:openai` 미해결은 supabase functions-js edge-runtime.d.ts 의 transitive 타입 이슈(master 동일) — 본 변경 무관.

## 배포
⚠️ Edge Function 미배포. 머지 시 Deploy Edge Functions GH Action 자동 배포. sandbox 검증 시 `REVENUECAT_ALLOW_SANDBOX=true` (sandbox 프로젝트 한정) 설정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)