### PR TITLE
fix(template): 고정공고 템플릿 불러오기 복구 + 삭제 타이머 누수/경쟁 + 저장 안내 정확화

### DIFF
--- a/uniqn-mobile/src/__tests__/hooks/useTemplateManager.delete.test.tsx
+++ b/uniqn-mobile/src/__tests__/hooks/useTemplateManager.delete.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * useTemplateManager 삭제(Undo 옵티미스틱) 동작 검증.
+ * - 타이머 만료 시 실제 DELETE 커밋
+ * - 되돌리기 시 취소 + 복원
+ * - [P2] 언마운트 시 진행 중 삭제 flush (타이머 누수 방지)
+ * - [P2] 연속 삭제 시 한 항목 복원이 다른 삭제 대기 항목을 되살리지 않음 (스냅샷 경쟁)
+ */
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useTemplateManager } from '@/hooks/useTemplateManager';
+import * as templateService from '@/services/jobs/templateService';
+import { queryKeys } from '@/lib/queryClient';
+import type { JobPostingTemplate } from '@/types';
+
+jest.mock('@/services/jobs/templateService');
+
+jest.mock('@/stores/authStore', () => ({
+  useAuthStore: (selector?: (s: { user: { uid: string } }) => unknown) => {
+    const state = { user: { uid: 'employer-1' } };
+    return selector ? selector(state) : state;
+  },
+}));
+
+const mockAddToast = jest.fn();
+jest.mock('@/stores/toastStore', () => ({
+  useToastStore: () => ({ addToast: mockAddToast }),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('@/lib/queryClient', () => ({
+  queryKeys: {
+    templates: {
+      all: ['templates'],
+      list: (userId?: string) =>
+        userId === undefined ? ['templates', 'list'] : ['templates', 'list', userId],
+      detail: (id: string) => ['templates', 'detail', id],
+    },
+  },
+  cachingPolicies: { stable: 60 * 60 * 1000 },
+}));
+
+const mockDeleteTemplate = templateService.deleteTemplate as jest.Mock;
+const mockGetTemplates = templateService.getTemplates as jest.Mock;
+
+const LIST_KEY = queryKeys.templates.list('employer-1');
+
+function makeTemplate(id: string, name: string): JobPostingTemplate {
+  return {
+    id,
+    userId: 'employer-1',
+    name,
+    description: null,
+    createdAt: null,
+    updatedAt: null,
+    templateData: {},
+    usageCount: 0,
+  };
+}
+
+function setup(seed: JobPostingTemplate[]) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  queryClient.setQueryData(LIST_KEY, seed);
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  const view = renderHook(() => useTemplateManager(), { wrapper });
+  return { queryClient, ...view };
+}
+
+function ids(queryClient: QueryClient): string[] {
+  return (queryClient.getQueryData<JobPostingTemplate[]>(LIST_KEY) ?? []).map((t) => t.id);
+}
+
+function findUndo(name: string): (() => void) | undefined {
+  const call = [...mockAddToast.mock.calls]
+    .reverse()
+    .find((c) => c[0]?.action && c[0]?.message?.includes(`'${name}'`));
+  return call?.[0]?.action?.onPress;
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockAddToast.mockClear();
+  mockDeleteTemplate.mockReset().mockResolvedValue(undefined);
+  mockGetTemplates.mockReset().mockResolvedValue([]);
+});
+
+afterEach(() => {
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+describe('useTemplateManager 삭제 Undo', () => {
+  it('타이머 만료 후 실제 DELETE 를 커밋한다', async () => {
+    const { result, queryClient } = setup([makeTemplate('a', 'A'), makeTemplate('b', 'B')]);
+
+    await act(async () => {
+      await result.current.handleDeleteTemplate('a', 'A');
+    });
+
+    expect(ids(queryClient)).toEqual(['b']);
+    expect(mockDeleteTemplate).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(mockDeleteTemplate).toHaveBeenCalledWith('a', 'employer-1');
+  });
+
+  it('되돌리기 시 DELETE 를 취소하고 복원한다', async () => {
+    const { result, queryClient } = setup([makeTemplate('a', 'A'), makeTemplate('b', 'B')]);
+
+    await act(async () => {
+      await result.current.handleDeleteTemplate('a', 'A');
+    });
+
+    const undo = findUndo('A');
+    expect(undo).toBeDefined();
+    act(() => undo!());
+
+    expect(ids(queryClient)).toEqual(['a', 'b']);
+
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(mockDeleteTemplate).not.toHaveBeenCalled();
+  });
+
+  it('[P2] 언마운트 시 진행 중인 삭제를 flush 한다 (타이머 누수 방지)', async () => {
+    const { result, unmount } = setup([makeTemplate('a', 'A'), makeTemplate('b', 'B')]);
+
+    await act(async () => {
+      await result.current.handleDeleteTemplate('a', 'A');
+    });
+    expect(mockDeleteTemplate).not.toHaveBeenCalled();
+
+    await act(async () => {
+      unmount();
+    });
+
+    expect(mockDeleteTemplate).toHaveBeenCalledWith('a', 'employer-1');
+  });
+
+  it('[P2] 연속 삭제 후 한 항목 복원이 다른 삭제 대기 항목을 되살리지 않는다', async () => {
+    const { result, queryClient } = setup([
+      makeTemplate('a', 'A'),
+      makeTemplate('b', 'B'),
+      makeTemplate('c', 'C'),
+    ]);
+
+    await act(async () => {
+      await result.current.handleDeleteTemplate('a', 'A');
+    });
+    await act(async () => {
+      await result.current.handleDeleteTemplate('b', 'B');
+    });
+
+    expect(ids(queryClient)).toEqual(['c']);
+
+    // A 되돌리기 → A 만 복원되고 B 는 삭제 대기 유지(되살아나면 안 됨)
+    const undoA = findUndo('A');
+    expect(undoA).toBeDefined();
+    act(() => undoA!());
+
+    expect(ids(queryClient)).toEqual(['a', 'c']);
+  });
+});

--- a/uniqn-mobile/src/components/employer/job-form/modals/LoadTemplateModal.tsx
+++ b/uniqn-mobile/src/components/employer/job-form/modals/LoadTemplateModal.tsx
@@ -36,20 +36,19 @@ function formatDate(timestamp: DateInput): string {
   return date.toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' });
 }
 
+// 불러올 수 없는 템플릿 = 스케줄 정보가 손상/누락된 경우뿐.
+// (고정공고 fixed 는 round-trip 검증 완료 → 정상 지원. jobTemplate.test.ts 참고)
 function isSupportedTemplateData(templateData?: JobPostingTemplate['templateData']): boolean {
-  if (!templateData?.schedule) {
-    return false;
-  }
-
-  return templateData.postingType !== 'fixed' && templateData.schedule.kind !== 'fixed';
+  return !!templateData?.schedule;
 }
 
 function getPostingTypeLabel(template: JobPostingTemplate): string {
   const postingType = template.templateData?.postingType;
   if (postingType === 'tournament') return '대회';
   if (postingType === 'urgent') return '긴급';
+  if (postingType === 'fixed') return '고정';
   if (template.templateData && !isSupportedTemplateData(template.templateData)) {
-    return '지원 중단';
+    return '불러올 수 없음';
   }
   return '일반';
 }
@@ -131,7 +130,7 @@ function TemplateCard({ template, onLoad, onDelete, isLoading, isDeleting }: Tem
       {isUnsupported ? (
         <View className="mb-3 rounded-lg bg-warning-50 p-3 dark:bg-warning-900/30">
           <Text className="text-xs text-warning-700 dark:text-warning-300 font-sans">
-            fixed 템플릿은 V3 canonical 전환 동안 불러올 수 없습니다.
+            이 템플릿은 저장된 정보가 손상되어 불러올 수 없어요. 삭제 후 새로 저장해 주세요.
           </Text>
         </View>
       ) : null}

--- a/uniqn-mobile/src/components/employer/job-form/modals/TemplateModal.tsx
+++ b/uniqn-mobile/src/components/employer/job-form/modals/TemplateModal.tsx
@@ -104,7 +104,7 @@ export function TemplateModal({
             - 지역, 연락처, 급여·복리후생
           </Text>
           <Text className="text-primary-700 dark:text-primary-300 text-xs font-sans">
-            - 역할/인원, 시간대 설정
+            - 역할/인원 정보
           </Text>
           <Text className="text-primary-700 dark:text-primary-300 text-xs font-sans">
             - 사전질문 설정
@@ -112,7 +112,7 @@ export function TemplateModal({
         </View>
         <View className="mt-2 pt-2 border-t border-primary-200 dark:border-primary-700">
           <Text className="text-primary-600 dark:text-primary-400 text-xs font-sans">
-            * 구체적인 모집 날짜는 저장되지 않아요. 불러온 뒤 다시 선택해 주세요.
+            * 날짜 및 일정은 저장되지 않습니다
           </Text>
         </View>
       </View>

--- a/uniqn-mobile/src/components/employer/job-form/modals/TemplateModal.tsx
+++ b/uniqn-mobile/src/components/employer/job-form/modals/TemplateModal.tsx
@@ -98,21 +98,21 @@ export function TemplateModal({
         </Text>
         <View className="flex-col gap-1">
           <Text className="text-primary-700 dark:text-primary-300 text-xs font-sans">
-            - 제목, 공고 타입, 지역 정보
+            - 제목, 공고 설명, 공고 타입
           </Text>
           <Text className="text-primary-700 dark:text-primary-300 text-xs font-sans">
-            - 급여 정보, 복리후생
+            - 지역, 연락처, 급여·복리후생
+          </Text>
+          <Text className="text-primary-700 dark:text-primary-300 text-xs font-sans">
+            - 역할/인원, 시간대 설정
           </Text>
           <Text className="text-primary-700 dark:text-primary-300 text-xs font-sans">
             - 사전질문 설정
           </Text>
-          <Text className="text-primary-700 dark:text-primary-300 text-xs font-sans">
-            - 역할/인원 정보
-          </Text>
         </View>
         <View className="mt-2 pt-2 border-t border-primary-200 dark:border-primary-700">
           <Text className="text-primary-600 dark:text-primary-400 text-xs font-sans">
-            * 날짜 및 일정은 저장되지 않습니다
+            * 구체적인 모집 날짜는 저장되지 않아요. 불러온 뒤 다시 선택해 주세요.
           </Text>
         </View>
       </View>

--- a/uniqn-mobile/src/hooks/useTemplateManager.ts
+++ b/uniqn-mobile/src/hooks/useTemplateManager.ts
@@ -4,7 +4,7 @@
  * @version 1.1.0
  */
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   deleteTemplate,
@@ -127,8 +127,24 @@ export function useTemplateManager() {
   const saveMutation = useSaveTemplate();
   const loadMutation = useLoadTemplate();
 
-  // 진행 중인 삭제 타이머 (Undo 지원)
-  const pendingDeletesRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  // 진행 중인 삭제 (Undo 지원) — 타이머 + 즉시 커밋 함수를 함께 보관해
+  // 언마운트 시 flush 할 수 있게 한다.
+  const pendingDeletesRef = useRef<
+    Map<string, { timer: ReturnType<typeof setTimeout>; commit: () => void }>
+  >(new Map());
+
+  // 언마운트 시 남아 있는 삭제를 즉시 커밋한다(타이머 누수 방지).
+  // 사용자는 이미 목록에서 사라진 상태로 화면을 떠났으므로 삭제 의도로 간주.
+  useEffect(() => {
+    const pending = pendingDeletesRef.current;
+    return () => {
+      pending.forEach(({ timer, commit }) => {
+        clearTimeout(timer);
+        commit();
+      });
+      pending.clear();
+    };
+  }, []);
 
   const openTemplateModal = useCallback(() => {
     setIsTemplateModalOpen(true);
@@ -204,38 +220,59 @@ export function useTemplateManager() {
       const userId = user.uid;
       const listKey = queryKeys.templates.list(userId);
 
-      const previousList = queryClient.getQueryData<JobPostingTemplate[]>(listKey);
-      const deletedTemplate = previousList?.find((t) => t.id === templateId);
+      const currentList = queryClient.getQueryData<JobPostingTemplate[]>(listKey);
+      const index = currentList?.findIndex((t) => t.id === templateId) ?? -1;
+      const deletedTemplate = index >= 0 && currentList ? currentList[index] : undefined;
 
-      if (!previousList || !deletedTemplate) {
+      if (!currentList || !deletedTemplate) {
         return false;
       }
+
+      // 삭제 항목을 현재 캐시의 원래 위치에 다시 끼워 넣어 복원한다.
+      // (전체 스냅샷 덮어쓰기 금지 — 연속 삭제 시 다른 대기 항목이 되살아나는 경쟁 방지)
+      const restore = () => {
+        const latest = queryClient.getQueryData<JobPostingTemplate[]>(listKey) ?? [];
+        if (latest.some((t) => t.id === templateId)) {
+          return;
+        }
+        const next = [...latest];
+        next.splice(Math.min(index, next.length), 0, deletedTemplate);
+        queryClient.setQueryData<JobPostingTemplate[]>(listKey, next);
+      };
 
       // 1. 캐시에서 즉시 제거 (옵티미스틱)
       queryClient.setQueryData<JobPostingTemplate[]>(
         listKey,
-        previousList.filter((t) => t.id !== templateId)
+        currentList.filter((t) => t.id !== templateId)
       );
 
-      // 2. 실제 DELETE 스케줄
-      const timer = setTimeout(async () => {
-        pendingDeletesRef.current.delete(templateId);
-        try {
-          await deleteTemplate(templateId, userId);
-          logger.info('템플릿 삭제 완료', { templateId });
-          queryClient.invalidateQueries({ queryKey: queryKeys.templates.all });
-        } catch (error) {
-          logger.error('템플릿 삭제 실패', toError(error));
-          // 실패 시 캐시 복원
-          queryClient.setQueryData<JobPostingTemplate[]>(listKey, previousList);
-          addToast({
-            type: 'error',
-            message: extractErrorMessage(error, '템플릿 삭제에 실패했습니다.'),
-          });
+      // 실제 DELETE 커밋 (타이머 만료 또는 언마운트 시 1회만 실행).
+      let committed = false;
+      const commit = () => {
+        if (committed) {
+          return;
         }
-      }, UNDO_DELAY_MS);
+        committed = true;
+        pendingDeletesRef.current.delete(templateId);
+        deleteTemplate(templateId, userId)
+          .then(() => {
+            logger.info('템플릿 삭제 완료', { templateId });
+            queryClient.invalidateQueries({ queryKey: queryKeys.templates.all });
+          })
+          .catch((error) => {
+            logger.error('템플릿 삭제 실패', toError(error));
+            // 실패 시 캐시 복원
+            restore();
+            addToast({
+              type: 'error',
+              message: extractErrorMessage(error, '템플릿 삭제에 실패했습니다.'),
+            });
+          });
+      };
 
-      pendingDeletesRef.current.set(templateId, timer);
+      // 2. 실제 DELETE 스케줄
+      const timer = setTimeout(commit, UNDO_DELAY_MS);
+      pendingDeletesRef.current.set(templateId, { timer, commit });
 
       // 3. Undo 토스트
       addToast({
@@ -247,10 +284,10 @@ export function useTemplateManager() {
           onPress: () => {
             const pending = pendingDeletesRef.current.get(templateId);
             if (pending) {
-              clearTimeout(pending);
+              clearTimeout(pending.timer);
               pendingDeletesRef.current.delete(templateId);
             }
-            queryClient.setQueryData<JobPostingTemplate[]>(listKey, previousList);
+            restore();
             addToast({
               type: 'info',
               message: `'${templateNameToDelete}' 템플릿을 복원했습니다.`,

--- a/uniqn-mobile/src/types/__tests__/jobTemplate.test.ts
+++ b/uniqn-mobile/src/types/__tests__/jobTemplate.test.ts
@@ -49,6 +49,68 @@ describe('jobTemplate fixed schedule', () => {
     expect(schedule?.kind).toBe('fixed');
     expect(schedule?.requirements[0].timeSlots[0].isTimeToBeAnnounced).toBe(false);
   });
+
+  // P1 라운드트립: 고정공고를 템플릿으로 저장 → 다시 불러오면 동일한 폼으로 복원돼야 한다.
+  // (LoadTemplateModal 의 fixed 차단 가드 해제 안전성 보장 — 깨지면 차단 유지 근거)
+  it('restores a fixed posting template back to a loadable form (save → load round-trip)', () => {
+    const template = createTemplate({
+      ...INITIAL_JOB_POSTING_FORM_DATA,
+      postingType: 'fixed',
+      title: '서울 딜러 고정',
+      daysPerWeek: 5,
+      startTime: '19:00',
+      isStartTimeNegotiable: false,
+      roles: [
+        {
+          name: DEALER_ROLE_NAME,
+          count: 3,
+          salary: { type: 'hourly', amount: 14000 },
+        },
+      ],
+    } as JobPostingFormData);
+
+    expect(template.templateData.schedule?.kind).toBe('fixed');
+
+    const loaded = {
+      ...INITIAL_JOB_POSTING_FORM_DATA,
+      ...templateToFormData(template),
+    } as JobPostingFormData;
+
+    expect(loaded.postingType).toBe('fixed');
+    expect(loaded.daysPerWeek).toBe(5);
+    expect(loaded.startTime).toBe('19:00');
+    expect(loaded.isStartTimeNegotiable).toBe(false);
+    expect(loaded.roles).toMatchObject([
+      {
+        name: DEALER_ROLE_NAME,
+        count: 3,
+        salary: { type: 'hourly', amount: 14000 },
+      },
+    ]);
+  });
+
+  // 협의 출근시간(isStartTimeNegotiable:true, startTime 없음) 고정공고도 round-trip 보존
+  it('restores a negotiable-start fixed template without a startTime', () => {
+    const template = createTemplate({
+      ...INITIAL_JOB_POSTING_FORM_DATA,
+      postingType: 'fixed',
+      title: '협의 고정',
+      daysPerWeek: 3,
+      startTime: '',
+      isStartTimeNegotiable: true,
+      roles: [{ name: DEALER_ROLE_NAME, count: 1 }],
+    } as JobPostingFormData);
+
+    const loaded = {
+      ...INITIAL_JOB_POSTING_FORM_DATA,
+      ...templateToFormData(template),
+    } as JobPostingFormData;
+
+    expect(loaded.postingType).toBe('fixed');
+    expect(loaded.daysPerWeek).toBe(3);
+    expect(loaded.isStartTimeNegotiable).toBe(true);
+    expect(loaded.startTime).toBe('');
+  });
 });
 
 describe('jobTemplate dated template helpers', () => {


### PR DESCRIPTION
## 개요
공고 템플릿 UX 결함 3종 수정. UX/유저플로우 감사에서 도출.

## P1 — 고정공고 템플릿 불러오기 복구 (죽은 데이터 해소)
- **증상:** 고정(fixed) 공고를 템플릿으로 저장은 되지만 목록에서 "지원 중단/사용 불가"로 표시돼 영구히 불러올 수 없었음 → 핵심 타깃(홀덤펍 고정 알바)에서 못 쓰는 템플릿 누적.
- **근본원인:** `LoadTemplateModal`의 fixed 차단(`isSupportedTemplateData`)은 Firebase 시절(2026-03 `5d2fc0eae`) "V3 canonical 전환" 레거시 가드. 이후 스케줄 스키마가 SP1/SP2/SP3로 통일됐고 `templateToDraft`에 fixed 복원 로직이 이미 완비 → **저장측만 막지 않은 비대칭**.
- **수정:** 저장→복원 round-trip 테스트로 안전성 증명(타입·주출근일수·출근시간·협의·역할·급여 보존) 후 차단 해제. 배지 `지원 중단`→`고정`, 개발용어(`fixed`/`V3 canonical`) 안내문구를 사용자 언어로 교체.

## P2 — 삭제 Undo 타이머 누수 + 스냅샷 경쟁
- **누수:** 삭제 후 화면 이탈 시 Undo 토스트는 사라지나 5초 타이머가 그대로 발화 → 삭제 유실/타이머 누수. → 언마운트 시 진행 중 삭제를 flush(타이머 정리 + 즉시 커밋).
- **경쟁:** 연속 삭제 시 전체 스냅샷 덮어쓰기로 한 항목 되돌리기가 다른 삭제 대기 항목을 되살림. → 현재 캐시의 원래 인덱스에 재삽입하는 방식으로 복원.

## C1 — 템플릿 저장 안내 문구 정확화
- 실제 저장/복원되는 **공고 설명(description)**이 안내에 누락돼 있던 것 추가.

## 테스트 / 게이트 (RED→GREEN)
- 신규 라운드트립 테스트 2개(fixed 저장→복원) GREEN
- 신규 삭제 동작 테스트 4개 — 수정 전 언마운트/경쟁 2개 RED → 수정 후 GREEN
- `npm run quality` exit 0 (tsc 0 · eslint 0 errors · prettier clean)
- jest 관련 영역 42 suites / 471 pass

## 배포 메모
- 머지 후 웹 Cloudflare 재배포 + **EAS OTA** 필요(머지만으론 앱 사용자 미반영)
- 실기기 수동 QA 권장: 고정공고 저장→목록→불러오기 / 삭제 후 화면 이탈·연속삭제

🤖 Generated with [Claude Code](https://claude.com/claude-code)