### PR TITLE
docs(wiki): overview Dataview MOC 업그레이드

### DIFF
--- a/wiki/overview.md
+++ b/wiki/overview.md
@@ -1,15 +1,15 @@
 ---
 area: architecture
-updated: 2026-06-18
+updated: 2026-06-19
 status: current
 sources:
   - CLAUDE.md
   - memory/project_target_market_pivot.md
   - memory/project_revenue_model_audit_20260609.md
-tags: [overview, hub]
+tags: [overview, hub, moc]
 ---
 
-# T-HOLDEM 위키 — 여기서 시작
+# T-HOLDEM 위키 — 여기서 시작 (MOC)
 
 UNIQN은 홀덤펍·대회사 대상 단발 인력 매칭 앱이다. Expo 55 / RN 0.83.4 / React 19.2 / TypeScript strict / NativeWind 4.2 / Supabase 스택으로 구동된다. (검증됨: CLAUDE.md)
 
@@ -17,7 +17,52 @@ UNIQN은 홀덤펍·대회사 대상 단발 인력 매칭 앱이다. Expo 55 / R
 
 코드베이스의 핵심 아키텍처 리스크는 반복 발생한 **enum 발산 → 읽기 레코드 증발** 패턴(3회)과 **RLS 재귀**(2건 함정)다.
 
-## 허브 링크
+> 📊 아래 표는 **Dataview 플러그인**이 설치돼 있으면 자동 생성된다(미설치 시 코드블록 그대로 표시). 플러그인 없이도 맨 아래 **정적 허브 링크**로 탐색 가능.
+
+## ⚠️ 주의 필요 (자동)
+
+`status`가 `current`가 아닌(= stale·draft) 페이지. 비어 있으면 건강한 상태:
+
+```dataview
+table status, updated, file.mtime as "수정됨"
+from "wiki"
+where status != "current" and file.name != "overview"
+sort updated asc
+```
+
+> file 소스가 없는 페이지(memory/PR# 전용)는 staleness 자동추적 대상이 아니다 → 터미널 `bash wiki/scripts/check-staleness.sh`의 **UNVERIFIABLE** 목록으로 별도 확인.
+
+## 🗺️ 영역별 카탈로그 (자동)
+
+### architecture
+```dataview
+table updated, status, join(file.tags, ", ") as tags
+from "wiki/architecture"
+sort file.name asc
+```
+
+### decisions
+```dataview
+table updated, status, join(file.tags, ", ") as tags
+from "wiki/decisions"
+sort file.name asc
+```
+
+### domain
+```dataview
+table updated, status, join(file.tags, ", ") as tags
+from "wiki/domain"
+sort file.name asc
+```
+
+### sources
+```dataview
+table updated, join(file.tags, ", ") as tags
+from "wiki/sources"
+sort file.name asc
+```
+
+## 🔗 허브 링크 (정적 폴백 — 플러그인 없이도 동작)
 
 ### 아키텍처
 - [[layers]] — 레이어별 의존 원칙 + 예외(TanStack Query 직접 호출)
@@ -36,4 +81,6 @@ UNIQN은 홀덤펍·대회사 대상 단발 인력 매칭 앱이다. Expo 55 / R
 
 ## 운영
 
-규약·워크플로우는 [[AGENTS]] 참조. 최신화 진단: `bash wiki/scripts/check-staleness.sh`.
+- 규약·워크플로우: [[AGENTS]]
+- 질문: `/query` · 소스 반영: `/ingest` · 건강진단: `/lint`
+- 최신화 진단: `bash wiki/scripts/check-staleness.sh` (stale / UNVERIFIABLE)


### PR DESCRIPTION
## 요약

`wiki/overview.md`를 **Dataview 기반 MOC(Map of Content)** 로 업그레이드. 옵시디언에서 위키를 한눈에 탐색·점검하기 위함.

## 변경

- **영역별 자동 카탈로그** — architecture/decisions/domain/sources를 Dataview `table`로 자동 나열(파일·updated·status·tags). `/ingest`로 페이지가 늘면 자동 반영.
- **⚠️ 주의 필요 블록** — `status != current`(stale·draft) 페이지 자동 하이라이트.
- **폴백 유지** — 기존 thesis + 정적 허브 링크(9페이지 + [[AGENTS]])를 그대로 둬 **Dataview 미설치 시에도** 탐색 가능.
- staleness 0 유지. 앱 코드 무변경(마크다운 1파일).

## 사용

옵시디언에 Dataview 커뮤니티 플러그인 설치 시 표가 자동 렌더. 미설치 시 코드블록으로 보이며 정적 링크로 탐색.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
