### PR TITLE
chore(wallet): RevenueCat 공개 SDK 키 env 배선

### DIFF
--- a/uniqn-mobile/.env.example
+++ b/uniqn-mobile/.env.example
@@ -37,6 +37,14 @@ EXPO_PUBLIC_SUPABASE_ANON_KEY=your_anon_key_here
 # SLACK_OUTBOX_ALERT_WEBHOOK=https://hooks.slack.com/services/XXX/YYY/ZZZ
 
 # ============================================================================
+# RevenueCat 다이아 충전 (네이티브 IAP, 선택적 - 미설정 시 충전 UI 비활성화)
+# ============================================================================
+# 공개(publishable) SDK 키이므로 커밋 가능. eas.json base.env에도 설정됨.
+# RevenueCat 대시보드 > Project settings > API keys 의 App-specific public key.
+# EXPO_PUBLIC_REVENUECAT_IOS_KEY=appl_xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# EXPO_PUBLIC_REVENUECAT_ANDROID_KEY=goog_xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# ============================================================================
 # reCAPTCHA v3 (웹 전용, 선택적 - 미설정 시 봇 방지 비활성화)
 # ============================================================================
 # EXPO_PUBLIC_RECAPTCHA_SITE_KEY=your_recaptcha_site_key_here

--- a/uniqn-mobile/eas.json
+++ b/uniqn-mobile/eas.json
@@ -9,7 +9,9 @@
       "env": {
         "SENTRY_ORG": "129908fd396a",
         "SENTRY_PROJECT": "uniqn-mobile",
-        "RCT_NEW_ARCH_ENABLED": "1"
+        "RCT_NEW_ARCH_ENABLED": "1",
+        "EXPO_PUBLIC_REVENUECAT_IOS_KEY": "appl_XiQzYCeHsEBFgRhRPiUQlbzJVcg",
+        "EXPO_PUBLIC_REVENUECAT_ANDROID_KEY": "goog_AGqIYvWCfjHvDAHOOHPLZZnHZZF"
       }
     },
     "development": {


### PR DESCRIPTION
## 요약
RevenueCat 충전(IAP)에 필요한 공개 SDK 키를 `eas.json base.env`에 배선. 모든 빌드 프로파일(development 포함)이 상속 → dev client sandbox 결제 검증 가능.

## 변경
- `eas.json` base.env: `EXPO_PUBLIC_REVENUECAT_IOS_KEY` / `EXPO_PUBLIC_REVENUECAT_ANDROID_KEY` 추가 (공개 publishable 키라 커밋 안전)
- `.env.example`: RC 키 문서화

## 배경
RC 프로젝트 UNIQN(`proja58415e9`) MCP 설정 연동:
- iOS app `app3b47b876d1` (key appl_…) / Android app `appe743859107` (key goog_…)
- diamond consumable 6종 + Offering default(6 패키지) + 웹훅(Bearer secret, curl 검증 PASS)

## 영향
config-only (TS 변경 없음). 런타임: 키 누락 시 graceful no-op이므로 회귀 위험 없음. 네이티브 모듈 반영은 별도 EAS 빌드 필요(OTA 불가).

🤖 Generated with [Claude Code](https://claude.com/claude-code)