### PR TITLE
fix(ui): 시간 피커 embedded Android 백 버튼 회귀 해소

### DIFF
--- a/uniqn-mobile/src/components/ui/TimeWheelPicker.tsx
+++ b/uniqn-mobile/src/components/ui/TimeWheelPicker.tsx
@@ -17,6 +17,8 @@ import {
   FlatList,
   Platform,
   StyleSheet,
+  BackHandler,
+  Keyboard,
   NativeSyntheticEvent,
   NativeScrollEvent,
 } from 'react-native';
@@ -605,6 +607,20 @@ export function TimeWheelPicker({
   onClose,
   embedded = false,
 }: TimeWheelPickerProps) {
+  // embedded(부모 Modal 내부) 경로는 자체 Modal이 없어 Android 하드웨어 백을
+  // 가로채지 못한다 → 백이 부모 SheetModal로 전파돼 편집기 전체가 닫히는 회귀.
+  // 피커가 열려 있는 동안 백을 소비해 피커만 닫는다. (네이티브 전용)
+  // 또한 열릴 때 키보드를 내려 오버레이가 KeyboardAvoidingView로 밀리는 것을 방지.
+  useEffect(() => {
+    if (isWeb || !embedded || !visible) return undefined;
+    Keyboard.dismiss();
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      onClose();
+      return true; // 이벤트 소비 → 부모 SheetModal onRequestClose 미발화
+    });
+    return () => sub.remove();
+  }, [embedded, visible, onClose]);
+
   // 웹에서는 Portal로 body에 직접 렌더링 (z-index 문제 해결)
   if (isWeb) {
     return (

--- a/uniqn-mobile/src/components/ui/__tests__/TimeWheelPicker.test.tsx
+++ b/uniqn-mobile/src/components/ui/__tests__/TimeWheelPicker.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * TimeWheelPicker — embedded 경로 Android 하드웨어 백 회귀 가드
+ *
+ * 배경: embedded 모드는 자체 Modal이 없어(absoluteFill 오버레이) Android 백을
+ * 가로채지 못하면 부모 SheetModal로 전파돼 편집기 전체가 닫히고 입력이 폐기된다.
+ * 피커가 열려 있는 동안 백을 소비해 피커만 닫아야 한다.
+ */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { BackHandler, Keyboard } from 'react-native';
+import { TimeWheelPicker } from '../TimeWheelPicker';
+
+jest.mock('../../icons', () => ({
+  AlertCircleIcon: () => null,
+}));
+
+const value = { hour: 19, minute: 0 };
+
+describe('TimeWheelPicker embedded 백 버튼', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('embedded+visible: 하드웨어 백을 소비(true)하고 피커만 닫는다', () => {
+    let backCb: (() => boolean | null | undefined) | undefined;
+    const addSpy = jest
+      .spyOn(BackHandler, 'addEventListener')
+      .mockImplementation((_event: string, cb: () => boolean | null | undefined) => {
+        backCb = cb;
+        return { remove: jest.fn() } as ReturnType<typeof BackHandler.addEventListener>;
+      });
+    const dismissSpy = jest.spyOn(Keyboard, 'dismiss').mockImplementation(() => undefined);
+    const onClose = jest.fn();
+
+    render(
+      <TimeWheelPicker visible value={value} embedded onConfirm={jest.fn()} onClose={onClose} />
+    );
+
+    expect(addSpy).toHaveBeenCalledWith('hardwareBackPress', expect.any(Function));
+    expect(dismissSpy).toHaveBeenCalled();
+
+    // 백 핸들러는 onClose를 호출하고 true(이벤트 소비)를 반환해야 함
+    expect(backCb?.()).toBe(true);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('embedded인데 비표시: 백 핸들러 미등록', () => {
+    const addSpy = jest.spyOn(BackHandler, 'addEventListener');
+
+    render(
+      <TimeWheelPicker
+        visible={false}
+        value={value}
+        embedded
+        onConfirm={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(addSpy).not.toHaveBeenCalledWith('hardwareBackPress', expect.any(Function));
+  });
+
+  it('standalone(비-embedded): 백 핸들러 미등록 (Modal onRequestClose 사용)', () => {
+    const addSpy = jest.spyOn(BackHandler, 'addEventListener');
+
+    render(<TimeWheelPicker visible value={value} onConfirm={jest.fn()} onClose={jest.fn()} />);
+
+    expect(addSpy).not.toHaveBeenCalledWith('hardwareBackPress', expect.any(Function));
+  });
+});


### PR DESCRIPTION
#186 사후 적대 재리뷰에서 발견한 **P2 회귀** 후속 픽스.

## 회귀
#186에서 `TimeWheelPicker`를 부모 Modal 내부에서 자체 `<Modal>` 대신 `absoluteFill` 오버레이로 렌더하도록 바꿔 iOS 터치 먹통은 해소했으나, embedded 경로에 Modal이 사라지면서 **Android 하드웨어 백을 가로채지 못함** → 백이 부모 `SheetModal`의 `onRequestClose`로 전파돼 **근무시간 편집기 전체가 닫히고 입력 중이던 시간 수정이 폐기**됨. (iOS 실기기 QA만으론 못 잡는 Android 전용 회귀)

## 수정
- `embedded && visible` 동안 `BackHandler`로 하드웨어 백을 소비(`onClose()` + `return true`) → 피커만 닫힘, 시트 유지.
- 함께 열릴 때 `Keyboard.dismiss()` → 키보드 떠 있을 때 오버레이가 `KeyboardAvoidingView`로 밀려 휠이 키보드 위로 올라가는 P3 엣지 해소.
- 네이티브 전용(웹은 Portal·iOS는 하드웨어 백 없음).

## 검증
- 회귀 테스트 3종 (TimeWheelPicker.test.tsx): 백 소비/onClose, 비표시 미등록, standalone 미등록.
- **Red-Green**: 픽스 제거 시 `embedded+visible` FAIL → 복원 시 3/3 PASS.
- tsc 0, 기존 WorkTimeEditor 4/4 유지.

## 관련
#186 (e3da9c275) 후속. 두 PR 합쳐 OTA 배포 시 iOS 터치 + Android 백 모두 정상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)