### PR TITLE
fix(db): e2e 로컬 스택 public 테이블 권한 명시 — 42501 회귀 해소 (prod 정합)

### DIFF
--- a/uniqn-mobile/supabase/migrations/20260619133156_grant_table_privileges_local_stack_parity.sql
+++ b/uniqn-mobile/supabase/migrations/20260619133156_grant_table_privileges_local_stack_parity.sql
@@ -1,0 +1,38 @@
+-- public 테이블/시퀀스 권한 명시화 — 로컬 Supabase 스택을 prod와 동일하게 (e2e 42501 회귀 해소)
+--
+-- 배경: base_schema 이래 모든 public 테이블이 Supabase 플랫폼 default 권한에만 의존했다
+--   (마이그레이션에 테이블 GRANT 0개). prod는 클라우드 플랫폼이 anon/authenticated/service_role
+--   에 default 권한을 부여하므로 정상이나, 로컬 CLI 스택(`supabase start`)은 현행 CLI 이미지에서
+--   이 default 권한을 자동 부여하지 않는다 → 모든 PostgREST 쿼리가 42501 permission denied.
+--   증상: e2e 로그인 후 화면 전역 타임아웃(run 27769458739 / 27787809344 — app_config(authenticated
+--   startup 버전체크) 42501 ×560k, board_posts(service_role seed) 42501). pgTAP의 #179와 동일 클래스.
+--   ⚠️ supabase/setup-cli 버전 pin(2.107.0, #180)으로는 미해결(run 27787809344 재현으로 검증됨).
+--
+-- 해결: prod 실측 권한 그대로를 명시 GRANT 한다(스키마를 플랫폼 magic 비의존으로).
+--   prod에는 이미 동일 권한이 있어 멱등 no-op. 로컬 스택만 정합 복구된다.
+--
+-- 보존 불변식(절대 위반 금지):
+--   1) 함수 권한은 건드리지 않는다 — 머니 RPC anon REVOKE 하드닝(#163 등) 보존.
+--   2) wallet 4테이블 DML 하드닝(20260605000010)을 동일하게 재적용 — 아래 GRANT ALL이
+--      anon/authenticated를 넓히지 못하게 마지막에 다시 REVOKE.
+--   prod 실측 정합: 일반 테이블=anon/authenticated/service_role 전체 DML / wallet 4테이블=
+--   anon·authenticated는 SELECT만(INSERT/UPDATE/DELETE 없음), service_role 전체.
+
+-- 1) 스키마 USAGE
+GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
+
+-- 2) 테이블 — Supabase 표준(전체 권한). 행 접근은 RLS가 통제.
+GRANT ALL ON ALL TABLES IN SCHEMA public TO anon, authenticated, service_role;
+
+-- 3) 시퀀스 — serial/identity insert 대비
+GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO anon, authenticated, service_role;
+
+-- 4) 향후 생성 객체에도 동일 default(플랫폼 동작 미러; 함수는 제외 — 신규 함수 anon 자동부여 회귀 방지)
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
+
+-- 5) wallet 4테이블 DML 하드닝 재적용 (20260605000010 미러 — 2)/4)가 anon/authenticated를 넓히는 것 방지)
+REVOKE INSERT, UPDATE, DELETE ON public.wallets          FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE ON public.wallet_ledger    FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE ON public.heart_lots       FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE ON public.diamond_products FROM anon, authenticated;


### PR DESCRIPTION
## 근본원인 (조사 완료)

master e2e ~96% 실패(run 27769458739: ✓5/✘123)는 **코드 회귀가 아니라 환경/스키마 갭**입니다.

- `base_schema` 이래 모든 public 테이블이 **Supabase 플랫폼 default 권한에만 의존**(마이그에 테이블 GRANT 0개).
- prod는 클라우드가 부여해 정상이나, 로컬 CLI 스택(`supabase start`)은 현행 CLI 이미지에서 default 권한을 자동 부여하지 않음 → 모든 PostgREST 쿼리가 `42501 permission denied` → e2e 로그인 후 화면 전역 타임아웃.

### 실측 증거
- trace(Staff 저니): `app_config` 42501 ×560,976 (versionService.ts:72 startup 버전체크, authenticated)
- seed 로그: `board_posts` 42501 (service_role, **앱 코드 실행 전** → React/UX 코드 회귀 배제 결정타)
- pgTAP의 #179와 동일 클래스(테이블 implicit GRANT 소실)

### ⚠️ #180 CLI pin은 무효 (검증으로 반증)
현 master 재실행 **run 27787809344**: 설치 CLI=`2.107.0`(pin 적용)인데도 동일 42501·동일 분포로 **여전히 실패**. 2.107.0도 default 권한을 자동 부여하지 않음. #179가 db-tests를 green으로 만든 건 pin이 아니라 **fixture 명시 GRANT**였고, e2e는 앱 테이블에 그 GRANT를 받은 적이 없음.

## 수정

prod 실측 권한 그대로를 명시 GRANT(스키마를 플랫폼 magic 비의존화). **prod 멱등 no-op**, 로컬 스택만 정합 복구.

### prod 실측 3회 검증 (MCP introspection)
1. 일반 테이블 = anon/authenticated/service_role 전체 DML / wallet 4테이블 = anon·auth SELECT만
2. anon INSERT 없는 테이블 = wallet 4개뿐
3. anon SELECT 없는(완전잠금) 테이블 = **0개** → `GRANT ALL`이 위험하게 넓히는 대상 없음

### 불변식 보존
- **함수 권한 미변경** → 머니 RPC anon REVOKE 하드닝(#163 등) 보존
- **wallet 4테이블 DML 하드닝(20260605000010) 동일 재적용** → `GRANT ALL`이 anon/authenticated를 넓히지 못하게 마지막에 다시 REVOKE

## Test plan
- [ ] 이 PR의 e2e 워크플로우 green 확인 (= 42501 회귀 해소 최종 검증)
- [ ] 로컬 docker/CLI 부재로 로컬 검증 불가 → CI가 검증 경로

## 후속(별도)
- versionService/useVersionCheck가 app_config 에러 시 560k 재시도/리렌더 폭주 → graceful 가드(드리프트 하에서만 발동하는 2차 이슈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)