### PR TITLE
docs(wiki): db-tests CLI grant 드리프트 ingest + .obsidian gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,9 @@ claude_set/
 .cursor/rules/
 .gstack/
 
+# Obsidian 볼트 로컬 설정 (플러그인/워크스페이스 등 — 버전관리 제외)
+.obsidian/
+
 # ========================================
 # GENERATED/TEMPORARY FILES
 # ========================================

--- a/wiki/architecture/rls-model.md
+++ b/wiki/architecture/rls-model.md
@@ -1,6 +1,6 @@
 ---
 area: architecture
-updated: 2026-06-18
+updated: 2026-06-19
 status: current
 sources:
   - uniqn-mobile/supabase/migrations/20260525153952_fix_job_postings_anon_public_select.sql
@@ -10,7 +10,8 @@ sources:
   - memory/pitfall_rls_with_check_self_select_recursion.md
   - PR#91
   - PR#92
-tags: [rls, postgres, security, supabase, recursion, secdef]
+  - PR#179
+tags: [rls, postgres, security, supabase, recursion, secdef, grants]
 ---
 
 # RLS 모델
@@ -30,6 +31,7 @@ tags: [rls, postgres, security, supabase, recursion, secdef]
 1. **permissive 정책은 OR 합산** — 하나라도 USING 절에서 함수 권한 실패 시 쿼리 전체 abort.
 2. **RLS 안에서 같은 테이블 inline SELECT → cycle 감지(42P17)** — SECURITY DEFINER plpgsql 함수로 wrap 필수.
 3. **SECDEF 함수는 절대 anon에 노출 금지** — 멤버십 논리는 `authenticated`에만 부여.
+4. **테이블 GRANT 는 RLS와 별개의 coarse 레이어** — RLS 평가 이전에 테이블 권한이 없으면 `permission denied for table`(42501)로 abort(RLS는 0행이 아니라 권한 거부). prod 는 Supabase 기본 default-privilege 로 GRANT 보유하지만 테스트/신환경은 implicit 부여에 의존하면 깨진다 → 명시 GRANT([[test-db-grants]]).
 
 ## 함정 1: anon + SECDEF 헬퍼 → 42501 (검증됨)
 
@@ -65,3 +67,4 @@ WITH CHECK 안 `SELECT count(*) FROM workspaces WHERE owner_id = auth.uid()` →
 - [[layers]] — Service/Repository에서 Supabase 호출 방식
 - [[roles]] — UserRole과 RLS authenticated 계층 매핑
 - [[enum-divergence]] — RLS와 함께 발생한 읽기 증발 패턴
+- [[test-db-grants]] — 테이블 GRANT 레이어를 테스트에서 명시화한 결정

