### PR TITLE
fix(employer): 정원마감 공고 공고관리 필터 증발 해소

### DIFF
--- a/uniqn-mobile/app/(app)/(tabs)/employer.tsx
+++ b/uniqn-mobile/app/(app)/(tabs)/employer.tsx
@@ -29,8 +29,13 @@ import { useHasRole } from '@/stores/authStore';
 import { useThemeStore } from '@/stores/themeStore';
 import type { JobPosting } from '@/types';
 import type { SharedJobPosting } from '@/types/jobPostingCollaborator';
+import {
+  countPostingsByFilter,
+  postingMatchesFilter,
+  type PostingFilterStatus,
+} from '@/utils/employerPostingFilter';
 
-type FilterStatus = 'all' | 'active' | 'closed';
+type FilterStatus = PostingFilterStatus;
 
 const FILTER_OPTIONS: { value: FilterStatus; label: string }[] = [
   { value: 'all', label: '전체' },
@@ -141,7 +146,9 @@ function EmployerView() {
 
     const today = new Date().toISOString().split('T')[0] ?? '';
     const filtered =
-      filter === 'all' ? postings : postings.filter((posting) => posting.status === filter);
+      filter === 'all'
+        ? postings
+        : postings.filter((posting) => postingMatchesFilter(posting.status, filter));
 
     return [...filtered].sort((left, right) => {
       const leftDateTime = getEarliestDateTime(left, today);
@@ -172,13 +179,7 @@ function EmployerView() {
       return {};
     }
 
-    const counts: Partial<Record<FilterStatus, number>> = { all: postings.length };
-    postings.forEach((posting) => {
-      const status = posting.status as FilterStatus;
-      counts[status] = (counts[status] || 0) + 1;
-    });
-
-    return counts;
+    return countPostingsByFilter(postings);
   }, [postings]);
 
   const handlePostingPress = useCallback((posting: JobPosting) => {

--- a/uniqn-mobile/src/utils/__tests__/employerPostingFilter.test.ts
+++ b/uniqn-mobile/src/utils/__tests__/employerPostingFilter.test.ts
@@ -1,0 +1,66 @@
+import { countPostingsByFilter, postingMatchesFilter } from '@/utils/employerPostingFilter';
+import type { JobPostingStatus } from '@/types/jobPosting';
+
+const posting = (status: JobPostingStatus) => ({ status });
+
+describe('postingMatchesFilter', () => {
+  it("'all' 필터는 모든 status 를 포함한다", () => {
+    expect(postingMatchesFilter('active', 'all')).toBe(true);
+    expect(postingMatchesFilter('capacity_full', 'all')).toBe(true);
+    expect(postingMatchesFilter('expired', 'all')).toBe(true);
+  });
+
+  it("capacity_full(정원 자동마감) 공고는 '모집중' 필터에 포함된다", () => {
+    // 회귀 가드: capacity_full 은 마감일 전 진행중 상태라 active 버킷에 합류해야 함
+    expect(postingMatchesFilter('capacity_full', 'active')).toBe(true);
+    expect(postingMatchesFilter('active', 'active')).toBe(true);
+  });
+
+  it("capacity_full 은 '마감' 필터에는 포함되지 않는다", () => {
+    expect(postingMatchesFilter('capacity_full', 'closed')).toBe(false);
+  });
+
+  it("'마감' 필터는 closed status 만 포함한다", () => {
+    expect(postingMatchesFilter('closed', 'closed')).toBe(true);
+    expect(postingMatchesFilter('active', 'closed')).toBe(false);
+  });
+
+  it('버킷에 매핑되지 않은 status(expired 등)는 active/closed 어디에도 포함되지 않는다', () => {
+    expect(postingMatchesFilter('expired', 'active')).toBe(false);
+    expect(postingMatchesFilter('expired', 'closed')).toBe(false);
+    expect(postingMatchesFilter('cancelled', 'active')).toBe(false);
+  });
+});
+
+describe('countPostingsByFilter', () => {
+  it('전체(all) 카운트는 공고 총 개수와 같다', () => {
+    const counts = countPostingsByFilter([
+      posting('active'),
+      posting('capacity_full'),
+      posting('closed'),
+      posting('expired'),
+    ]);
+    expect(counts.all).toBe(4);
+  });
+
+  it("capacity_full 은 '모집중' 카운트에 합산된다", () => {
+    const counts = countPostingsByFilter([
+      posting('active'),
+      posting('active'),
+      posting('capacity_full'),
+      posting('closed'),
+    ]);
+    expect(counts.active).toBe(3); // active 2 + capacity_full 1
+    expect(counts.closed).toBe(1);
+  });
+
+  it('버킷 없는 status 는 active/closed 카운트를 부풀리지 않는다', () => {
+    const counts = countPostingsByFilter([
+      posting('active'),
+      posting('expired'),
+      posting('cancelled'),
+    ]);
+    expect(counts.active).toBe(1);
+    expect(counts.closed ?? 0).toBe(0);
+  });
+});

--- a/uniqn-mobile/src/utils/employerPostingFilter.ts
+++ b/uniqn-mobile/src/utils/employerPostingFilter.ts
@@ -1,0 +1,50 @@
+import type { JobPostingStatus } from '@/types/jobPosting';
+
+/**
+ * 구인자 공고관리 화면의 상단 필터 탭 값.
+ * UI 탭은 전체/모집중/마감 3종이며, 공고의 세부 status 를 이 3개 버킷으로 묶는다.
+ */
+export type PostingFilterStatus = 'all' | 'active' | 'closed';
+
+/**
+ * 공고 status → 필터 버킷 매핑.
+ *
+ * capacity_full(정원 자동마감)은 마감일 전까지 노출되는 '진행중' 상태이므로 '모집중'에 합류한다.
+ * 매핑되지 않은 status(draft/pending/expired/cancelled 등)는 어떤 탭에도 잡히지 않고
+ * '전체'에서만 보인다(기존 동작 유지).
+ */
+const STATUS_FILTER_BUCKET: Partial<Record<JobPostingStatus, Exclude<PostingFilterStatus, 'all'>>> =
+  {
+    active: 'active',
+    capacity_full: 'active',
+    closed: 'closed',
+  };
+
+/** 공고 status 가 주어진 필터에 해당하는지 판정한다. */
+export function postingMatchesFilter(
+  status: JobPostingStatus,
+  filter: PostingFilterStatus
+): boolean {
+  if (filter === 'all') {
+    return true;
+  }
+  return STATUS_FILTER_BUCKET[status] === filter;
+}
+
+/** 공고 목록을 필터 버킷별로 집계한다(전체 + 매핑된 버킷). */
+export function countPostingsByFilter<T extends { status: JobPostingStatus }>(
+  postings: readonly T[]
+): Partial<Record<PostingFilterStatus, number>> {
+  const counts: Partial<Record<PostingFilterStatus, number>> = {
+    all: postings.length,
+  };
+
+  for (const posting of postings) {
+    const bucket = STATUS_FILTER_BUCKET[posting.status];
+    if (bucket) {
+      counts[bucket] = (counts[bucket] ?? 0) + 1;
+    }
+  }
+
+  return counts;
+}


### PR DESCRIPTION
## 문제
구인자 공고관리 상단 필터(전체/모집중/마감)가 `posting.status === filter` 정확 매칭이라, `capacity_full`(정원 자동마감) 공고가 **'모집중'에도 '마감'에도 안 잡히고 '전체'에만** 노출됐다. 정원이 차는 것은 가장 흔한 정상 상태라 구인자 입장에서 공고가 사라진 것처럼 보이고, 탭 카운트 합도 어긋났다(전체 ≠ 모집중 + 마감).

## 변경
- `capacity_full` 을 '모집중' 버킷에 합류(마감일 전 진행중 상태) — 카드의 '정원마감' 배지는 유지
- 카운트도 동일 규칙으로 합산 → 전체 = 모집중 + 마감 정합
- status→필터 버킷 매핑을 순수 헬퍼 `employerPostingFilter` 로 추출(단위 테스트 8건)
- `expired`/`cancelled` 등 미매핑 status 는 기존대로 '전체'에서만 노출(동작 보존)

## 검증
- tsc 0 · eslint 0
- jest: 신규 8건 + 기존 (tabs)·employer 86건 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)