### PR TITLE
fix(e2e): 45분 cap 초과 cancelled 해소 — timeout 45→75 + retries 2→1

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 75
     permissions:
       contents: read
       issues: write

--- a/uniqn-mobile/e2e/playwright.config.ts
+++ b/uniqn-mobile/e2e/playwright.config.ts
@@ -27,7 +27,8 @@ export default defineConfig({
   testIgnore: /.*-debug\.spec\.ts/,
   fullyParallel: true,
   forbidOnly: isCI,
-  retries: isCI ? 2 : 0,
+  // retries 2→1: 실패/flaky 테스트 재실행을 3배→2배로 줄여 전체 wall-clock 단축 (45분 cap 초과 cancelled 방어, 단일 flake는 1회 재시도로 흡수)
+  retries: isCI ? 1 : 0,
   // ubuntu-latest 는 2 vCPU. workers:4 + 로컬 Supabase + 웹서버가 CPU 초과구독되면
   // 인증후 페이지 로드가 expect timeout 을 넘겨 광범위 실패 → retries 3배 증폭 →
   // 45분 job cap 초과 cancelled. 2 로 낮춰 경합 완화 (8.5→~15분이나 안정적).


### PR DESCRIPTION
## 문제 (시스템 장애)
e2e 잡이 **브랜치 불문 전부 45분 `timeout-minutes` cap 초과로 cancelled** 됨:
- `schedule master`(PR 변경 없는 순수 베이스라인) cancelled
- `fix/e2e-runner-contention`(#174, workers:2 적용본) 자신도 cancelled
- `fix/ux-workflow-audit`(#175) cancelled, `design/ui-ux-consistency-loop`(#173) cancelled ×3

최근 PR들(#170/#172/#175)로 테스트가 **230개 / 42 spec**까지 늘며, workers:2(PR #174)로도 전체 wall-clock이 45분 cap을 초과. 특정 브랜치 회귀 아님(master 자신도 안 통과).

## 변경
- `.github/workflows/e2e.yml`: `timeout-minutes` 45→75 (완주 여유)
- `uniqn-mobile/e2e/playwright.config.ts`: `retries` 2→1 (실패/flaky 재실행 3배→2배, 주 증폭원 완화)

## 검증 계획
- [x] quality (type-check + lint + format) — pre-push 통과
- [ ] 머지 후 `workflow_dispatch`로 master에서 e2e 직접 실행 → 45분 내 **완주(cancel 아님)** 확인
- [ ] master e2e 결과로 실제 pass/fail 파악 (취소가 아닌 진짜 신호 확보)

## 참고
이 수정으로도 완주 후 특정 테스트가 fail하면, 그건 별개의 실제 테스트 결함(인프라 아님)으로 분리 대응.

🤖 Generated with [Claude Code](https://claude.com/claude-code)