--- a/wiki/decisions/test-db-grants.md
+++ b/wiki/decisions/test-db-grants.md
@@ -1,0 +1,37 @@
+---
+area: decisions
+updated: 2026-06-19
+status: current
+sources:
+  - uniqn-mobile/supabase/fixtures/jpc_helpers.sql
+  - .github/workflows/db-tests.yml
+  - PR#179
+  - PR#180
+tags: [db-tests, ci, grants, supabase, pgtap]
+---
+
+# 결정: 테스트 DB 권한은 명시 GRANT + CLI 버전 pin
+
+**한 줄:** pgTAP 테스트는 Supabase 기본 default-privilege(implicit 테이블 GRANT)에 의존하지 말고, 테스트 fixture에서 **명시 GRANT** + setup-cli **버전 고정**으로 환경 드리프트에 면역시킨다.
+
+## 왜 (검증됨)
+
+테이블 레벨 GRANT 는 RLS(행 가시성)와 **별개의 coarse 레이어**다([[rls-model]]). pgTAP RLS 테스트는 `jpc_test_set_user()`(`uniqn-mobile/supabase/fixtures/jpc_helpers.sql:139`)로 `authenticated`/`anon` 으로 전환 후 `job_postings`/`workspaces` 에 직접 접근하므로 그 GRANT 가 존재해야 RLS 평가에 도달한다.
+
+prod 는 Supabase 기본 default-privilege 로 GRANT 를 보유하지만, CI 의 `supabase/setup-cli` `version: latest` 가 받는 최신 이미지는 마이그레이션 생성 테이블에 implicit GRANT 를 자동부여하지 않게 드리프트 → `permission denied for table` 로 db-tests 전면 red(상세 [[db-tests-cli-grant-drift]]). 명시 GRANT 마이그레이션이 0개라 기본권한에만 의존한 게 취약점.
+
+## 규칙
+
+1. **테스트 grant 는 명시적으로** — `jpc_helpers.sql`(fixtures 전용, `npm run test:db:helpers` 가 로컬 컨테이너에만 등록)에서 `GRANT ALL ON ALL TABLES/SEQUENCES IN SCHEMA public TO anon, authenticated, service_role`. prod grant 상태와 동치 → CLI 버전 무관 결정적.
+2. **함수는 grant 확대 금지** — 결제 RPC 하드닝이 anon/authenticated 에서 REVOKE 한 EXECUTE 를 되살리면 회귀(`wallet_grants_hardening.test.sql`). 테이블/시퀀스만.
+3. **setup-cli 버전 pin** — `version: 2.107.0` + `github-token`(PR#180). `latest` 는 (a) 익명 GitHub API rate-limit, (b) 이미지 드리프트 두 사고의 단일 뿌리. 3개 워크플로우 일괄.
+4. **fixtures 는 prod 등록 금지** — SECDEF 헬퍼 포함, prod 적용 시 RLS 우회 가능(catastrophic).
+
+## 경계 (raw 수정 금지 영역과의 관계)
+
+테스트 grant 는 `wiki/`(여기) 가 아니라 `uniqn-mobile/supabase/fixtures/` 가 단일 소스. 이 페이지는 "왜 그렇게 했는가"의 합성일 뿐, 규칙 변경은 fixture/workflow 수정으로.
+
+## 관련
+- [[rls-model]] — 테이블 GRANT vs RLS 정책 레이어(증상은 같고 원인 다름)
+- [[db-tests-cli-grant-drift]] — 이 결정의 원천 소스(RED→GREEN 증거)
+- [[enum-divergence]] — DB 스키마/환경 드리프트가 읽기를 깨는 또 다른 클래스

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -12,6 +12,7 @@
 - [[enum-divergence]] — enum 발산 → 읽기 레코드 증발 방지 규칙 (3회 재발 클래스)
 - [[worktime-ssot]] — 근무시간 표시 SSOT(WorkTimeDisplay) 우회 금지
 - [[capacity-full]] — 공고 자동마감 capacity_full + dead counter 제거
+- [[test-db-grants]] — 테스트 DB는 명시 GRANT + setup-cli 버전 pin (기본 default-privilege 의존 금지)
 
 ## domain
 - [[roles]] — UserRole(앱권한: admin/employer/staff) vs StaffRole(직무: dealer/floor/serving)
@@ -19,4 +20,4 @@
 - [[revenue-model]] — 이중통화(하트·다이아)·IAP·RevenueCat (게이트 OFF 휴면)
 
 ## sources
-_(ingest로 점진 추가)_
+- [[db-tests-cli-grant-drift]] — pg_prove red 근본원인: setup-cli `version:latest` 드리프트로 implicit 테이블 GRANT 소실 (PR#179/#180)

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -6,3 +6,5 @@
 ## [2026-06-18] bootstrap | 위키 초기화 (골격 + 백본 시드 + 커맨드 + 감지 스크립트)
 
 ## [2026-06-18] bootstrap | 백본 시드 완료 — 9페이지 (architecture×3 + domain×3 + decisions×3), stale 0, 링크 9/9, citation 10/10 OK
+
+## [2026-06-19] ingest | db-tests CLI grant 드리프트 — sources/db-tests-cli-grant-drift + decisions/test-db-grants 생성, rls-model 갱신(테이블 GRANT 레이어 보강). 출처 PR#179/#180

--- a/wiki/sources/db-tests-cli-grant-drift.md
+++ b/wiki/sources/db-tests-cli-grant-drift.md
@@ -1,0 +1,49 @@
+---
+area: sources
+updated: 2026-06-19
+status: current
+sources:
+  - uniqn-mobile/supabase/fixtures/jpc_helpers.sql
+  - .github/workflows/db-tests.yml
+  - PR#179
+  - PR#180
+  - memory/pitfall_supabase_cli_latest_drift_implicit_table_grant.md
+tags: [db-tests, pgtap, ci, supabase, grants]
+---
+
+# 소스: db-tests "permission denied" 회귀 — CLI 이미지 드리프트 (2026-06-19)
+
+> 원천: 2026-06-18 master DB Tests(pg_prove) 조사 + 수정 PR#179/#180. 합성 결론은 [[test-db-grants]].
+
+## 무슨 일이 있었나 (검증됨)
+
+master **DB Tests (pg_prove)** 가 #175 시점 8개 테스트 fail — `job_postings_anon_public_select` + `jpc_*_rls`(6) + `workspace_archive`. CI 실 로그(run 27768845292):
+> `jpc_work_logs_rls.test.sql:39: ERROR:  permission denied for table job_postings`
+> `Files=28, Tests=100 ... Result: FAIL`
+
+`#172` 의 red 는 **별개** — `supabase/setup-cli@v1` 의 `version: latest` 가 익명 GitHub API 'resolve latest' 호출에서 rate limit → Setup 단계 6초 실패(테스트 0개 실행). 마지막 정상 = #170(2026-06-05).
+
+## 근본 원인 (검증됨)
+
+`uniqn-mobile/supabase/fixtures/jpc_helpers.sql:139` 의 `jpc_test_set_user()` 는 `set_config('role','authenticated',true)`(= `SET LOCAL ROLE authenticated`)로 전환 후 `public.job_postings`/`workspaces` 에 **직접 접근** → 테이블 레벨 GRANT 필요.
+
+- **prod**: `information_schema.role_table_grants` 실측 — anon/authenticated/service_role 이 해당 테이블에 ALL GRANT 보유 → **앱 정상, 영향 0**.
+- **CI 로컬**: `version: latest` 가 받는 최신 Supabase 이미지가 마이그레이션 생성 테이블에 implicit GRANT 를 더 이상 자동부여 안 함. job_postings/workspaces 명시 GRANT 마이그레이션은 **0개**(기본 default-privilege 의존). 코드 무변경인데 6/5 pass → 6/18 fail 로 드리프트.
+
+핵심: 이 GRANT 는 RLS(행 가시성)와 **별개의 coarse 레이어**다. RLS 평가 전에 테이블 권한에서 42501 abort → [[rls-model]] 의 "permissive OR abort" 와 같은 표면 증상이지만 원인은 GRANT 부재.
+
+## 수정 (검증됨)
+
+- **PR#179** (`0c33032cc`): `jpc_helpers.sql`(fixtures 전용·prod 미적용, `docker exec psql -U postgres` 로 로컬 컨테이너에만 실행)에 prod 동치 `GRANT ALL ON ALL TABLES/SEQUENCES ... TO anon, authenticated, service_role` 추가. **함수는 제외**(결제 RPC 하드닝이 REVOKE 한 EXECUTE 되살림 방지 → `wallet_grants_hardening.test.sql` 회귀 차단).
+- **PR#180** (`70614e403`): 3개 워크플로우(db-tests/e2e/deploy-edge-functions) `version: latest` → `version: 2.107.0` 고정 + `github-token: ${{ github.token }}`. 드리프트 + 익명 rate-limit 동시 예방.
+- 검증: master 머지 커밋 db-tests `success`(2m39s), `Files=28, Tests=193, Result: PASS`. RED→GREEN 실측.
+
+## 교훈
+
+- db-tests.yml 은 `paths: uniqn-mobile/supabase/**` 변경 PR/push 에서만 실행 → 회귀가 잠복하다 다음 supabase PR(#175)에서 표면화. "red 시작 커밋(#172)" ≠ 실제 원인.
+- 테스트가 Supabase 기본 default-privilege 에 의존하면 CLI 버전에 취약. 같은 비결정성 클래스: [[enum-divergence]] 가 아니라 환경 드리프트(메모리 `pitfall_e2e_runner_contention_timeout`).
+
+## 관련
+- [[test-db-grants]] — 이 소스의 합성 결정/규칙
+- [[rls-model]] — 테이블 GRANT vs RLS 레이어 구분
+- [[enum-divergence]] — 또 다른 "읽기 레코드 증발" 클래스(원인은 다름)


### PR DESCRIPTION
2026-06-18 master DB Tests(pg_prove) red 조사·수정(PR #179/#180)을 위키 합성 레이어에 정제 반영(`/ingest`) + Obsidian 볼트 로컬 설정 gitignore.

## 커밋
1. `chore: .obsidian 볼트 로컬 설정 gitignore 추가` — `.obsidian/`(플러그인/워크스페이스 등 머신별 상태) 버전관리 제외.
2. `docs(wiki): db-tests CLI grant 드리프트 ingest` — `/ingest` 워크플로우(`wiki/AGENTS.md` §5).

## 위키 변경 (wiki/ 합성 레이어만, raw 미수정)
| 동작 | 페이지 |
|------|--------|
| 🆕 | `wiki/sources/db-tests-cli-grant-drift.md` — RED→GREEN 증거 + 근본원인 압축(첫 sources 페이지) |
| 🆕 | `wiki/decisions/test-db-grants.md` — "테스트 DB는 명시 GRANT + setup-cli 버전 pin" 규칙 |
| ✏️ | `wiki/architecture/rls-model.md` — 핵심원칙 #4(테이블 GRANT는 RLS와 별개 coarse 레이어) + 교차링크 |
| ✏️ | `wiki/index.md` / `wiki/log.md` — 카탈로그 + ingest 로그 |

## 규약 준수 (wiki/AGENTS.md)
- raw(`uniqn-mobile/`·`docs/`·`memory/`) 미수정 ✓
- frontmatter 5필드 · 무출처 주장 0(전부 `파일:줄`/PR#/소스 인용) · cross-link 각 ≥3(타 영역 ≥1) ✓
- file 소스 포함 → `/lint` UNVERIFIABLE 회피 ✓ · 기존 페이지와 모순 0(rls-model과 보완 관계) ✓

## 배경 출처
- PR #179 (`0c33032cc`) — fixture 명시 GRANT
- PR #180 (`70614e403`) — setup-cli 2.107.0 pin + github-token

🤖 Generated with [Claude Code](https://claude.com/claude-code)