### PR TITLE
fix(deps): expo-intent-launcher 복원 + 1.0.3 — 네이티브 빌드 블로커 해소

### DIFF
--- a/uniqn-mobile/package.json
+++ b/uniqn-mobile/package.json
@@ -70,6 +70,7 @@
     "expo-image": "~55.0.8",
     "expo-image-manipulator": "~55.0.15",
     "expo-image-picker": "~55.0.18",
+    "expo-intent-launcher": "~55.0.12",
     "expo-linear-gradient": "~55.0.13",
     "expo-linking": "~55.0.13",
     "expo-local-authentication": "~55.0.13",
@@ -160,7 +161,8 @@
   "knip": {
     "ignoreDependencies": [
       "react-native-mmkv",
-      "react-native-nitro-modules"
+      "react-native-nitro-modules",
+      "expo-intent-launcher"
     ]
   },
   "private": true

--- a/uniqn-mobile/package.json
+++ b/uniqn-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniqn-mobile",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "index.ts",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## 요약
PR #156이 남긴 **네이티브 빌드 블로커**를 해소합니다. master는 현재 iOS/Android 프로덕션 번들이 실패하는 상태이며, 이 PR 머지 전까지 EAS 빌드·CI가 깨져 있습니다.

## 문제
PR #156(`499590fcf`)의 knip 정리가 `"import 0건 확인"`이라는 근거로 `expo-intent-launcher ~55.0.12`를 제거했으나, `@portone/react-native-sdk/lib/module/SdkDelegate.js`가 이 모듈을 import합니다(KG이니시스 본인인증 SDK의 transitive peer). 결과:

```
Unable to resolve module expo-intent-launcher
  from node_modules/@portone/react-native-sdk/lib/module/SdkDelegate.js
```

→ EAS 프로덕션 빌드가 iOS/Android **양쪽 "Bundle JavaScript" 단계**에서 실패(빌드 `19dc7678` / `f780354b`). `npm run quality`(tsc/lint/format)는 직접 import가 없어 못 잡습니다 — 메모리 `feedback_knip_peer_deps`(mmkv/nitro 선례)와 동일 패턴 재발.

추가로 #156은 package.json에서만 제거하고 lockfile root deps엔 남겨둬 **불일치 상태**였습니다(npm install이 package.json 기준 prune).

## 변경
- `expo install expo-intent-launcher` (~55.0.12, SDK55 정합) 재설치
- `knip.ignoreDependencies`에 `expo-intent-launcher` 추가 → 재발 방지
- 빌드 버전 `1.0.2 → 1.0.3` (iOS 1.0.2가 ASC에 이미 존재해 TestFlight 재업로드 거부 → 신규 테스트 빌드용 상향, package.json 단일 소스)

## 검증
- ✅ 로컬 프로덕션 export: `APP_ENV=production npx expo export --platform android` → `EXIT=0`, Hermes 번들 16MB 생성, resolve 에러 0건
- ✅ `npm run quality` 통과 (0 errors)
- ✅ `npm run release:check` 통과 (버전 1.0.3 단일 소스 무결성)
- ✅ `npm ci --dry-run` package.json↔lockfile 정합 확인
- ✅ **EAS 1.0.3 빌드 성공** — iOS(build35) TestFlight 업로드 + Android(vc34) `UNIQN 1` 테스트 트랙 제출 완료

## 후속 권장
- 배포 빌드 전 `npx expo export`를 게이트로 1회 실행하면 transitive 누락을 EAS 30분 빌드 전에 적발 가능
- 249MB 프로젝트 아카이브 → `.easignore` 정리 여지 (별도)

🤖 Generated with [Claude Code](https://claude.com/claude-code)