### PR TITLE
docs(wiki): e2e CLI grant 드리프트 ingest — pin≠fix 보정 + 마이그레이션 수정

### DIFF
--- a/wiki/decisions/test-db-grants.md
+++ b/wiki/decisions/test-db-grants.md
@@ -4,15 +4,21 @@ updated: 2026-06-19
 status: current
 sources:
   - uniqn-mobile/supabase/fixtures/jpc_helpers.sql
+  - uniqn-mobile/supabase/migrations/20260619133156_grant_table_privileges_local_stack_parity.sql
   - .github/workflows/db-tests.yml
   - PR#179
   - PR#180
-tags: [db-tests, ci, grants, supabase, pgtap]
+  - PR#183
+tags: [db-tests, e2e, ci, grants, supabase, pgtap]
 ---
 
-# 결정: 테스트 DB 권한은 명시 GRANT + CLI 버전 pin
+# 결정: 테스트 DB 권한은 명시 GRANT (CLI pin은 예방일 뿐 수정 아님)
 
-**한 줄:** pgTAP 테스트는 Supabase 기본 default-privilege(implicit 테이블 GRANT)에 의존하지 말고, 테스트 fixture에서 **명시 GRANT** + setup-cli **버전 고정**으로 환경 드리프트에 면역시킨다.
+**한 줄:** 테스트 DB(pgTAP fixture·e2e 로컬 스택)는 Supabase 기본 default-privilege(implicit 테이블 GRANT)에 의존하지 말고 **명시 GRANT**로 prod와 정합시킨다. setup-cli 버전 고정은 드리프트 *예방*이지 GRANT 부재의 *수정*이 아니다(e2e에서 실측 반증).
+
+## ⚠️ 핵심 보정: pin ≠ fix (검증됨)
+
+같은 드리프트가 **e2e도 전면 red**로 만들었고(상세 [[e2e-cli-grant-drift]]), `version: 2.107.0` pin(#180)이 포함된 master 재실행(run 27787809344)에서도 `permission denied` 그대로 실패했다. → 2.107.0도 implicit GRANT를 자동부여하지 않으므로 **pin만으론 못 고친다.** db-tests가 #179로 green이 된 실제 원인도 pin이 아니라 fixture 명시 GRANT다. 면역의 핵심은 **명시 GRANT**, pin은 (a) 익명 rate-limit·(b) 추가 드리프트를 막는 보조일 뿐.
 
 ## 왜 (검증됨)
 
@@ -22,8 +28,8 @@ prod 는 Supabase 기본 default-privilege 로 GRANT 를 보유하지만, CI 의
 
 ## 규칙
 
-1. **테스트 grant 는 명시적으로** — `jpc_helpers.sql`(fixtures 전용, `npm run test:db:helpers` 가 로컬 컨테이너에만 등록)에서 `GRANT ALL ON ALL TABLES/SEQUENCES IN SCHEMA public TO anon, authenticated, service_role`. prod grant 상태와 동치 → CLI 버전 무관 결정적.
-2. **함수는 grant 확대 금지** — 결제 RPC 하드닝이 anon/authenticated 에서 REVOKE 한 EXECUTE 를 되살리면 회귀(`wallet_grants_hardening.test.sql`). 테이블/시퀀스만.
+1. **테스트 grant 는 명시적으로** — `GRANT ALL ON ALL TABLES/SEQUENCES IN SCHEMA public TO anon, authenticated, service_role`로 prod grant 상태와 동치화 → CLI 버전 무관 결정적. **두는 위치는 무대별로 다름**: pgTAP은 `jpc_helpers.sql`(fixtures 전용, `npm run test:db:helpers`가 로컬 컨테이너에만 등록); e2e는 전체 앱을 로컬 스택에 띄우므로 **마이그레이션**(`20260619133156_..._local_stack_parity.sql`, PR#183)으로 스키마 자체를 정합화(prod 멱등 no-op).
+2. **함수는 grant 확대 금지** — 결제 RPC 하드닝이 anon/authenticated 에서 REVOKE 한 EXECUTE 를 되살리면 회귀(`wallet_grants_hardening.test.sql`). 테이블/시퀀스만. 마이그레이션 경로는 추가로 wallet 4테이블 DML REVOKE 재적용(`20260605000010` 미러)으로 anon/auth 확대 방지.
 3. **setup-cli 버전 pin** — `version: 2.107.0` + `github-token`(PR#180). `latest` 는 (a) 익명 GitHub API rate-limit, (b) 이미지 드리프트 두 사고의 단일 뿌리. 3개 워크플로우 일괄.
 4. **fixtures 는 prod 등록 금지** — SECDEF 헬퍼 포함, prod 적용 시 RLS 우회 가능(catastrophic).
 
@@ -33,5 +39,6 @@ prod 는 Supabase 기본 default-privilege 로 GRANT 를 보유하지만, CI 의
 
 ## 관련
 - [[rls-model]] — 테이블 GRANT vs RLS 정책 레이어(증상은 같고 원인 다름)
-- [[db-tests-cli-grant-drift]] — 이 결정의 원천 소스(RED→GREEN 증거)
+- [[db-tests-cli-grant-drift]] — db-tests(pgTAP) 쪽 원천 소스(RED→GREEN 증거)
+- [[e2e-cli-grant-drift]] — e2e 쪽 원천 소스(pin≠fix 반증 + 마이그레이션 수정)
 - [[enum-divergence]] — DB 스키마/환경 드리프트가 읽기를 깨는 또 다른 클래스

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -21,3 +21,4 @@
 
 ## sources
 - [[db-tests-cli-grant-drift]] — pg_prove red 근본원인: setup-cli `version:latest` 드리프트로 implicit 테이블 GRANT 소실 (PR#179/#180)
+- [[e2e-cli-grant-drift]] — e2e ~96% red 같은 드리프트, pin(2.107.0)으론 미해결 → 명시 GRANT 마이그레이션이 수정 (PR#183)

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -8,3 +8,5 @@
 ## [2026-06-18] bootstrap | 백본 시드 완료 — 9페이지 (architecture×3 + domain×3 + decisions×3), stale 0, 링크 9/9, citation 10/10 OK
 
 ## [2026-06-19] ingest | db-tests CLI grant 드리프트 — sources/db-tests-cli-grant-drift + decisions/test-db-grants 생성, rls-model 갱신(테이블 GRANT 레이어 보강). 출처 PR#179/#180
+
+## [2026-06-19] ingest | e2e CLI grant 드리프트 — sources/e2e-cli-grant-drift 생성(같은 드리프트가 e2e도 타격, pin 2.107.0으론 미해결 반증, 명시 GRANT 마이그레이션이 수정). decisions/test-db-grants 보정(pin≠fix, 무대별 grant 위치). 출처 PR#183(run 27769458739/27787809344/27829125384)

--- a/wiki/sources/e2e-cli-grant-drift.md
+++ b/wiki/sources/e2e-cli-grant-drift.md
@@ -1,0 +1,49 @@
+---
+area: sources
+updated: 2026-06-19
+status: current
+sources:
+  - uniqn-mobile/supabase/migrations/20260619133156_grant_table_privileges_local_stack_parity.sql
+  - uniqn-mobile/supabase/migrations/20260409000000_base_schema.sql
+  - .github/workflows/e2e.yml
+  - PR#183
+  - PR#180
+  - memory/project_e2e_systemic_failure_20260618.md
+tags: [e2e, playwright, ci, supabase, grants]
+---
+
+# 소스: e2e ~96% 실패 — 같은 CLI 드리프트, 그러나 pin으론 안 고쳐짐 (2026-06-19)
+
+> 원천: 2026-06-18 master e2e 시스템 장애 조사 + 수정 PR#183. 합성 결론은 [[test-db-grants]]. 자매 소스 [[db-tests-cli-grant-drift]](db-tests 쪽).
+
+## 무슨 일이 있었나 (검증됨)
+
+master e2e(`workflow_dispatch` run 27769458739, 커밋 8ce38f2ee)가 **✓5 / ✘123 / -56**, 75분 cap 도달 cancelled. 패턴: 앱 로드·로그인은 됨(smoke·미인증·로그인실패 통과), **로그인 후 기능 화면 전역 타임아웃**.
+
+trace 실측(`gh run download`): 유일 DB 쿼리 `/rest/v1/app_config`(authenticated startup 버전체크, `uniqn-mobile/src/services/versionService.ts:72`) → **403 code 42501**. seed 로그: `permission denied for table board_posts`(service_role, 앱 코드 실행 *전*). → React/UX 코드 회귀가 만들 수 없는 순수 DB 권한 에러.
+
+## 근본 원인 (검증됨)
+
+[[db-tests-cli-grant-drift]]와 **동일 클래스**: `uniqn-mobile/supabase/migrations/20260409000000_base_schema.sql`은 모든 public 테이블을 CREATE만 하고 **명시 GRANT 0개**(플랫폼 default-privilege 의존). e2e도 `supabase/setup-cli` `version: latest`(당시)로 로컬 스택 기동 → 최신 이미지가 implicit GRANT 미부여 → 앱의 authenticated 쿼리·seed의 service_role 쿼리 모두 42501 → 인증 화면 데이터 로드 불가 → 셀렉터 타임아웃.
+
+## 핵심 교훈: 버전 pin은 e2e를 못 고쳤다 (검증됨)
+
+[[test-db-grants]] 규칙 3(setup-cli pin)이 **단독으로는 무효**임이 실측 반증됨. 현 master(#180의 `2.107.0` pin 포함)에 e2e 재실행 = **run 27787809344**: 설치 CLI=`2.107.0`인데도 `board_posts` 42501 그대로·동일 분포로 **여전히 실패**. 즉 2.107.0도 default 권한을 자동부여하지 않는다 → **pin은 드리프트 예방일 뿐 GRANT 부재를 고치지 못한다**. db-tests가 #179로 green이 된 진짜 이유도 pin이 아니라 fixture **명시 GRANT**였음.
+
+## 수정 (검증됨)
+
+- **PR#183** (`dc1b0c491`): 마이그레이션 `20260619133156_grant_table_privileges_local_stack_parity.sql` — prod 실측 권한 그대로 명시 GRANT. db-tests의 fixture-only 수정과 달리 **마이그레이션**으로 한 이유: e2e는 전체 앱을 로컬 스택에 띄워 돌리므로 스키마 자체가 정합해야 함.
+  - `GRANT ALL ON ALL TABLES/SEQUENCES IN SCHEMA public TO anon, authenticated, service_role` + `ALTER DEFAULT PRIVILEGES`(테이블/시퀀스만, **함수 제외**=머니 RPC anon REVOKE 보존).
+  - wallet 4테이블(wallets/wallet_ledger/heart_lots/diamond_products) DML REVOKE 재적용 → `20260605000010` 하드닝 미러.
+  - prod 실측 3회로 멱등·안전 검증: 일반테이블=전체 DML / wallet4=anon·auth SELECT만 / anon SELECT 없는 완전잠금 테이블=0개. prod 적용도 no-op 확인.
+- 검증: PR#183 e2e `success`, **225 passed / 11 skip / 1 flaky, 11분**(75분 cap→정상화), 로그 42501 0건. Red(run 27787809344 ✘123)→Green 실측.
+
+## 부수 교훈
+
+- versionService는 이미 graceful(에러 시 null 폴백, throw 無)이고 splash 재시도도 상한(`MAX_PROFILE_RETRIES=5`) 있음. trace의 "app_config 42501 ×560k"는 **실 HTTP 아닌 trace 파일 아티팩트**(network 로그상 실제 요청 1건). "재시도 폭주" 추정은 조사 후 기각.
+- e2e.yml은 `paths: uniqn-mobile/**` PR/dispatch에서만 실행 + **non-required 체크** → red가 잠복하며 다른 PR이 jest/quality만으로 머지됨(메모리 `feedback_master_direct_push_bypasses_e2e`).
+
+## 관련
+- [[test-db-grants]] — 이 소스가 보정하는 합성 결정(pin≠fix)
+- [[db-tests-cli-grant-drift]] — 같은 드리프트의 db-tests 쪽 자매 소스
+- [[rls-model]] — 테이블 GRANT vs RLS 레이어 구분(증상 동일, 원인 다름)


### PR DESCRIPTION
## 요약

2026-06-18 master e2e ~96% 실패 조사·수정(PR#183 머지 완료)을 위키 지식베이스에 ingest. [[db-tests-cli-grant-drift]](#181)의 자매 소스이며, 그 결정 페이지의 핵심 가정을 **보정**한다.

## 변경

- **`wiki/sources/e2e-cli-grant-drift.md`** (신규): 같은 `version:latest` 드리프트가 e2e도 전면 red로 만든 경위. trace 실측(`app_config`/`board_posts` 42501), `2.107.0` pin(#180)으로도 미해결임을 재실행(run 27787809344)으로 반증, 명시 GRANT 마이그레이션(#183)이 진짜 수정. RED→GREEN(run 27829125384, 225 passed) 증거.
- **`wiki/decisions/test-db-grants.md`** (보정): 제목/한 줄을 "**pin은 예방일 뿐 수정 아님**"으로 정정(기존 "명시 GRANT + CLI pin"이 pin을 수정처럼 읽히게 함). 무대별 grant 위치 규칙 추가(pgTAP=fixture / e2e=마이그레이션). PR#183 출처 편입.
- **`wiki/index.md` / `wiki/log.md`**: 카탈로그·로그 갱신.

## 검증

- 위키링크 4개 타깃 전부 실재 확인
- 신규 source 페이지는 실파일 경로 출처(마이그·base_schema·e2e.yml) 보유 → `/lint` UNVERIFIABLE 회피
- 변경은 `wiki/`로만 한정 (합성 레이어만 수정, 원천 소스 무수정 — AGENTS.md §2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)