### PR TITLE
fix(jobs): 공고 작성/수정 시 지역(region) 저장 누락 수정

### DIFF
--- a/uniqn-mobile/src/utils/job-posting/__tests__/draftAdapter.test.ts
+++ b/uniqn-mobile/src/utils/job-posting/__tests__/draftAdapter.test.ts
@@ -389,3 +389,29 @@ describe('draftAdapter fixed (통일 구조)', () => {
     expect(form.startTime).toBe('19:00');
   });
 });
+
+describe('draftAdapter location.region 보존', () => {
+  function draftWithRegion(): JobPostingDraft {
+    const base = createDatedDraft();
+    return {
+      ...base,
+      location: { ...base.location!, region: '서울 강남구' },
+    };
+  }
+
+  it('draftToFormData 가 region 을 보존한다 (작성 폼 표시)', () => {
+    const form = draftToFormData(draftWithRegion());
+    expect(form.location?.region).toBe('서울 강남구');
+  });
+
+  it('draftToCreateJobPostingInput 가 region 을 저장 페이로드에 포함한다', () => {
+    const input = draftToCreateJobPostingInput(draftWithRegion());
+    expect((input.location as { region?: string }).region).toBe('서울 강남구');
+  });
+
+  it('formDataToDraft → draftToCreateJobPostingInput 전체 경로에서 region 이 살아남는다', () => {
+    const form = draftToFormData(draftWithRegion());
+    const input = draftToCreateJobPostingInput(formDataToDraft(form));
+    expect((input.location as { region?: string }).region).toBe('서울 강남구');
+  });
+});

--- a/uniqn-mobile/src/utils/job-posting/draftAdapter.ts
+++ b/uniqn-mobile/src/utils/job-posting/draftAdapter.ts
@@ -48,11 +48,13 @@ function toCanonicalPostingLocation(
   }
 
   const district = location.district ?? location.address;
+  const region = location.region;
   const detailedAddress = location.detailedAddress;
 
   return {
     name: location.name,
     ...(district !== undefined ? { district } : {}),
+    ...(region !== undefined ? { region } : {}),
     ...(detailedAddress !== undefined ? { detailedAddress } : {}),
   };
 }
@@ -65,11 +67,13 @@ function toCreateInputLocation(
   }
 
   const district = normalizeOptionalText(location.district ?? location.address);
+  const region = normalizeOptionalText(location.region);
   const detailedAddress = normalizeOptionalText(location.detailedAddress);
 
   return {
     name: location.name.trim(),
     ...(district ? { district } : {}),
+    ...(region ? { region } : {}),
     ...(detailedAddress ? { detailedAddress } : {}),
   };
 }
@@ -82,15 +86,18 @@ function toUpdateInputLocation(
   }
 
   const district = normalizeOptionalText(location.district ?? location.address);
+  const region = normalizeOptionalText(location.region);
   const detailedAddress = normalizeOptionalText(location.detailedAddress);
   const hasDistrictField =
     Object.prototype.hasOwnProperty.call(location, 'district') ||
     Object.prototype.hasOwnProperty.call(location, 'address');
+  const hasRegionField = Object.prototype.hasOwnProperty.call(location, 'region');
   const hasDetailedAddressField = Object.prototype.hasOwnProperty.call(location, 'detailedAddress');
 
   return {
     name: location.name.trim(),
     ...(hasDistrictField ? { district } : {}),
+    ...(hasRegionField ? { region } : {}),
     ...(hasDetailedAddressField ? { detailedAddress } : {}),
   };
 }


### PR DESCRIPTION
## 문제
PR #192에서 도입한 `location.region`이 **작성 폼 경로에서 유실**됨. 폼에서 지역을 선택해도 필드에 안 붙고, 공고 생성 시 region이 저장되지 않음.

## 원인
`draftAdapter.ts`의 location 매퍼 3종이 region 키를 누락(`{ name, district, detailedAddress }`만 재구성):
- `toCanonicalPostingLocation` (formData→draft): 선택해도 draft 저장 단계에서 사라짐 → 표시·저장 안 됨
- `toCreateInputLocation` (draft→생성 payload): 신규 공고에 region 미저장
- `toUpdateInputLocation` (draft→수정 payload): 수정 시 유실

`toFormLocation`만 `...location` 스프레드라 보존됨(그래서 단위테스트 일부는 통과해 가려졌음).

## 발견 경위
로컬 웹에서 **실제 작성 폼을 조작**하니 지역 선택이 필드에 안 붙어 드릴다운. 기존 region 테스트는 `serializeJobPostingV3`를 직접 호출(이미 region 포함된 input)해서 폼→draftAdapter→serialize 체인을 건너뛰어 미적발. 4536개 단위테스트가 못 잡은 걸 라이브 검증이 잡음.

## 수정
세 함수에 region 통과 추가(district 패턴 동일, update는 `hasRegionField` 가드).

## 테스트
- [x] TDD: draftAdapter region 3건 (draft→form 표시 / draft→createInput 저장 / formData→draft→createInput 전체 경로) — RED→GREEN
- [x] tsc 0 / eslint 0 / prettier clean / job-posting 16 suites 164 pass
- [x] **라이브 재확인**: 작성 폼에서 '서초구' 선택 → 필드에 '서초구' 표시 확정

🤖 Generated with [Claude Code](https://claude.com/claude-code)