### PR TITLE
chore(deps): 미사용 react-refresh devDep 제거 + lockfile 재생성

### DIFF
--- a/uniqn-mobile/package-lock.json
+++ b/uniqn-mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "uniqn-mobile",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "uniqn-mobile",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@expo-google-fonts/outfit": "^0.4.3",
         "@expo-google-fonts/plus-jakarta-sans": "^0.4.2",
@@ -97,7 +97,6 @@
         "jest-watch-typeahead": "^2.2.2",
         "lint-staged": "^15.5.0",
         "prettier": "^3.5.0",
-        "react-refresh": "^0.18.0",
         "react-test-renderer": "19.2.0",
         "source-map-explorer": "^2.5.3",
         "ts-node": "^10.9.2",
@@ -16453,16 +16452,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-refresh": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
-      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react-remove-scroll": {

--- a/uniqn-mobile/package.json
+++ b/uniqn-mobile/package.json
@@ -132,7 +132,6 @@
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^15.5.0",
     "prettier": "^3.5.0",
-    "react-refresh": "^0.18.0",
     "react-test-renderer": "19.2.0",
     "source-map-explorer": "^2.5.3",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
## 요약
rev2 품질 리뷰(PR #169)에서 의도적으로 미뤄둔 후속 작업. 최상위 `react-refresh@^0.18.0` devDep은 소비자 0건 orphan으로, 실제 web Fast Refresh는 expo/react-native/babel-preset이 nested로 끌어오는 `react-refresh@0.14.2`를 사용한다. 제거해도 HMR 영향 없음.

## 변경
- `package.json`: `react-refresh: ^0.18.0` devDep 1줄 제거
- `package-lock.json`: `npm install`로 재생성 — 해당 devDep ref + `node_modules/react-refresh@0.18.0` 노드 삭제, version 1.0.2→1.0.3 동기화(이미 커밋된 package.json에 정합)

## 사전 가드
- `npm why react-refresh`: 최상위 0.18.0은 소비자 0건 orphan 확인
- `overrides`/`resolutions` 강제 없음
- `git log -S`: 의도적 HMR override가 아닌 feature 커밋(`844138cd6`) 부수 추가로 도입됨 → 제거 안전

## 검증 (fresh)
- `npm why react-refresh`: 최상위 0.18.0 소거, nested `0.14.2` 3곳(babel-preset/expo/react-native) 잔존 ✓
- `npm run quality`: exit 0 (tsc 0 errors / eslint 0 errors / prettier all-pass)
- `npx jest`: **4466 passed, 0 failed** (336 suites)
- lockfile diff: react-refresh 2엔트리 삭제 + version 동기화만, 그 외 churn 없음

## 영향
- 런타임/소스 영향 없음(devDep, nested 0.14.2 무변경)
- 보안/RLS/마이그레이션/결제 무관

🤖 Generated with [Claude Code](https://claude.com/claude-code)