### PR TITLE
fix(e2e): CI 러너 리소스 경합 완화 — workers 4→2 + expect timeout 15s

### DIFF
--- a/uniqn-mobile/e2e/playwright.config.ts
+++ b/uniqn-mobile/e2e/playwright.config.ts
@@ -28,7 +28,10 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: isCI,
   retries: isCI ? 2 : 0,
-  workers: isCI ? 4 : 1,
+  // ubuntu-latest 는 2 vCPU. workers:4 + 로컬 Supabase + 웹서버가 CPU 초과구독되면
+  // 인증후 페이지 로드가 expect timeout 을 넘겨 광범위 실패 → retries 3배 증폭 →
+  // 45분 job cap 초과 cancelled. 2 로 낮춰 경합 완화 (8.5→~15분이나 안정적).
+  workers: isCI ? 2 : 1,
   outputDir: testResultsDir,
   reporter: isCI
     ? [['list'], ['html', { open: 'never', outputFolder: htmlReportDir }], ['github']]
@@ -38,7 +41,8 @@ export default defineConfig({
   globalTeardown: require.resolve('./global-teardown'),
 
   timeout: 60_000,
-  expect: { timeout: 10_000 },
+  // CI 러너 부하 시 페이지 로드 여유 확보 (10s → 15s). 근본은 workers 축소.
+  expect: { timeout: 15_000 },
 
   use: {
     baseURL: E2E_CONFIG.runtime.baseUrl,


### PR DESCRIPTION
## 문제
CI E2E 잡이 비결정적으로 45분 job cap을 초과해 `cancelled` 됨. 직전 PR #173 e2e가 **46분22초 후 cancelled**(테스트 assertion 실패 아님, `Cleaning up orphan processes`로 강제 종료)로 만성 경합을 재확인.

## 근본 원인
ubuntu-latest(2 vCPU)에서 playwright `workers:4` + 로컬 Supabase + Expo 웹서버가 CPU 초과구독 → 느린 회차 인증 후 페이지 로드가 `expect timeout(10s)` 초과 → 광범위 실패 → `retries:2`가 3배 증폭 → 45분 cap 초과. 동일 코드가 8.5분 success / 45.8분 cancelled를 모두 생성하는 비결정성으로 확인됨.

## 변경 (`uniqn-mobile/e2e/playwright.config.ts` 단일 파일)
- `workers: isCI ? 4 → 2` (2 vCPU 매칭, 경합 완화)
- `expect.timeout: 10s → 15s` (러너 부하 시 페이지 로드 여유)

## Test plan
- [x] quality (type-check + lint + format) — pre-push 게이트 통과
- [ ] CI: 이 PR의 E2E가 45분 cap 내 완주하는지 확인(workers:2 효과 검증)
- [ ] 머지 후 PR #173에 master 반영 → #173 e2e 재실행으로 end-to-end 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)