### PR TITLE
ci: supabase/setup-cli 버전 pin(2.107.0) + github-token — rate-limit·드리프트 예방

### DIFF
--- a/.github/workflows/db-tests.yml
+++ b/.github/workflows/db-tests.yml
@@ -29,7 +29,11 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          # 버전 pin: version:latest 는 GitHub API 'resolve latest' 호출로 익명 rate-limit(#172
+          # 6초 실패) + 이미지 드리프트(implicit 테이블 GRANT 소실 회귀, PR #179) 유발.
+          # 고정 버전 + github-token 인증으로 둘 다 예방. 갱신 시 supabase/cli 릴리스 참고.
+          version: 2.107.0
+          github-token: ${{ github.token }}
 
       - name: Start local Supabase
         run: supabase start

--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -48,7 +48,10 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          # 버전 pin + github-token: version:latest 의 익명 GitHub API rate-limit(#172) +
+          # 이미지 드리프트(PR #179) 예방. 갱신 시 supabase/cli 릴리스 참고.
+          version: 2.107.0
+          github-token: ${{ github.token }}
 
       - name: Determine functions to deploy
         id: targets

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,7 +36,10 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          # 버전 pin + github-token: version:latest 의 익명 GitHub API rate-limit(#172) +
+          # 이미지 드리프트(PR #179) 예방. 갱신 시 supabase/cli 릴리스 참고.
+          version: 2.107.0
+          github-token: ${{ github.token }}
 
       - name: Start local Supabase
         run: supabase start


### PR DESCRIPTION
## 문제
`db-tests` / `e2e` / `deploy-edge-functions` 3개 워크플로우가 `supabase/setup-cli@v1` 을 **`version: latest` + github-token 없이** 사용 → 매 실행마다 GitHub API 'resolve latest' **익명** 호출.

- **#172**: 익명 rate-limit → `Failed to resolve latest Supabase CLI release: rate limit exceeded` → Setup 단계 6초 실패(테스트 0개 실행).
- **PR #179**: `latest` 이미지가 드리프트 → 마이그레이션 생성 테이블에 implicit GRANT 미부여 → pgTAP RLS 테스트 `permission denied for table` 전면 red.

두 사고 모두 `version: latest`(+token 부재) 단일 뿌리.

## 해결
- **버전 pin `2.107.0`**(현재 최신 stable, 'v' 없는 semver 포맷) → 이미지 드리프트 예방.
- **`github-token: ${{ github.token }}`** 추가 → API 인증으로 rate-limit 예방(README 권장 패턴).
- 3개 워크플로우 일괄 적용.

PR #179(테스트 GRANT 정합)는 CLI 버전과 무관하게 db-tests 를 robust 하게 만들고, 본 PR 은 그 위에 rate-limit·드리프트 자체를 막는 보완.

## Test plan
- [ ] db-tests (pg_prove) green — pin 버전으로 정상 setup + 통과
- [ ] e2e setup-cli 정상 동작
- [ ] (deploy-edge-functions 는 master push 시에만 실행 — 머지 후 확인)

## 후속
- CLI 버전 정기 갱신은 Dependabot(github-actions) 또는 수동. 현재는 명시 핀으로 충분.

🤖 Generated with [Claude Code](https://claude.com/claude-code)