### PR TITLE
fix(workspace): staff 초대 dead-end 차단 — 멤버 초대를 구인자로 한정

### DIFF
--- a/uniqn-mobile/app/(employer)/workspace/invite.tsx
+++ b/uniqn-mobile/app/(employer)/workspace/invite.tsx
@@ -55,7 +55,7 @@ export default function WorkspaceInviteScreen() {
       const found = await workspaceService.lookupUserByEmail(trimmed);
       setLookupResult(found);
       if (!found) {
-        setSearchError('등록된 사용자를 찾을 수 없어요');
+        setSearchError('구인자로 등록된 사용자를 찾을 수 없어요');
       }
     } catch (err) {
       logger.warn('사용자 검색 실패', { error: String(err) });
@@ -171,7 +171,7 @@ export default function WorkspaceInviteScreen() {
               <View className="items-center py-12">
                 <EmptyState
                   title="이메일을 입력해주세요"
-                  description="등록된 사용자 이메일로 검색하면 초대할 수 있어요."
+                  description="구인자로 등록된 사용자만 멤버로 초대할 수 있어요."
                 />
               </View>
             )

--- a/uniqn-mobile/src/services/workspace/__tests__/workspaceService.test.ts
+++ b/uniqn-mobile/src/services/workspace/__tests__/workspaceService.test.ts
@@ -1,6 +1,7 @@
 import { workspaceService } from '@/services/workspace/workspaceService';
 import { BusinessError, ERROR_CODES, ValidationError } from '@/errors';
 import { workspaceRepository } from '@/repositories';
+import { supabase } from '@/lib/supabase';
 import type { Workspace } from '@/types/workspace';
 
 const mockFindAllByMember = jest.fn();
@@ -150,5 +151,55 @@ describe('workspaceService - archive/restore', () => {
     const spy = jest.spyOn(workspaceRepository, 'findArchivedByOwner').mockResolvedValue([]);
     await workspaceService.listArchivedWorkspaces('owner-1');
     expect(spy).toHaveBeenCalledWith('owner-1');
+  });
+});
+
+describe('workspaceService.lookupUserByEmail', () => {
+  function mockUsersQueryOnce(row: Record<string, unknown> | null) {
+    const inSpy = jest.fn().mockReturnThis();
+    const chain = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      in: inSpy,
+      maybeSingle: jest.fn().mockResolvedValue({ data: row, error: null }),
+    };
+    (supabase.from as jest.Mock).mockReturnValueOnce(chain);
+    return { inSpy };
+  }
+
+  it('초대 대상 조회를 employer/admin 역할로만 한정한다 (staff 초대 dead-end 차단)', async () => {
+    const { inSpy } = mockUsersQueryOnce(null);
+
+    await workspaceService.lookupUserByEmail('someone@uniqn.app');
+
+    // 회귀 가드: 역할 한정 필터가 빠지면 staff 가 다시 초대돼 수락 화면 없는 dead-end 발생
+    expect(inSpy).toHaveBeenCalledWith('role', ['employer', 'admin']);
+  });
+
+  it('employer 사용자는 정상 매핑되어 반환된다', async () => {
+    mockUsersQueryOnce({
+      id: 'emp-1',
+      name: '사장',
+      email: 'boss@uniqn.app',
+      photo_url: null,
+      is_active: true,
+    });
+
+    const result = await workspaceService.lookupUserByEmail('boss@uniqn.app');
+
+    expect(result).toEqual({
+      id: 'emp-1',
+      name: '사장',
+      email: 'boss@uniqn.app',
+      photoUrl: null,
+    });
+  });
+
+  it('역할 미일치(쿼리 결과 없음)면 null 을 반환한다', async () => {
+    mockUsersQueryOnce(null);
+
+    const result = await workspaceService.lookupUserByEmail('staff@uniqn.app');
+
+    expect(result).toBeNull();
   });
 });

--- a/uniqn-mobile/src/services/workspace/workspaceService.ts
+++ b/uniqn-mobile/src/services/workspace/workspaceService.ts
@@ -196,10 +196,14 @@ export const workspaceService = {
     }
 
     try {
+      // 워크스페이스 멤버는 구조적으로 employer/admin 전제(공고 생성 RLS·(employer) 라우트 가드).
+      // staff 를 초대하면 수락 화면이 employer 전용이라 수신자가 도달 불가한 dead-end 가 되므로
+      // 조회 단계에서 employer/admin 으로 한정해 애초에 초대되지 않도록 막는다.
       const { data, error } = await supabase
         .from('users')
         .select('id, name, email, photo_url, is_active')
         .eq('email', trimmed)
+        .in('role', ['employer', 'admin'])
         .maybeSingle();
 
       if (error) {


### PR DESCRIPTION
## 문제
워크스페이스 멤버 초대(`lookupUserByEmail`)가 역할 무관 전체 사용자를 조회해 **staff 도 초대 가능**했다. 그러나 워크스페이스 멤버는 구조적으로 **employer 전제**다:
- 수락 화면·공고 관리가 모두 `(employer)` 라우트 → 비-employer 는 `home-jobs` 로 리다이렉트
- 공고 생성(`jp_insert`) RLS 가 `users.role = employer/admin` 요구
- 수락 RPC(`accept_workspace_invitation`)는 `users.role` 을 올리지 않음

→ staff 를 초대하면 수신자가 수락 화면에 **도달할 수 없는 dead-end**.

## 변경
- `lookupUserByEmail` 조회를 `employer`/`admin` 역할로 한정 → staff 는 애초에 초대 불가
- invite 화면 안내/검색 실패 문구를 "구인자로 등록된 사용자" 로 명확화
- 회귀 가드 단위 테스트 3건(역할 필터 적용·employer 매핑·미일치 null) — Red→Green 확인

## 후속 권장(별도)
서버 경계 방어로 `invite_workspace_member` RPC 에도 invitee 역할 검증 추가 권장. (이 PR 은 클라 조회 한정으로 UI dead-end 를 원천 차단)

## 검증
- tsc 0 · eslint 0 · jest 12건 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)