### PR TITLE
fix(db-tests): pgTAP RLS 테스트 테이블 GRANT 정합 — CLI version 드리프트 회귀 해소

### DIFF
--- a/uniqn-mobile/supabase/fixtures/jpc_helpers.sql
+++ b/uniqn-mobile/supabase/fixtures/jpc_helpers.sql
@@ -29,6 +29,26 @@
 -- ============================================================================
 
 -- ============================================================================
+-- 테이블 GRANT 정합 (Supabase CLI 버전 드리프트 방어) — 2026-06-19
+-- ============================================================================
+-- 배경: 이 RLS 테스트들은 jpc_test_set_user() 로 role=authenticated/anon 전환 후
+--       public 테이블에 직접 접근한다. prod 는 Supabase 기본 default-privilege 로
+--       anon/authenticated/service_role 에 ALL 테이블 GRANT 를 보유하지만(실측 확인),
+--       `supabase/setup-cli@v1 version: latest` 가 받는 최신 로컬 이미지는
+--       마이그레이션 생성 테이블에 implicit GRANT 를 더 이상 자동부여하지 않는다.
+--       그 결과 RLS 평가 전에 "permission denied for table" (42501) 로 die →
+--       db-tests 전면 red (job_postings_anon_public_select + jpc_*_rls 6 +
+--       workspace_archive). master #175(2026-06-18) 에서 16/16 subtest fail.
+-- 해결: 테스트 스택 grant 를 prod 와 동일하게 맞춰 CLI 버전과 무관하게 결정적으로.
+--       RLS 가 실제 행 접근의 보안 경계이므로 테이블 GRANT 확대는 prod 동치이며 안전.
+-- ⚠️ 함수는 GRANT 금지: 결제 RPC 하드닝(#172, wallet_grants_hardening.test.sql)이
+--    anon/authenticated 에서 REVOKE 한 EXECUTE 를 되살리면 회귀. 테이블/시퀀스만.
+-- ⚠️ 이 파일은 fixtures 전용(prod 등록 금지) — 로컬/CI 테스트 DB 에만 적용된다.
+GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
+GRANT ALL ON ALL TABLES IN SCHEMA public TO anon, authenticated, service_role;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO anon, authenticated, service_role;
+
+-- ============================================================================
 -- 4 페르소나 + 리소스 셋업 (트랜잭션 안에서만 호출, ROLLBACK 로 정리)
 -- ============================================================================
 


### PR DESCRIPTION
## 문제
master **DB Tests (pg_prove)** 가 #175 부터 red. 8개 테스트가 `permission denied for table job_postings/workspaces`(42501)로 실패:
`job_postings_anon_public_select` + `jpc_*_rls`(6) + `workspace_archive`.

> 참고: #172 의 red 는 별개 원인 — `supabase/setup-cli@v1` 의 `version: latest` 가 GitHub API rate limit 에 걸려 **테스트가 한 번도 실행되지 않음**(6초 실패). 마지막 정상 실행은 #170(2026-06-05).

## 근본 원인
이 RLS 테스트들은 `jpc_test_set_user()` 로 `role=authenticated/anon` 전환 후 `public.job_postings` / `public.workspaces` 에 **직접 접근**한다 → 테이블 레벨 GRANT 필요.

- **prod**: Supabase 기본 default-privilege 로 anon/authenticated/service_role 에 ALL 테이블 GRANT 보유 (실측 확인 → **앱 정상, prod 영향 0**).
- **CI 로컬**: `version: latest` 가 받는 최신 Supabase 이미지가 마이그레이션 생성 테이블에 implicit GRANT 를 더 이상 자동부여하지 않음 → 6/5 통과 → 6/18 실패로 회귀.
- `job_postings`/`workspaces` 를 명시 GRANT 하는 마이그레이션은 **0개**(기본 권한에만 의존).

## 해결
테스트 setup 훅 `supabase/fixtures/jpc_helpers.sql`(fixtures 전용 · **prod 미적용**, `docker exec psql -U postgres` 로 로컬 컨테이너에만 실행)에 prod 동치 테이블/시퀀스 GRANT 추가 → CLI 버전과 무관하게 결정적.

- **함수 GRANT 제외**: 결제 RPC 하드닝(#172)이 anon/authenticated 에서 REVOKE 한 EXECUTE 를 되살리면 `wallet_grants_hardening.test.sql` 회귀 → 테이블/시퀀스만.
- RLS 가 실제 행 접근의 보안 경계이므로 테이블 GRANT 확대는 prod 동치이며 안전.

## 검증
- **RED**: master #175 CI 실 로그 (16/16 subtest fail, `permission denied for table`).
- **GREEN**: 본 PR 의 db-tests CI (이 변경으로 통과 기대).

## Test plan
- [ ] db-tests (pg_prove) CI green
- [ ] `wallet_grants_hardening` / `job_postings_anon_public_select` / `jpc_*_rls` / `workspace_archive` 통과 확인

## 후속(별도)
- `supabase/setup-cli` `version: latest` → 고정 버전 pin 검토 (#172 rate-limit flake + 향후 드리프트 동시 예방).

🤖 Generated with [Claude Code](https://claude.com/claude-code)