### PR TITLE
fix: 알림 중복 발송 + 근무시간 피커 먹통 해소

### DIFF
--- a/uniqn-mobile/src/components/employer/settlement/WorkTimeEditor.tsx
+++ b/uniqn-mobile/src/components/employer/settlement/WorkTimeEditor.tsx
@@ -338,6 +338,17 @@ export function WorkTimeEditor({
         title="근무 시간 수정"
         footer={footerContent}
         isLoading={isLoading}
+        overlay={
+          <TimeWheelPicker
+            visible={activePicker !== null}
+            value={activePickerValue}
+            title={activePickerTitle}
+            minuteInterval={15}
+            onConfirm={handlePickerConfirm}
+            onClose={() => setActivePicker(null)}
+            embedded
+          />
+        }
       >
         <View className="px-4">
           {/* 스태프 정보 */}
@@ -442,15 +453,6 @@ export function WorkTimeEditor({
             </Text>
           </View>
         </View>
-        {/* 휠 피커 모달 (SheetModal 내부에서 렌더링하여 iOS Modal 스태킹 문제 방지) */}
-        <TimeWheelPicker
-          visible={activePicker !== null}
-          value={activePickerValue}
-          title={activePickerTitle}
-          minuteInterval={15}
-          onConfirm={handlePickerConfirm}
-          onClose={() => setActivePicker(null)}
-        />
       </SheetModal>
     </>
   );

--- a/uniqn-mobile/src/components/employer/settlement/__tests__/WorkTimeEditor.test.tsx
+++ b/uniqn-mobile/src/components/employer/settlement/__tests__/WorkTimeEditor.test.tsx
@@ -36,15 +36,18 @@ jest.mock('../../../ui/SheetModal', () => ({
     visible,
     children,
     footer,
+    overlay,
   }: {
     visible: boolean;
     children: React.ReactNode;
     footer?: React.ReactNode;
+    overlay?: React.ReactNode;
   }) =>
     visible ? (
       <>
         {children}
         {footer}
+        {overlay}
       </>
     ) : null,
 }));

--- a/uniqn-mobile/src/components/ui/SheetModal.tsx
+++ b/uniqn-mobile/src/components/ui/SheetModal.tsx
@@ -48,6 +48,12 @@ export interface SheetModalProps {
   /** 로딩 중 닫기 방지 */
   isLoading?: boolean;
   fullHeight?: boolean;
+  /**
+   * 모달 최상위에 겹쳐 띄우는 오버레이(시간 피커 등).
+   * children(ScrollView 내부)이 아닌 Modal 루트에 렌더링하므로
+   * 중첩 Modal 없이 전체 화면 오버레이가 터치를 정상 수신한다.
+   */
+  overlay?: React.ReactNode;
 }
 
 // ============================================================================
@@ -64,6 +70,7 @@ function WebSheetModal({
   showCloseButton = true,
   isLoading = false,
   fullHeight = false,
+  overlay,
 }: SheetModalProps) {
   const { isDarkMode } = useThemeStore();
   const { height: windowHeight } = useWindowDimensions();
@@ -195,6 +202,9 @@ function WebSheetModal({
             {footer && <View className="px-4 py-4 border-t border-divider pb-8">{footer}</View>}
           </View>
         </View>
+
+        {/* 오버레이 (웹: TimeWheelPicker가 자체 Portal로 최상위 렌더) */}
+        {overlay}
       </View>
     </WebPortal>
   );
@@ -214,6 +224,7 @@ function NativeSheetModal({
   showCloseButton = true,
   isLoading = false,
   fullHeight = false,
+  overlay,
 }: SheetModalProps) {
   const { isDarkMode } = useThemeStore();
   const { height: windowHeight } = useWindowDimensions();
@@ -355,6 +366,10 @@ function NativeSheetModal({
               {footer && <View className="px-4 py-4 border-t border-divider">{footer}</View>}
             </SafeAreaView>
           </Animated.View>
+
+          {/* 오버레이 (시간 피커 등) — Modal 루트에 직접 렌더하여 중첩 Modal 회피.
+              자식 오버레이가 absoluteFill로 전체 화면을 덮어 터치를 정상 수신한다. */}
+          {overlay}
         </View>
       </KeyboardAvoidingView>
     </RNModal>

--- a/uniqn-mobile/src/components/ui/TimeWheelPicker.tsx
+++ b/uniqn-mobile/src/components/ui/TimeWheelPicker.tsx
@@ -16,6 +16,7 @@ import {
   ScrollView,
   FlatList,
   Platform,
+  StyleSheet,
   NativeSyntheticEvent,
   NativeScrollEvent,
 } from 'react-native';
@@ -55,6 +56,12 @@ export interface TimeWheelPickerProps {
   onConfirm: (value: TimeValue) => void;
   /** 닫기 콜백 */
   onClose: () => void;
+  /**
+   * 부모 Modal 내부에서 사용할 때 true.
+   * 네이티브에서 자체 Modal 대신 absoluteFill 오버레이로 렌더하여
+   * 중첩 Modal로 인한 터치 먹통(iOS)을 방지한다. (웹은 항상 Portal 사용)
+   */
+  embedded?: boolean;
 }
 
 // ============================================================================
@@ -596,6 +603,7 @@ export function TimeWheelPicker({
   minuteInterval = 5,
   onConfirm,
   onClose,
+  embedded = false,
 }: TimeWheelPickerProps) {
   // 웹에서는 Portal로 body에 직접 렌더링 (z-index 문제 해결)
   if (isWeb) {
@@ -613,24 +621,34 @@ export function TimeWheelPicker({
     );
   }
 
-  // 네이티브에서는 기존 Modal 사용
-  // Pressable 중첩을 피해 backdrop과 콘텐츠를 분리 (ScrollView 제스처 충돌 방지)
+  // 네이티브 콘텐츠 (backdrop + 휠) — Modal 여부와 무관하게 공유
+  const content = (
+    <View style={StyleSheet.absoluteFill} className="justify-end">
+      {/* Backdrop - 콘텐츠 위의 빈 영역만 터치 가능 */}
+      <Pressable className="flex-1 bg-black/50" onPress={onClose} />
+      {/* 콘텐츠 - Pressable로 감싸지 않아 ScrollView 제스처 정상 동작 */}
+      <NativeWheelPicker
+        value={value}
+        title={title}
+        minHour={minHour}
+        maxHour={maxHour}
+        minuteInterval={minuteInterval}
+        onConfirm={onConfirm}
+        onClose={onClose}
+      />
+    </View>
+  );
+
+  // 부모 Modal 내부(embedded): 중첩 Modal을 피해 absoluteFill 오버레이로 렌더.
+  // iOS에서 Modal-in-Modal은 콘텐츠는 보이나 터치/스크롤이 먹통이 되므로 금지.
+  if (embedded) {
+    return visible ? content : null;
+  }
+
+  // 독립 사용(standalone): 기존 Modal 경로 유지 (하위 호환)
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
-      <View className="flex-1 justify-end">
-        {/* Backdrop - 콘텐츠 위의 빈 영역만 터치 가능 */}
-        <Pressable className="flex-1 bg-black/50" onPress={onClose} />
-        {/* 콘텐츠 - Pressable로 감싸지 않아 ScrollView 제스처 정상 동작 */}
-        <NativeWheelPicker
-          value={value}
-          title={title}
-          minHour={minHour}
-          maxHour={maxHour}
-          minuteInterval={minuteInterval}
-          onConfirm={onConfirm}
-          onClose={onClose}
-        />
-      </View>
+      {content}
     </Modal>
   );
 }

--- a/uniqn-mobile/supabase/migrations/20260620151331_drop_duplicate_worklog_checkinout_trigger.sql
+++ b/uniqn-mobile/supabase/migrations/20260620151331_drop_duplicate_worklog_checkinout_trigger.sql
@@ -1,0 +1,17 @@
+-- 출퇴근/평가 알림 중복 발송 회귀 해소
+--
+-- 증상: 출근 확인·퇴근 확인·스태프 출근·평가 요청 알림이 각각 정확히 2번씩 발송됨.
+--
+-- 근본 원인: work_logs UPDATE에 대해 동일한 함수 notify_on_work_log_checkinout_update()
+--   를 호출하는 트리거가 두 개 공존.
+--     1) work_log_notify_checkinout_update  — 구버전(20260417050000), AFTER UPDATE(전체)
+--     2) tr_notify_work_log_checkinout       — 신버전(20260421190000), AFTER UPDATE OF check_in_ts, check_out_ts
+--   20260421190000에서 함수를 CREATE OR REPLACE 하면서 신규 트리거를 추가했으나
+--   구버전 트리거를 DROP하지 않아, 한 번의 출퇴근 UPDATE가 함수를 2회 실행 → 알림 2배 INSERT.
+--
+-- 수정: 구버전 트리거를 제거하고, 더 정밀한 신버전 트리거(tr_notify_work_log_checkinout)만 유지.
+--   함수 본문은 그대로 유지(두 트리거가 같은 함수를 가리켰으므로 동작 동일, 발송 횟수만 1배로 정상화).
+--
+-- 멱등: DROP TRIGGER IF EXISTS — 이미 제거된 환경(로컬/재적용)에서도 안전.
+
+DROP TRIGGER IF EXISTS work_log_notify_checkinout_update ON public.work_logs;

--- a/uniqn-mobile/supabase/tests/worklog_checkinout_notify_single_trigger.test.sql
+++ b/uniqn-mobile/supabase/tests/worklog_checkinout_notify_single_trigger.test.sql
@@ -1,0 +1,37 @@
+-- =============================================================================
+-- 출퇴근/평가 알림 중복 발송 회귀 가드
+-- =============================================================================
+-- 사용법:
+--   psql "$SUPABASE_DB_URL" -f supabase/tests/worklog_checkinout_notify_single_trigger.test.sql
+--   pg_prove 호환: BEGIN/plan/finish/ROLLBACK
+--
+-- 배경:
+--   work_logs UPDATE 시 동일 함수 notify_on_work_log_checkinout_update()를
+--   호출하는 트리거가 둘(work_log_notify_checkinout_update + tr_notify_work_log_checkinout)
+--   공존하면 한 번의 출퇴근 UPDATE가 알림을 2배 INSERT → 푸시 2건 발송.
+--   (마이그레이션 20260620151331에서 구버전 트리거 DROP으로 해소)
+--
+-- 불변식: 해당 함수를 호출하는 work_logs 트리거는 정확히 1개여야 한다.
+-- =============================================================================
+
+BEGIN;
+SELECT plan(1);
+
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM pg_trigger t
+    JOIN pg_class c ON t.tgrelid = c.oid
+    JOIN pg_namespace n ON c.relnamespace = n.oid
+    JOIN pg_proc p ON t.tgfoid = p.oid
+    WHERE n.nspname = 'public'
+      AND c.relname = 'work_logs'
+      AND p.proname = 'notify_on_work_log_checkinout_update'
+      AND NOT t.tgisinternal
+  ),
+  1,
+  'work_logs에서 출퇴근 알림 함수를 호출하는 트리거는 정확히 1개 (중복 발송 회귀 가드)'
+);
+
+SELECT finish();
+ROLLBACK;


### PR DESCRIPTION
실사용자 신고 2건 근본 원인 해소.

## 🔔 버그 1 — 출퇴근/평가 알림 2번씩 발송

**근본 원인 (prod DB 실측):** `work_logs` UPDATE 한 번에 **같은 함수**(`notify_on_work_log_checkinout_update`)를 호출하는 트리거가 **2개** 공존.

| 트리거 | 조건 | 출처 |
|---|---|---|
| `tr_notify_work_log_checkinout` | `AFTER UPDATE OF check_in_ts, check_out_ts` | 신버전 (20260421190000) |
| `work_log_notify_checkinout_update` | `AFTER UPDATE` 전체 | 구버전 (20260417050000) — **DROP 누락** |

신버전 마이그레이션이 함수를 `CREATE OR REPLACE` + 새 트리거 추가하면서 구버전 트리거를 안 지워, 함수가 2회 실행 → 알림 2배 INSERT → 푸시 2건.

**수정:** 마이그레이션 `20260620151331` — `DROP TRIGGER IF EXISTS work_log_notify_checkinout_update` (멱등). 정밀한 신버전만 유지. 함수 본문 불변.

**회귀 가드:** pgTAP — "해당 함수 호출 트리거 = 정확히 1개" 불변식.

**Red→Green (prod 실측):** 적용 전 트리거 2개(RED) → 적용 후 1개(GREEN). ✅ **prod 마이그레이션 적용 완료.**

## ⏱️ 버그 2 — 근무시간 수정 시간 피커 먹통

**근본 원인:** `SheetModal`(RNModal) children 안에서 `TimeWheelPicker`가 자체 `<Modal>`을 또 띄워 **Modal-in-Modal**. iOS는 내부 Modal을 표시는 하나 휠 스크롤/취소·확인 터치를 전부 삼킴. (PR #170 모달 재구조화에서 유입)

**수정:** 중첩 Modal 제거.
- `SheetModal`에 `overlay` prop 추가 (ScrollView 밖, Modal 루트 직접 렌더)
- `TimeWheelPicker`에 `embedded` prop 추가 (네이티브에서 Modal 대신 `absoluteFill` 오버레이)
- 웹은 기존 Portal 경로 유지
- `WorkTimeEditor`가 피커를 `overlay`로 전달

## 검증
- `tsc --noEmit` 통과
- WorkTimeEditor 테스트 4/4 통과 (SheetModal mock에 overlay 렌더 반영)
- 버그 1 prod Red→Green 실측

## ⚠️ 배포 잔여
- 버그 1: **prod 마이그레이션 적용 완료** (코드 머지 시 마이그레이션 이력 정합)
- 버그 2: **실기기 미검증** — EAS OTA 배포 후 iOS 실기기 QA 필요 (구조적 수정은 RN 표준 패턴이나 실터치 확인 권장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)