### PR TITLE
feat(ux): UX 동선 Quick Wins — 알림 긴급 우선·구인자 진입점·지역 필터

### DIFF
--- a/uniqn-mobile/app/(app)/(tabs)/home-jobs.tsx
+++ b/uniqn-mobile/app/(app)/(tabs)/home-jobs.tsx
@@ -3,12 +3,16 @@
  */
 
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
-import { View, Keyboard } from 'react-native';
+import { View, Text, Pressable, Keyboard } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useQuery } from '@tanstack/react-query';
 import { router } from 'expo-router';
 import { format } from 'date-fns';
 import { JobList, PostingTypeChips, DateCalendar, SearchBar } from '@/components/jobs';
+import { RegionSelectModal } from '@/components/employer/job-form/modals';
+import { getRegionLabel } from '@/constants/regions';
+import { MapPinIcon, ChevronDownIcon } from '@/components/icons';
+import { SECONDARY_PALETTE } from '@/constants/colors';
 import { TabHeader } from '@/components/headers';
 import { useJobPostings } from '@/hooks/useJobPostings';
 import { usePostingTypeCounts } from '@/hooks/usePostingTypeCounts';
@@ -39,6 +43,8 @@ export default function JobsScreen() {
 
   const [selectedType, setSelectedType] = useState<PostingType | null>(null);
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  const [selectedRegion, setSelectedRegion] = useState<string | null>(null);
+  const [regionModalVisible, setRegionModalVisible] = useState(false);
   const [searchText, setSearchText] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const normalizedSearchText = searchText.trim();
@@ -103,8 +109,12 @@ export default function JobsScreen() {
       result.workDate = selectedDateString;
     }
 
+    if (selectedRegion) {
+      result.region = selectedRegion;
+    }
+
     return result;
-  }, [selectedDateString, selectedType]);
+  }, [selectedDateString, selectedType, selectedRegion]);
 
   const { jobs, isLoading, isRefreshing, isFetchingMore, hasMore, error, refresh, loadMore } =
     useJobPostings({
@@ -172,6 +182,10 @@ export default function JobsScreen() {
     router.push(`/(app)/jobs/${jobId}`);
   }, []);
 
+  const handleRegionSelect = useCallback((slug: string | null) => {
+    setSelectedRegion(slug);
+  }, []);
+
   return (
     <SafeAreaView className="flex-1 bg-surface-page dark:bg-surface" edges={['top']}>
       <TabHeader title="구인구직" />
@@ -179,6 +193,40 @@ export default function JobsScreen() {
       <SearchBar value={searchText} onChangeText={setSearchText} />
 
       <PostingTypeChips selected={selectedType} onChange={handleTypeChange} counts={chipCounts} />
+
+      {!isSearchMode && (
+        <View className="flex-row px-4 pb-2">
+          <Pressable
+            onPress={() => setRegionModalVisible(true)}
+            className={`min-h-[36px] flex-row items-center gap-1 rounded-full border px-3 py-1.5 active:opacity-70 ${
+              selectedRegion
+                ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/30'
+                : 'border-secondary-300 dark:border-surface-overlay'
+            }`}
+            accessibilityRole="button"
+            accessibilityLabel="지역 필터 선택"
+            testID="home-region-filter"
+          >
+            <MapPinIcon
+              size={16}
+              color={selectedRegion ? SECONDARY_PALETTE[600] : SECONDARY_PALETTE[400]}
+            />
+            <Text
+              className={`text-sm font-sans-medium ${
+                selectedRegion
+                  ? 'text-primary-700 dark:text-primary-300'
+                  : 'text-content-secondary dark:text-secondary-400'
+              }`}
+            >
+              {getRegionLabel(selectedRegion ?? undefined) ?? '지역 전체'}
+            </Text>
+            <ChevronDownIcon
+              size={16}
+              color={selectedRegion ? SECONDARY_PALETTE[600] : SECONDARY_PALETTE[400]}
+            />
+          </Pressable>
+        </View>
+      )}
 
       {selectedType === 'regular' && (
         <DateCalendar selectedDate={selectedDate} onDateSelect={setSelectedDate} />
@@ -210,6 +258,11 @@ export default function JobsScreen() {
           onLoadMore={loadMore}
           onJobPress={handleJobPress}
           filledCounts={filledCountsQuery.data}
+          emptyMessage={
+            selectedRegion
+              ? `${getRegionLabel(selectedRegion) ?? '선택한 지역'} 공고가 없어요. 위 지역 칩을 눌러 '지역 전체'로 바꿔보세요.`
+              : undefined
+          }
         />
       )}
 
@@ -222,6 +275,14 @@ export default function JobsScreen() {
           />
         </View>
       )}
+
+      <RegionSelectModal
+        visible={regionModalVisible}
+        onClose={() => setRegionModalVisible(false)}
+        onSelect={handleRegionSelect}
+        selectedSlug={selectedRegion ?? undefined}
+        title="지역 필터"
+      />
     </SafeAreaView>
   );
 }

--- a/uniqn-mobile/app/(app)/(tabs)/profile.tsx
+++ b/uniqn-mobile/app/(app)/(tabs)/profile.tsx
@@ -28,6 +28,7 @@ import {
   HomeIcon,
   UsersIcon,
   StarIcon,
+  BriefcaseIcon,
 } from '@/components/icons';
 import { useAuth } from '@/hooks/useAuth';
 import { useBubbleScore } from '@/hooks/useReviews';
@@ -208,6 +209,16 @@ export default function ProfileScreen() {
         </Card>
 
         <Card className="mb-4">
+          {profile?.role === 'staff' && (
+            <>
+              <MenuItem
+                icon={<BriefcaseIcon size={22} color={SECONDARY_PALETTE[500]} />}
+                label="구인자 신청"
+                onPress={() => router.push('/(app)/employer-application-status')}
+              />
+              <Divider spacing="sm" />
+            </>
+          )}
           <MenuItem
             icon={<StarIcon size={20} color={SECONDARY_PALETTE[500]} />}
             label="내 평점·리뷰 이력"

--- a/uniqn-mobile/src/components/employer/job-form/modals/RegionSelectModal.tsx
+++ b/uniqn-mobile/src/components/employer/job-form/modals/RegionSelectModal.tsx
@@ -1,0 +1,94 @@
+import { memo, useCallback } from 'react';
+import { View, Text, Pressable, ScrollView } from 'react-native';
+import { Modal } from '@/components/ui/Modal';
+import { CheckIcon } from '@/components/icons';
+import { useThemeStore } from '@/stores/themeStore';
+import { REGION_GROUPS, REGIONS_BY_GROUP, type RegionOption } from '@/constants/regions';
+
+export interface RegionSelectModalProps {
+  visible: boolean;
+  onClose: () => void;
+  /** slug 선택. null = 선택 해제 */
+  onSelect: (slug: string | null) => void;
+  selectedSlug?: string;
+  title?: string;
+}
+
+export const RegionSelectModal = memo(function RegionSelectModal({
+  visible,
+  onClose,
+  onSelect,
+  selectedSlug,
+  title = '지역 선택',
+}: RegionSelectModalProps) {
+  const isDarkMode = useThemeStore((state) => state.isDarkMode);
+
+  const handleSelect = useCallback(
+    (slug: string | null) => {
+      onSelect(slug);
+      onClose();
+    },
+    [onClose, onSelect]
+  );
+
+  const renderItem = useCallback(
+    (item: RegionOption) => {
+      const isSelected = item.slug === selectedSlug;
+      return (
+        <Pressable
+          key={item.slug}
+          onPress={() => handleSelect(item.slug)}
+          className="flex-row items-center justify-between px-4 py-3.5 border-b border-secondary-100 dark:border-surface-overlay active:opacity-70"
+          accessibilityRole="button"
+          accessibilityState={{ selected: isSelected }}
+          accessibilityLabel={`${item.label} 지역 선택`}
+        >
+          <Text className="text-base font-sans text-content-primary">{item.label}</Text>
+          {isSelected ? <CheckIcon size={20} color={isDarkMode ? '#D4AF37' : '#8A7228'} /> : null}
+        </Pressable>
+      );
+    },
+    [handleSelect, isDarkMode, selectedSlug]
+  );
+
+  return (
+    <Modal visible={visible} onClose={onClose} title={title} position="bottom" showCloseButton>
+      <View className="-mx-5 -mb-5">
+        <ScrollView
+          className="max-h-[420px]"
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator
+        >
+          {/* 선택 해제 */}
+          <Pressable
+            onPress={() => handleSelect(null)}
+            className="flex-row items-center justify-between px-4 py-3.5 border-b border-secondary-100 dark:border-surface-overlay active:opacity-70"
+            accessibilityRole="button"
+            accessibilityLabel="지역 선택 안 함"
+          >
+            <Text className="text-base font-sans text-content-secondary dark:text-secondary-400">
+              선택 안 함
+            </Text>
+            {!selectedSlug ? (
+              <CheckIcon size={20} color={isDarkMode ? '#D4AF37' : '#8A7228'} />
+            ) : null}
+          </Pressable>
+
+          {REGION_GROUPS.map((group) => (
+            <View key={group}>
+              <View className="bg-surface-card px-4 py-2 dark:bg-surface-elevated">
+                <Text className="text-xs font-sans-semibold text-content-muted dark:text-secondary-400">
+                  {group}
+                </Text>
+              </View>
+              {REGIONS_BY_GROUP[group].map(renderItem)}
+            </View>
+          ))}
+          <View className="h-8" />
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+});
+
+export default RegionSelectModal;

--- a/uniqn-mobile/src/components/employer/job-form/modals/index.ts
+++ b/uniqn-mobile/src/components/employer/job-form/modals/index.ts
@@ -6,3 +6,4 @@ export { DatePickerModal } from './DatePickerModal';
 export { RoleSelectModal, type RoleSelectModalProps } from './RoleSelectModal';
 export { GroupingConfirmModal, type GroupingConfirmModalProps } from './GroupingConfirmModal';
 export { NumberPickerModal, type NumberPickerModalProps } from './NumberPickerModal';
+export { RegionSelectModal, type RegionSelectModalProps } from './RegionSelectModal';

--- a/uniqn-mobile/src/components/employer/job-form/sections/BasicInfoSection.tsx
+++ b/uniqn-mobile/src/components/employer/job-form/sections/BasicInfoSection.tsx
@@ -7,12 +7,14 @@
 
 import { SECONDARY_PALETTE } from '@/constants/colors';
 import React, { useState, useCallback, useEffect, useRef, memo } from 'react';
-import { View, Text, TextInput } from 'react-native';
+import { View, Text, TextInput, Pressable } from 'react-native';
 import { Input, FormField } from '@/components';
-import { MapPinIcon, PhoneIcon } from '@/components/icons';
+import { MapPinIcon, PhoneIcon, ChevronRightIcon } from '@/components/icons';
 import type { JobPostingFormData, Location, PostingType } from '@/types';
 import { PostingTypeSelector } from '../shared';
+import { RegionSelectModal } from '../modals';
 import { formatPhoneNumber } from '@/utils/phone';
+import { findRegionByAddress, getRegionLabel } from '@/constants/regions';
 
 // ============================================================================
 // Types
@@ -46,6 +48,7 @@ export const BasicInfoSection = memo(function BasicInfoSection({
 }: BasicInfoSectionProps) {
   const [locationName, setLocationName] = useState(data.location?.name || '');
   const [locationAddress, setLocationAddress] = useState(getLocationAddressValue(data.location));
+  const [regionModalVisible, setRegionModalVisible] = useState(false);
 
   // 외부에서 data.location이 변경되면 (템플릿 불러오기 등) 로컬 상태 동기화
   // 주의: data.location은 draftToFormData() 호출마다 새 객체를 생성하므로 객체 자체가 아닌
@@ -64,11 +67,13 @@ export const BasicInfoSection = memo(function BasicInfoSection({
   dataRef.current = data;
 
   // 장소 정보 업데이트
+  // region 은 default 를 두지 않는다 — 호출부가 보존/갱신/해제를 명시 전달(default 시 해제 불가).
   const handleUpdateLocation = useCallback(
     (
       name: string,
       address: string,
-      detailedAddress: string = getDetailedAddressValue(dataRef.current)
+      detailedAddress: string = getDetailedAddressValue(dataRef.current),
+      region?: string
     ) => {
       if (name.trim()) {
         const location: Location = {
@@ -76,6 +81,7 @@ export const BasicInfoSection = memo(function BasicInfoSection({
           name,
           address,
           district: address,
+          ...(region ? { region } : {}),
           ...(detailedAddress ? { detailedAddress } : {}),
         };
         onUpdate({ location, detailedAddress });
@@ -86,22 +92,31 @@ export const BasicInfoSection = memo(function BasicInfoSection({
     [onUpdate]
   );
 
-  // 장소명 변경
+  // 장소명 변경 (기존 지역 보존)
   const handleLocationNameChange = useCallback(
     (name: string) => {
       setLocationName(name);
-      handleUpdateLocation(name, locationAddress);
+      handleUpdateLocation(name, locationAddress, undefined, dataRef.current.location?.region);
     },
     [locationAddress, handleUpdateLocation]
   );
 
-  // 장소 주소 변경
+  // 장소 주소 변경 (지역 미설정 시 주소에서 자동 제안)
   const handleLocationAddressChange = useCallback(
     (address: string) => {
       setLocationAddress(address);
-      handleUpdateLocation(locationName, address);
+      const region = dataRef.current.location?.region ?? findRegionByAddress(address)?.slug;
+      handleUpdateLocation(locationName, address, undefined, region);
     },
     [locationName, handleUpdateLocation]
+  );
+
+  // 지역 선택 (null = 해제)
+  const handleRegionSelect = useCallback(
+    (slug: string | null) => {
+      handleUpdateLocation(locationName, locationAddress, undefined, slug ?? undefined);
+    },
+    [locationName, locationAddress, handleUpdateLocation]
   );
 
   // 공고 타입 변경 핸들러
@@ -175,13 +190,43 @@ export const BasicInfoSection = memo(function BasicInfoSection({
         />
       </FormField>
 
+      {/* 지역 선택 (선택) — 지역 필터 노출용. 주소 입력 시 자동 제안 */}
+      <FormField label="지역" error={errors.region}>
+        <Pressable
+          onPress={() => setRegionModalVisible(true)}
+          className="min-h-[44px] flex-row items-center justify-between rounded-lg border-2 border-secondary-300 bg-white px-4 py-3 active:opacity-70 dark:border-surface-overlay dark:bg-surface"
+          accessibilityRole="button"
+          accessibilityLabel="지역 선택"
+          testID="job-posting-region-selector"
+        >
+          <View className="flex-row items-center">
+            <MapPinIcon size={20} color={SECONDARY_PALETTE[500]} />
+            <Text
+              className={`ml-2 text-base font-sans ${
+                data.location?.region
+                  ? 'text-content-primary'
+                  : 'text-secondary-400 dark:text-secondary-500'
+              }`}
+            >
+              {getRegionLabel(data.location?.region) ?? '지역 선택 (선택 사항)'}
+            </Text>
+          </View>
+          <ChevronRightIcon size={18} color={SECONDARY_PALETTE[400]} />
+        </Pressable>
+      </FormField>
+
       {/* 상세 주소 */}
       <FormField label="상세 주소" error={errors.detailedAddress}>
         <Input
           placeholder="건물명, 층수 등 (선택)"
           value={getDetailedAddressValue(data)}
           onChangeText={(detailedAddress) =>
-            handleUpdateLocation(locationName, locationAddress, detailedAddress)
+            handleUpdateLocation(
+              locationName,
+              locationAddress,
+              detailedAddress,
+              dataRef.current.location?.region
+            )
           }
           accessibilityLabel="상세 주소"
           testID="job-posting-detailed-address-input"
@@ -222,6 +267,13 @@ export const BasicInfoSection = memo(function BasicInfoSection({
           {data.description.length}/500
         </Text>
       </FormField>
+
+      <RegionSelectModal
+        visible={regionModalVisible}
+        onClose={() => setRegionModalVisible(false)}
+        onSelect={handleRegionSelect}
+        selectedSlug={data.location?.region}
+      />
     </View>
   );
 });

--- a/uniqn-mobile/src/constants/__tests__/regions.test.ts
+++ b/uniqn-mobile/src/constants/__tests__/regions.test.ts
@@ -1,0 +1,114 @@
+/**
+ * UNIQN Mobile - regions 상수/헬퍼 테스트
+ */
+
+import {
+  REGIONS,
+  REGIONS_BY_GROUP,
+  REGION_GROUPS,
+  getRegionLabel,
+  isRegionSlug,
+  findRegionByAddress,
+} from '../regions';
+
+describe('REGIONS 분류', () => {
+  it('서울 25개 구를 포함한다', () => {
+    const seoul = REGIONS.filter((r) => r.group === '서울');
+    expect(seoul).toHaveLength(25);
+    expect(seoul.some((r) => r.label === '강남구')).toBe(true);
+    expect(seoul.some((r) => r.label === '중랑구')).toBe(true);
+  });
+
+  it('7개 광역시를 단일 항목으로 포함한다', () => {
+    const metro = REGIONS.filter((r) => r.group === '광역시');
+    expect(metro).toHaveLength(7);
+    expect(metro.map((r) => r.slug)).toEqual(
+      expect.arrayContaining(['부산', '대구', '인천', '광주', '대전', '울산', '세종'])
+    );
+  });
+
+  it('경기 주요시를 포함한다', () => {
+    const gyeonggi = REGIONS.filter((r) => r.group === '경기');
+    expect(gyeonggi.some((r) => r.label === '수원시')).toBe(true);
+    expect(gyeonggi.some((r) => r.label === '성남시')).toBe(true);
+  });
+
+  it('제주(제주시·서귀포시)를 포함한다', () => {
+    const jeju = REGIONS.filter((r) => r.group === '제주');
+    expect(jeju.map((r) => r.label)).toEqual(['제주시', '서귀포시']);
+  });
+
+  it('기타 그룹에 기타 지역과 해외를 포함한다', () => {
+    const etc = REGIONS.filter((r) => r.group === '기타');
+    expect(etc.map((r) => r.slug)).toEqual(['기타', '해외']);
+  });
+
+  it('slug 는 전역에서 고유하다', () => {
+    const slugs = REGIONS.map((r) => r.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it('REGIONS_BY_GROUP 가 REGION_GROUPS 순서대로 그룹핑한다', () => {
+    const flattened = REGION_GROUPS.flatMap((g) => REGIONS_BY_GROUP[g]);
+    expect(flattened).toHaveLength(REGIONS.length);
+  });
+});
+
+describe('getRegionLabel / isRegionSlug', () => {
+  it('알려진 slug 의 라벨을 반환한다', () => {
+    expect(getRegionLabel('서울 강남구')).toBe('강남구');
+    expect(getRegionLabel('부산')).toBe('부산광역시');
+    expect(getRegionLabel('제주 제주시')).toBe('제주시');
+    expect(getRegionLabel('해외')).toBe('해외');
+  });
+
+  it('알 수 없는 slug 는 undefined 를 반환한다', () => {
+    expect(getRegionLabel('존재하지않음')).toBeUndefined();
+    expect(isRegionSlug('서울 강남구')).toBe(true);
+    expect(isRegionSlug('존재하지않음')).toBe(false);
+  });
+});
+
+describe('findRegionByAddress (자동 제안)', () => {
+  it('서울 주소에서 구를 추출한다', () => {
+    expect(findRegionByAddress('서울특별시 강남구 역삼동 123-45')?.slug).toBe('서울 강남구');
+    expect(findRegionByAddress('서울 마포구 합정동')?.slug).toBe('서울 마포구');
+  });
+
+  it('광역시 주소를 단일 광역시로 매칭한다', () => {
+    expect(findRegionByAddress('부산광역시 해운대구 우동')?.slug).toBe('부산');
+    expect(findRegionByAddress('대전 서구 둔산동')?.slug).toBe('대전');
+  });
+
+  it('경기 도시를 광역시 광주와 혼동하지 않는다', () => {
+    expect(findRegionByAddress('경기도 광주시 역동')?.slug).toBe('경기 광주시');
+    expect(findRegionByAddress('광주광역시 서구 치평동')?.slug).toBe('광주');
+  });
+
+  it('경기 주요시를 추출한다', () => {
+    expect(findRegionByAddress('경기도 성남시 분당구 정자동')?.slug).toBe('경기 성남시');
+  });
+
+  it('제주 주소에서 시를 추출한다', () => {
+    expect(findRegionByAddress('제주특별자치도 제주시 노형동')?.slug).toBe('제주 제주시');
+    expect(findRegionByAddress('제주 서귀포시 중문동')?.slug).toBe('제주 서귀포시');
+  });
+
+  it('해외는 자동 매칭하지 않는다(수동 선택 전용)', () => {
+    expect(findRegionByAddress('Las Vegas, Nevada, USA')).toBeUndefined();
+  });
+
+  it('도/시 접두 없는 구 이름은 서울 구로 폴백한다', () => {
+    expect(findRegionByAddress('강남구 역삼동')?.slug).toBe('서울 강남구');
+  });
+
+  it('부산 강서구는 서울 강서구로 오인하지 않는다', () => {
+    expect(findRegionByAddress('부산 강서구 명지동')?.slug).toBe('부산');
+  });
+
+  it('매칭 불가/빈 입력은 undefined 를 반환한다', () => {
+    expect(findRegionByAddress('')).toBeUndefined();
+    expect(findRegionByAddress('알 수 없는 행성 어딘가')).toBeUndefined();
+    expect(findRegionByAddress(undefined)).toBeUndefined();
+  });
+});

--- a/uniqn-mobile/src/constants/regions.ts
+++ b/uniqn-mobile/src/constants/regions.ts
@@ -1,0 +1,207 @@
+/**
+ * UNIQN Mobile - 지역(region) 분류 상수
+ *
+ * @description 공고 작성 시 선택하는 정규화된 지역 코드. 자유텍스트 주소(location.address)
+ * 와 별개로 location.region 에 stable slug 를 저장해 지역 필터(eq)에 사용한다.
+ *
+ * 범위: 서울 25개 구(개별) + 7개 광역시(시 단위) + 경기 주요시 + 제주 + 기타/해외.
+ * 추후 확장은 이 상수에 항목 추가만으로 무손실 가능(slug 는 변경 금지).
+ */
+
+export type RegionGroup = '서울' | '경기' | '광역시' | '제주' | '기타';
+
+export interface RegionOption {
+  /** 저장/필터에 사용하는 stable id (변경 금지) */
+  slug: string;
+  /** 표시 라벨 */
+  label: string;
+  /** UI 그룹 */
+  group: RegionGroup;
+  /** 주소 텍스트 매칭용 키워드 (구/시 이름) */
+  keyword: string;
+}
+
+export const REGION_GROUPS: readonly RegionGroup[] = ['서울', '경기', '광역시', '제주', '기타'];
+
+const SEOUL_GU = [
+  '강남구',
+  '강동구',
+  '강북구',
+  '강서구',
+  '관악구',
+  '광진구',
+  '구로구',
+  '금천구',
+  '노원구',
+  '도봉구',
+  '동대문구',
+  '동작구',
+  '마포구',
+  '서대문구',
+  '서초구',
+  '성동구',
+  '성북구',
+  '송파구',
+  '양천구',
+  '영등포구',
+  '용산구',
+  '은평구',
+  '종로구',
+  '중구',
+  '중랑구',
+] as const;
+
+const GYEONGGI_SI = [
+  '수원시',
+  '성남시',
+  '고양시',
+  '용인시',
+  '부천시',
+  '안산시',
+  '안양시',
+  '남양주시',
+  '화성시',
+  '평택시',
+  '의정부시',
+  '시흥시',
+  '파주시',
+  '김포시',
+  '광명시',
+  '광주시',
+  '군포시',
+  '하남시',
+  '오산시',
+  '양주시',
+  '이천시',
+  '구리시',
+  '안성시',
+  '포천시',
+  '의왕시',
+  '여주시',
+  '동두천시',
+  '과천시',
+  '가평군',
+  '양평군',
+  '연천군',
+] as const;
+
+const METRO: readonly { slug: string; label: string; keyword: string }[] = [
+  { slug: '부산', label: '부산광역시', keyword: '부산' },
+  { slug: '대구', label: '대구광역시', keyword: '대구' },
+  { slug: '인천', label: '인천광역시', keyword: '인천' },
+  { slug: '광주', label: '광주광역시', keyword: '광주' },
+  { slug: '대전', label: '대전광역시', keyword: '대전' },
+  { slug: '울산', label: '울산광역시', keyword: '울산' },
+  { slug: '세종', label: '세종특별자치시', keyword: '세종' },
+];
+
+// 제주특별자치도 — 시 단위(서귀포시 우선 매칭으로 제주시 substring 충돌 방지)
+const JEJU_SI = ['제주시', '서귀포시'] as const;
+
+const SEOUL_REGIONS: RegionOption[] = SEOUL_GU.map((gu) => ({
+  slug: `서울 ${gu}`,
+  label: gu,
+  group: '서울',
+  keyword: gu,
+}));
+
+const GYEONGGI_REGIONS: RegionOption[] = GYEONGGI_SI.map((si) => ({
+  slug: `경기 ${si}`,
+  label: si,
+  group: '경기',
+  keyword: si,
+}));
+
+const METRO_REGIONS: RegionOption[] = METRO.map((m) => ({
+  slug: m.slug,
+  label: m.label,
+  group: '광역시',
+  keyword: m.keyword,
+}));
+
+const JEJU_REGIONS: RegionOption[] = JEJU_SI.map((si) => ({
+  slug: `제주 ${si}`,
+  label: si,
+  group: '제주',
+  keyword: si,
+}));
+
+const ETC_REGION: RegionOption = {
+  slug: '기타',
+  label: '기타 지역',
+  group: '기타',
+  keyword: '',
+};
+
+// 해외 — 자동 매칭 대상 아님(keyword 빈 문자열, find 스캔에서 제외). 수동 선택 전용.
+const OVERSEAS_REGION: RegionOption = {
+  slug: '해외',
+  label: '해외',
+  group: '기타',
+  keyword: '',
+};
+
+export const REGIONS: readonly RegionOption[] = [
+  ...SEOUL_REGIONS,
+  ...GYEONGGI_REGIONS,
+  ...METRO_REGIONS,
+  ...JEJU_REGIONS,
+  ETC_REGION,
+  OVERSEAS_REGION,
+];
+
+export const REGIONS_BY_GROUP: Record<RegionGroup, RegionOption[]> = {
+  서울: SEOUL_REGIONS,
+  경기: GYEONGGI_REGIONS,
+  광역시: METRO_REGIONS,
+  제주: JEJU_REGIONS,
+  기타: [ETC_REGION, OVERSEAS_REGION],
+};
+
+const REGION_BY_SLUG: ReadonlyMap<string, RegionOption> = new Map(REGIONS.map((r) => [r.slug, r]));
+
+export function isRegionSlug(slug: string | null | undefined): boolean {
+  return !!slug && REGION_BY_SLUG.has(slug);
+}
+
+export function getRegionLabel(slug: string | null | undefined): string | undefined {
+  if (!slug) return undefined;
+  return REGION_BY_SLUG.get(slug)?.label;
+}
+
+/**
+ * 자유텍스트 주소에서 가장 적합한 지역을 best-effort 로 추출한다.
+ *
+ * @description 작성 폼에서 주소 입력 시 지역 드롭다운 자동 선택용. 결과는 사용자가
+ * 수정 가능하므로 정확도보다 충돌 회피(경기 광주 vs 광주광역시, 부산 강서구 vs 서울 강서구)에
+ * 무게를 둔다. 매칭 실패 시 undefined → 사용자가 직접 선택.
+ */
+export function findRegionByAddress(address: string | null | undefined): RegionOption | undefined {
+  const text = (address ?? '').trim();
+  if (!text) return undefined;
+
+  // 1) 경기 우선 — '경기' 명시 시 경기 도시로 한정(광역시 광주와 혼동 방지)
+  if (text.includes('경기')) {
+    return GYEONGGI_REGIONS.find((r) => text.includes(r.keyword));
+  }
+
+  // 2) 광역시 — 시 단위 명시 매칭
+  const metro = METRO_REGIONS.find((r) => text.includes(r.keyword));
+  if (metro) return metro;
+
+  // 2-1) 제주 — 서귀포시 먼저(제주시 substring 충돌 방지)
+  if (text.includes('서귀포')) {
+    return JEJU_REGIONS.find((r) => r.keyword === '서귀포시');
+  }
+  if (text.includes('제주')) {
+    return JEJU_REGIONS.find((r) => r.keyword === '제주시');
+  }
+
+  // 3) 서울 — '서울' 명시 시 구 매칭
+  if (text.includes('서울')) {
+    return SEOUL_REGIONS.find((r) => text.includes(r.keyword));
+  }
+
+  // 4) 폴백 — 도/시 접두 없는 구 이름은 서울 구로 가정(target market = 수도권 집중)
+  return SEOUL_REGIONS.find((r) => text.includes(r.keyword));
+}

--- a/uniqn-mobile/src/domains/job-posting/__tests__/serialization.region.test.ts
+++ b/uniqn-mobile/src/domains/job-posting/__tests__/serialization.region.test.ts
@@ -1,0 +1,65 @@
+import { serializeJobPostingV3, deserializeJobPostingDocument } from '../serialization';
+import type { CreateJobPostingInput } from '@/types/jobPosting';
+
+function createInput(region?: string): CreateJobPostingInput {
+  return {
+    postingType: 'regular',
+    title: '테스트 공고',
+    location: {
+      name: 'Seoul',
+      district: '서울 강남구 역삼동',
+      ...(region ? { region } : {}),
+      detailedAddress: '101',
+    },
+    schedule: {
+      kind: 'dated',
+      primaryDate: '2026-06-01',
+      allDates: ['2026-06-01'],
+      requirements: [
+        {
+          date: '2026-06-01',
+          timeSlots: [
+            {
+              id: 'slot-1',
+              startTime: '09:00',
+              roles: [{ id: 'dealer-1', role: 'dealer', count: 1 }],
+            },
+          ],
+        },
+      ],
+    },
+    roleCatalog: [{ role: 'dealer', salary: { type: 'hourly', amount: 12000 } }],
+    compensation: {
+      mode: 'shared',
+      defaultSalary: { type: 'hourly', amount: 12000 },
+    },
+    questions: { items: [] },
+  };
+}
+
+describe('serializeJobPostingV3 — location.region 보존', () => {
+  it('쓰기 직렬화가 location.region 을 보존한다', () => {
+    const result = serializeJobPostingV3(createInput('서울 강남구'), {
+      ownerId: 'owner-uuid-1',
+      ownerName: '테스트 오너',
+    });
+    expect((result.location as { region?: string }).region).toBe('서울 강남구');
+  });
+
+  it('region 미지정 시 location.region 필드는 누락된다', () => {
+    const result = serializeJobPostingV3(createInput(), {
+      ownerId: 'owner-uuid-1',
+      ownerName: '테스트 오너',
+    });
+    expect((result.location as { region?: string }).region).toBeUndefined();
+  });
+
+  it('직렬화→역직렬화 라운드트립에서 region 이 유지된다', () => {
+    const doc = serializeJobPostingV3(createInput('부산'), {
+      ownerId: 'owner-uuid-1',
+      ownerName: '테스트 오너',
+    });
+    const runtime = deserializeJobPostingDocument(doc);
+    expect(runtime.location.region).toBe('부산');
+  });
+});

--- a/uniqn-mobile/src/domains/job-posting/serialization.ts
+++ b/uniqn-mobile/src/domains/job-posting/serialization.ts
@@ -87,26 +87,30 @@ function normalizeOptionalText(value?: string | null): string | undefined {
 }
 
 function toCanonicalLocation(
-  location: Pick<PostingLocation, 'name' | 'address' | 'district' | 'detailedAddress'>
+  location: Pick<PostingLocation, 'name' | 'address' | 'district' | 'region' | 'detailedAddress'>
 ): JobPostingDocumentV3['location'] {
   const district =
     normalizeOptionalText(location.district) ?? normalizeOptionalText(location.address);
+  const region = normalizeOptionalText(location.region);
   const detailedAddress = normalizeOptionalText(location.detailedAddress);
 
   return {
     name: location.name.trim(),
     ...(district ? { district } : {}),
+    ...(region ? { region } : {}),
     ...(detailedAddress ? { detailedAddress } : {}),
   };
 }
 
 function normalizeRuntimeLocation(location: JobPostingDocumentV3['location']): PostingLocation {
   const district = normalizeOptionalText(location.district);
+  const region = normalizeOptionalText(location.region);
   const detailedAddress = normalizeOptionalText(location.detailedAddress);
 
   return {
     name: location.name.trim(),
     ...(district ? { district, address: district } : {}),
+    ...(region ? { region } : {}),
     ...(detailedAddress ? { detailedAddress } : {}),
   };
 }

--- a/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
@@ -131,6 +131,7 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
           }
           if (filters?.roles?.length) qr = qr.overlaps('role_keys', filters.roles.slice(0, 10));
           if (filters?.district) qr = qr.eq('location->>district', filters.district);
+          if (filters?.region) qr = qr.eq('location->>region', filters.region);
           if (filters?.ownerId) qr = qr.eq('owner_id', filters.ownerId);
           if (filters?.dateRange) {
             qr = qr

--- a/uniqn-mobile/src/schemas/__tests__/jobPosting.schema.test.ts
+++ b/uniqn-mobile/src/schemas/__tests__/jobPosting.schema.test.ts
@@ -247,11 +247,39 @@ describe('jobPosting schemas', () => {
       expect(jobFilterSchema.safeParse({ status: 'active', roles: ['dealer'] }).success).toBe(true);
       expect(jobFilterSchema.safeParse({ roles: ['invalid_role'] }).success).toBe(false);
     });
+
+    it('region 필터를 보존한다(검증 시 누락 방지)', () => {
+      const result = jobFilterSchema.safeParse({ region: '서울 강남구' });
+      expect(result.success).toBe(true);
+      expect(result.success && result.data.region).toBe('서울 강남구');
+    });
   });
 
   describe('jobPostingDocumentSchema', () => {
     it('accepts strict V3 job posting documents', () => {
       expect(jobPostingDocumentSchema.safeParse(createValidDocument()).success).toBe(true);
+    });
+
+    it('location.region 을 읽기 파싱에서 보존한다 (read 증발 방지)', () => {
+      const parsed = parseJobPostingDocument({
+        ...createValidDocument(),
+        location: {
+          name: 'Seoul',
+          district: '서울 강남구 역삼동',
+          region: '서울 강남구',
+          detailedAddress: 'Teheran-ro 123',
+        },
+      });
+      expect(parsed?.location.region).toBe('서울 강남구');
+    });
+
+    it('알 수 없는 region 문자열도 read 를 깨뜨리지 않는다', () => {
+      const parsed = parseJobPostingDocument({
+        ...createValidDocument(),
+        location: { name: 'Seoul', region: '미래신도시' },
+      });
+      expect(parsed).not.toBeNull();
+      expect(parsed?.location.region).toBe('미래신도시');
     });
 
     it('rejects postingType and schedule.kind mismatches or stale derived date fields', () => {

--- a/uniqn-mobile/src/schemas/jobPosting.schema.ts
+++ b/uniqn-mobile/src/schemas/jobPosting.schema.ts
@@ -16,6 +16,7 @@ import {
 import { JOB_POSTING_SCHEMA_VERSION } from '@/types/jobPosting';
 import { isWithinUrgentDateLimit } from '@/utils/date';
 import { Constants } from '@/types/supabase';
+import { isRegionSlug } from '@/constants/regions';
 
 /**
  * 공고 상태 SSOT — DB enum(posting_status)을 단일출처로 파생.
@@ -114,6 +115,7 @@ export const jobFilterSchema = z.object({
   status: z.enum(POSTING_STATUS_VALUES).optional(),
   roles: z.array(roleSchema).optional(),
   district: z.string().optional(),
+  region: z.string().optional(),
   dateRange: z
     .object({
       start: z.string(),
@@ -150,6 +152,8 @@ const postingLocationSchema = z
   .object({
     name: z.string(),
     district: z.string().optional(),
+    // region 은 읽기에서 enum 제한하지 않는다(미래 신규 slug 도입 시 read 증발 방지).
+    region: z.string().optional(),
     detailedAddress: z.string().optional(),
   })
   .strict();
@@ -165,6 +169,12 @@ const postingLocationInputSchema = z
       .string()
       .trim()
       .refine(xssValidation, { message: 'Unsafe text is not allowed' })
+      .optional(),
+    // 쓰기에서는 알려진 region slug 만 허용(오염 방지). 미선택은 undefined.
+    region: z
+      .string()
+      .trim()
+      .refine((v) => isRegionSlug(v), { message: 'Unknown region' })
       .optional(),
     detailedAddress: z
       .string()

--- a/uniqn-mobile/src/types/common.ts
+++ b/uniqn-mobile/src/types/common.ts
@@ -101,6 +101,8 @@ export interface Location {
   name: string;
   address?: string;
   district?: string;
+  /** 정규화된 지역 slug (src/constants/regions.ts). 지역 필터용. district(자유텍스트)와 별개 */
+  region?: string;
   detailedAddress?: string;
   coordinates?: {
     latitude: number;

--- a/uniqn-mobile/src/types/jobPosting.ts
+++ b/uniqn-mobile/src/types/jobPosting.ts
@@ -187,6 +187,8 @@ export interface JobPostingFilters {
   status?: JobPostingStatus;
   roles?: StaffRole[];
   district?: string;
+  /** 정규화된 지역 slug (src/constants/regions.ts) — location.region 과 eq 매칭 */
+  region?: string;
   dateRange?: {
     start: string;
     end: string;

--- a/uniqn-mobile/src/utils/__tests__/notificationGrouping.test.ts
+++ b/uniqn-mobile/src/utils/__tests__/notificationGrouping.test.ts
@@ -483,6 +483,74 @@ describe('groupNotifications', () => {
     const grouped = result[0] as GroupedNotificationData;
     expect(grouped.groupBody).toContain('외 1명');
   });
+
+  it('읽지 않은 urgent 알림은 더 최신인 일반 알림보다 상단에 고정된다', () => {
+    const notifications = [
+      createNotificationWithTime(1, {
+        id: 'normal-recent',
+        type: NotificationType.JOB_UPDATED, // 기본 우선순위 low
+        isRead: false,
+        data: { jobPostingId: 'job-1' },
+        body: '공고가 수정되었습니다',
+      }),
+      createNotificationWithTime(120, {
+        id: 'urgent-old',
+        type: NotificationType.CHECKIN_REMINDER, // 기본 우선순위 urgent
+        isRead: false,
+        data: {},
+        body: '출근 시간이 임박했습니다',
+      }),
+    ];
+    const result = groupNotifications(notifications);
+    // urgent-old 가 시간상 더 오래됐지만 읽지 않은 urgent 라 상단 고정
+    expect((result[0] as NotificationData).id).toBe('urgent-old');
+    expect((result[1] as NotificationData).id).toBe('normal-recent');
+  });
+
+  it('이미 읽은 urgent 알림은 상단 고정하지 않고 시간순을 유지한다', () => {
+    const notifications = [
+      createNotificationWithTime(1, {
+        id: 'normal-recent',
+        type: NotificationType.JOB_UPDATED,
+        isRead: false,
+        data: { jobPostingId: 'job-1' },
+        body: '공고가 수정되었습니다',
+      }),
+      createNotificationWithTime(120, {
+        id: 'urgent-old-read',
+        type: NotificationType.CHECKIN_REMINDER,
+        isRead: true, // 이미 읽음 → 고정 안 함
+        data: {},
+        body: '출근 시간이 임박했습니다',
+      }),
+    ];
+    const result = groupNotifications(notifications);
+    // 읽은 urgent 는 고정 제외 → 최신순(normal-recent 먼저)
+    expect((result[0] as NotificationData).id).toBe('normal-recent');
+    expect((result[1] as NotificationData).id).toBe('urgent-old-read');
+  });
+
+  it('명시적 priority 필드가 기본 우선순위보다 우선한다', () => {
+    const notifications = [
+      createNotificationWithTime(1, {
+        id: 'normal-recent',
+        type: NotificationType.NEW_APPLICATION, // 기본 high
+        isRead: false,
+        data: { jobPostingId: 'job-1' },
+        body: '새 지원자',
+      }),
+      createNotificationWithTime(120, {
+        id: 'explicit-urgent',
+        type: NotificationType.JOB_UPDATED, // 기본 low 이지만
+        priority: 'urgent', // 명시적 urgent 로 격상
+        isRead: false,
+        data: { jobPostingId: 'job-2' },
+        body: '긴급 공지',
+      }),
+    ];
+    const result = groupNotifications(notifications);
+    expect((result[0] as NotificationData).id).toBe('explicit-urgent');
+  });
 });
 
 // ============================================================================

--- a/uniqn-mobile/src/utils/notificationGrouping.ts
+++ b/uniqn-mobile/src/utils/notificationGrouping.ts
@@ -9,12 +9,14 @@ import { toDateValue } from '@/utils/date';
 import {
   NotificationData,
   NotificationType,
+  NotificationPriority,
   GroupedNotificationData,
   NotificationListItem,
   NotificationGroupingOptions,
   GROUPABLE_NOTIFICATION_TYPES,
   NOTIFICATION_TYPE_LABELS,
   NOTIFICATION_TYPE_TO_CATEGORY,
+  NOTIFICATION_DEFAULT_PRIORITY,
   isGroupedNotification,
 } from '@/types/notification';
 
@@ -130,6 +132,27 @@ function extractGroupContext(
   };
 }
 
+/**
+ * 알림의 실효 우선순위 (명시적 priority 우선, 없으면 타입별 기본값)
+ */
+function resolvePriority(notification: NotificationData): NotificationPriority {
+  return notification.priority ?? NOTIFICATION_DEFAULT_PRIORITY[notification.type] ?? 'normal';
+}
+
+/**
+ * 리스트 아이템(단건/그룹)이 "읽지 않은 긴급(urgent)" 인지 판정
+ *
+ * @description 출근 임박·노쇼·정산 마이너스 등 urgent 알림은 시간순과 무관하게
+ * 상단에 고정한다. 단, 이미 읽은 알림은 이미 인지한 것이므로 고정 대상에서 제외.
+ */
+function isUnreadUrgent(item: NotificationListItem): boolean {
+  if (isGroupedNotification(item)) {
+    if (item.unreadCount <= 0) return false;
+    return item.notifications.some((n) => !n.isRead && resolvePriority(n) === 'urgent');
+  }
+  return !item.isRead && resolvePriority(item) === 'urgent';
+}
+
 // ============================================================================
 // Main Functions
 // ============================================================================
@@ -218,8 +241,14 @@ export function groupNotifications(
   // 그룹화 불가능한 알림 추가
   result.push(...ungrouped);
 
-  // 최신순 정렬
+  // 정렬: 읽지 않은 urgent 를 최상단에 고정한 뒤, 나머지는 최신순
   result.sort((a, b) => {
+    const urgentA = isUnreadUrgent(a) ? 1 : 0;
+    const urgentB = isUnreadUrgent(b) ? 1 : 0;
+    if (urgentA !== urgentB) {
+      return urgentB - urgentA; // urgent 가 위로
+    }
+
     const timeA = isGroupedNotification(a)
       ? timestampToMs(a.latestCreatedAt)
       : timestampToMs(a.createdAt);


### PR DESCRIPTION
## 요약
UX/유저플로우 개선 분석 후 도출한 Quick Wins 3건. 도메인 신기능이 아니라 **이미 만들어둔 자산을 동선에 연결**하는 데 집중.

## 변경 (2커밋)

### 1. 알림 긴급 우선 노출 + 스태프 구인자 신청 진입점
- **알림**: 읽지 않은 `urgent`(출근 임박·노쇼·정산 마이너스)를 시간순과 무관하게 목록 최상단 고정. `notificationGrouping.ts` 단일 정렬 지점만 변경 → 모든 소비처 자동 반영. 이미 읽은 알림은 고정 제외(시간순 유지). 우선순위는 `NOTIFICATION_DEFAULT_PRIORITY` + 명시적 `priority` 폴백.
- **프로필**: `role==='staff'`일 때 "구인자 신청" 메뉴 항목 추가 → `employer-application-status`. 기존엔 심사중(pending) 배너만 떠서 미신청 스태프는 "내 공고" 탭으로만 진입 가능했음.

### 2. 공고 지역(region) 구조화 + 홈 지역 필터
- **근본 원인**: 기존 `district`에 자유텍스트 주소 전체를 저장 → `location->>district` eq 필터 매칭 불가(필터 UI 붙여도 항상 0건).
- **해결(Option B)**: 정규화 `location.region` slug 도입. 신규 `src/constants/regions.ts` — 서울 25구 + 7광역시 + 경기 주요시 + 제주 + 기타/해외 (총 67개) + `findRegionByAddress`(주소 자동 제안, 경기/광역시 광주·부산/서울 강서구·제주 서귀포 충돌 회피; 해외는 수동 전용).
- 읽기/쓰기 location 스키마 양쪽 `.strict()`에 region 추가(누락 시 read 증발 회귀 방지). 읽기는 enum 미제한(미래 slug 호환), 쓰기는 known slug 검증.
- 직렬화/역직렬화 region 통과 + `JobPostingRepository`: `filters.region → location->>region` eq.
- 작성 폼 `RegionSelectModal`(그룹별 선택) + 주소 자동 제안. 홈 지역 칩 + 모달(검색은 '검색=전체' 결정대로 미적용). 기존 공고는 region 없음 → 지역 선택 시 지역 인지 빈 상태 + '지역 전체' 안내.

region은 **선택**. 기존 공고 백필은 후속 best-effort.

## 적대 리뷰 결과
신선 컨텍스트 리뷰어 2명 디스패치. P1/P2 실결함 0. 보고된 P2(region-clear no-op)는 **오인용 기반 false positive**(실제 코드엔 `...location` 스프레드 없음 → 정상 해제). P3 2건 반영: `jobFilterSchema`에 region 추가(잠재 footgun 예방), 홈 빈 상태 지역 인지 메시지.

## 테스트 플랜
- [x] tsc 0 errors / eslint 0 errors / prettier clean
- [x] jest **343 suites / 4536 pass** (origin/master 리베이스 후)
- [x] TDD: regions 18 + 스키마 read 라운드트립 2 + 직렬화 write 3 + 알림 우선순위 3 + jobFilterSchema region 1
- [ ] 실기기/웹 수동 QA (머지 후 EAS OTA + Cloudflare 재배포 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)