### PR TITLE
fix(security): anon RPC 보안 하드닝(P0/P1) + 머니 정합 + 품질/성능

### DIFF
--- a/uniqn-mobile/app/(app)/employer-register.tsx
+++ b/uniqn-mobile/app/(app)/employer-register.tsx
@@ -19,6 +19,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useEmployerApplication } from '@/hooks/auth/useEmployerApplication';
 import { registerAsEmployer } from '@/services/auth';
 import { useToast } from '@/stores/toastStore';
+import { extractUserMessage } from '@/errors';
 import { logger } from '@/utils/logger';
 import { formatE164ToDisplay } from '@/utils/phone';
 import {
@@ -179,7 +180,8 @@ export default function EmployerRegisterScreen() {
         '구인자 등록 신청 실패',
         error instanceof Error ? error : new Error(String(error))
       );
-      toast.error(error instanceof Error ? error.message : '구인자 등록 신청에 실패했습니다');
+      // 원본(개발자) 에러 메시지 노출 금지 — AppError userMessage/일반 메시지로 sanitize.
+      toast.error(extractUserMessage(error));
     } finally {
       setIsSubmitting(false);
     }

--- a/uniqn-mobile/src/components/schedule/ScheduleDetailSheet.tsx
+++ b/uniqn-mobile/src/components/schedule/ScheduleDetailSheet.tsx
@@ -21,7 +21,7 @@ import {
 import { useCurrentWorkStatus } from '@/hooks/useWorkLogs';
 import { formatCurrency } from '@/utils/settlement';
 import { getRoleDisplayName } from '@/types/unified';
-import { TimeNormalizer, type TimeInput } from '@/shared/time';
+import { formatTime } from './helpers/timeHelpers';
 import type { ScheduleEvent } from '@/types';
 import { useThemeStore } from '@/stores/themeStore';
 import { STATUS } from '@/constants';
@@ -53,11 +53,7 @@ interface ScheduleDetailSheetProps {
 // Helper Functions
 // ============================================================================
 
-function formatTime(value: TimeInput): string {
-  const date = TimeNormalizer.parseTime(value);
-  if (!date) return '--:--';
-  return date.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false });
-}
+// formatTime: 공용 헬퍼(./helpers/timeHelpers)로 통일 — 중복 구현 제거(impeccable v2 §19).
 
 function formatDate(dateString: string): string {
   return formatDateKoreanWithDay(dateString) || dateString || '-';

--- a/uniqn-mobile/src/components/wallet/PurchaseSheet.tsx
+++ b/uniqn-mobile/src/components/wallet/PurchaseSheet.tsx
@@ -28,14 +28,24 @@ export function PurchaseSheet() {
   const { restoring, restore } = useRestorePurchases();
   const [packages, setPackages] = useState<PurchasesPackage[]>([]);
 
+  // 충전 UI 원격 킬스위치(app_config monetization.show_purchase_ui).
+  // false 면 재배포 없이 충전 노출 차단. 로딩/실패 시 기본 노출(fail-open).
+  const monetizationQuery = useQuery({
+    queryKey: [...queryKeys.wallet.all, 'monetization'] as const,
+    queryFn: () => WalletRepository.getMonetizationConfig(),
+    enabled: isOpen,
+    staleTime: 5 * 60 * 1000,
+  });
+  const showPurchaseUi = monetizationQuery.data?.showPurchaseUi ?? true;
+
   const productsQuery = useQuery({
     queryKey: [...queryKeys.wallet.all, 'products'] as const,
     queryFn: () => WalletRepository.listProducts(),
-    enabled: isOpen,
+    enabled: isOpen && showPurchaseUi,
   });
 
   useEffect(() => {
-    if (!isOpen || !available) return;
+    if (!isOpen || !available || !showPurchaseUi) return;
     let active = true;
     purchasesService
       .getDiamondPackages()
@@ -51,7 +61,7 @@ export function PurchaseSheet() {
     return () => {
       active = false;
     };
-  }, [isOpen, available]);
+  }, [isOpen, available, showPurchaseUi]);
 
   const busy = status === 'purchasing' || status === 'processing';
   // 결제·복원 어느 쪽이든 진행 중이면 상호 배타 — 동시 빌링 트랜잭션·폴링 baseline 오염 차단
@@ -109,7 +119,16 @@ export function PurchaseSheet() {
 
   return (
     <Modal visible={isOpen} onClose={handleClose} title="다이아 충전" position="bottom">
-      {!available ? (
+      {!showPurchaseUi ? (
+        <View className="py-6">
+          <Text className="text-center font-sans text-content-primary dark:text-secondary-100">
+            다이아 충전은 현재 준비 중이에요.
+          </Text>
+          <Text className="mt-1 text-center font-sans text-sm text-secondary-500 dark:text-secondary-400">
+            곧 만나보실 수 있어요.
+          </Text>
+        </View>
+      ) : !available ? (
         <View className="py-6">
           <Text className="text-center font-sans text-content-primary dark:text-secondary-100">
             다이아 충전은 모바일 앱에서 가능해요.

--- a/uniqn-mobile/src/components/wallet/__tests__/PurchaseSheet.test.tsx
+++ b/uniqn-mobile/src/components/wallet/__tests__/PurchaseSheet.test.tsx
@@ -39,6 +39,7 @@ jest.mock('@/repositories/supabase/WalletRepository', () => ({
         },
       ])
     ),
+    getMonetizationConfig: jest.fn(() => Promise.resolve({ showPurchaseUi: true })),
   },
 }));
 

--- a/uniqn-mobile/src/repositories/interfaces/IWalletRepository.ts
+++ b/uniqn-mobile/src/repositories/interfaces/IWalletRepository.ts
@@ -54,6 +54,14 @@ export interface IWalletRepository {
   listProducts(): Promise<DiamondProduct[]>;
 
   /**
+   * 수익화 원격 설정(app_config key='monetization') 조회.
+   * 충전 UI 노출 원격 킬스위치(show_purchase_ui)를 위한 단일 reader.
+   *
+   * @returns showPurchaseUi: 충전 UI 노출 허용 여부. 읽기 실패/미설정 시 기본 true(fail-open).
+   */
+  getMonetizationConfig(): Promise<{ showPurchaseUi: boolean }>;
+
+  /**
    * 본인 일일 출석 체크 — 하트 1개 적립(90일 만료). KST 기준 일일 1회.
    *
    * @returns 성공 시 lot 정보, 이미 출석 시 success:false. 미인증 등은 throw.

--- a/uniqn-mobile/src/repositories/supabase/WalletRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/WalletRepository.ts
@@ -79,6 +79,28 @@ export const WalletRepository: IWalletRepository = {
   },
 
   /**
+   * 수익화 원격 설정(app_config key='monetization') 조회 — 충전 UI 원격 킬스위치.
+   * show_purchase_ui=false 면 충전 UI 를 숨겨 재배포 없이 결제를 차단할 수 있다.
+   * 읽기 실패/미설정 시 fail-open(true) — 일시적 오류로 정상 결제가 막히지 않도록.
+   */
+  async getMonetizationConfig(): Promise<{ showPurchaseUi: boolean }> {
+    const { data, error } = await supabase
+      .from('app_config')
+      .select('value')
+      .eq('key', 'monetization')
+      .maybeSingle();
+    if (error) {
+      logger.warn('wallet.getMonetizationConfig.failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return { showPurchaseUi: true };
+    }
+    const value = (data?.value ?? {}) as { show_purchase_ui?: boolean };
+    // 명시적 false 만 차단, 그 외(미설정/true)는 노출 허용.
+    return { showPurchaseUi: value.show_purchase_ui !== false };
+  },
+
+  /**
    * 본인 일일 출석 체크 — 하트 1개 적립(90일 만료). KST 기준 일일 1회.
    *
    * @returns 성공 시 lot 정보, 이미 출석 시 success:false. 미인증 등은 throw.

--- a/uniqn-mobile/src/repositories/supabase/__tests__/WalletRepository.monetization.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/WalletRepository.monetization.test.ts
@@ -1,0 +1,46 @@
+/**
+ * WalletRepository.getMonetizationConfig — 충전 UI 원격 킬스위치 reader (iap-2)
+ * app_config key='monetization' 의 show_purchase_ui 를 읽어 노출 여부를 반환.
+ */
+import { WalletRepository } from '../WalletRepository';
+
+const mockMaybeSingle = jest.fn();
+const mockEq = jest.fn(() => ({ maybeSingle: mockMaybeSingle }));
+const mockSelect = jest.fn(() => ({ eq: mockEq }));
+const mockFrom = jest.fn(() => ({ select: mockSelect }));
+jest.mock('@/lib/supabase', () => ({ supabase: { from: (...a: unknown[]) => mockFrom(...a) } }));
+
+describe('WalletRepository.getMonetizationConfig', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('show_purchase_ui=false 면 showPurchaseUi=false (킬스위치 ON)', async () => {
+    mockMaybeSingle.mockResolvedValue({
+      data: { value: { show_purchase_ui: false } },
+      error: null,
+    });
+    const r = await WalletRepository.getMonetizationConfig();
+    expect(mockFrom).toHaveBeenCalledWith('app_config');
+    expect(mockEq).toHaveBeenCalledWith('key', 'monetization');
+    expect(r.showPurchaseUi).toBe(false);
+  });
+
+  it('show_purchase_ui=true 면 showPurchaseUi=true', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: { value: { show_purchase_ui: true } }, error: null });
+    expect((await WalletRepository.getMonetizationConfig()).showPurchaseUi).toBe(true);
+  });
+
+  it('설정 미존재(행 없음) 시 fail-open(true)', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+    expect((await WalletRepository.getMonetizationConfig()).showPurchaseUi).toBe(true);
+  });
+
+  it('show_purchase_ui 키 누락 시 fail-open(true)', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: { value: {} }, error: null });
+    expect((await WalletRepository.getMonetizationConfig()).showPurchaseUi).toBe(true);
+  });
+
+  it('읽기 에러 시 fail-open(true)', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: null, error: { message: 'boom' } });
+    expect((await WalletRepository.getMonetizationConfig()).showPurchaseUi).toBe(true);
+  });
+});

--- a/uniqn-mobile/src/repositories/supabase/__tests__/WalletRepository.monetization.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/WalletRepository.monetization.test.ts
@@ -5,9 +5,9 @@
 import { WalletRepository } from '../WalletRepository';
 
 const mockMaybeSingle = jest.fn();
-const mockEq = jest.fn(() => ({ maybeSingle: mockMaybeSingle }));
-const mockSelect = jest.fn(() => ({ eq: mockEq }));
-const mockFrom = jest.fn(() => ({ select: mockSelect }));
+const mockEq = jest.fn((..._a: unknown[]) => ({ maybeSingle: mockMaybeSingle }));
+const mockSelect = jest.fn((..._a: unknown[]) => ({ eq: mockEq }));
+const mockFrom = jest.fn((..._a: unknown[]) => ({ select: mockSelect }));
 jest.mock('@/lib/supabase', () => ({ supabase: { from: (...a: unknown[]) => mockFrom(...a) } }));
 
 describe('WalletRepository.getMonetizationConfig', () => {

--- a/uniqn-mobile/src/services/board/boardPostService.ts
+++ b/uniqn-mobile/src/services/board/boardPostService.ts
@@ -295,7 +295,8 @@ export async function incrementBoardPostViewCount(postId: string): Promise<void>
 
     await boardRepository.incrementViewCount(postId);
   } catch (error) {
-    throw handleSilentError(error, {
+    // 조회수 증가 실패는 비핵심 — 조용히 삼킨다(handleSilentError 는 void 반환이라 throw 금지).
+    handleSilentError(error, {
       operation: '게시글 조회수 증가',
       component: COMPONENT,
       context: { postId },

--- a/uniqn-mobile/src/services/work/settlement/settlementQuery.ts
+++ b/uniqn-mobile/src/services/work/settlement/settlementQuery.ts
@@ -295,16 +295,17 @@ export async function getMySettlementSummary(
       await jobPostingRepository.getManagedJobPostings(undefined, workspaceId)
     ).filter(isCanonicalDatedPosting);
 
-    // 2. 각 공고별 정산 요약 조회
-    const summaries: JobPostingSettlementSummary[] = [];
+    // 2. 각 공고별 정산 요약 조회 — 병렬화(perf-query-1).
+    //    기존 직렬 await 루프는 공고 수 N 에 비례해 라운드트립이 선형 누적됐다.
+    //    Promise.all 로 동시 실행(순서 보존). 권한검사/시그니처는 불변.
+    const summaries = await Promise.all(
+      jobPostings.map((jobPosting) => getJobPostingSettlementSummary(jobPosting.id!, ownerId))
+    );
+
     let totalWorkLogs = 0;
     let totalPendingAmount = 0;
     let totalCompletedAmount = 0;
-
-    for (const jobPosting of jobPostings) {
-      const summary = await getJobPostingSettlementSummary(jobPosting.id!, ownerId);
-      summaries.push(summary);
-
+    for (const summary of summaries) {
       totalWorkLogs += summary.totalWorkLogs;
       totalPendingAmount += summary.totalPendingAmount;
       totalCompletedAmount += summary.totalCompletedAmount;

--- a/uniqn-mobile/src/utils/__tests__/formatters.test.ts
+++ b/uniqn-mobile/src/utils/__tests__/formatters.test.ts
@@ -7,7 +7,6 @@
 import {
   formatNumber,
   formatCurrency,
-  formatCurrencyShort,
   maskEmail,
   formatPositions,
   formatPercent,
@@ -49,33 +48,6 @@ describe('Formatters', () => {
 
     it('should handle zero', () => {
       expect(formatCurrency(0)).toBe('₩0');
-    });
-  });
-
-  describe('formatCurrencyShort', () => {
-    it('should format amounts under 10,000', () => {
-      expect(formatCurrencyShort(5000)).toBe('5,000원');
-      expect(formatCurrencyShort(9999)).toBe('9,999원');
-    });
-
-    it('should format amounts in 만원 units', () => {
-      expect(formatCurrencyShort(10000)).toBe('1만원');
-      expect(formatCurrencyShort(150000)).toBe('15만원');
-      expect(formatCurrencyShort(1000000)).toBe('100만원');
-    });
-
-    it('should format amounts with remainder', () => {
-      expect(formatCurrencyShort(15000)).toBe('1만 5,000원');
-      expect(formatCurrencyShort(125000)).toBe('12만 5,000원');
-    });
-
-    it('should handle zero', () => {
-      expect(formatCurrencyShort(0)).toBe('0원');
-    });
-
-    it('should handle null/undefined', () => {
-      expect(formatCurrencyShort(null)).toBe('0원');
-      expect(formatCurrencyShort(undefined)).toBe('0원');
     });
   });
 

--- a/uniqn-mobile/src/utils/formatters.ts
+++ b/uniqn-mobile/src/utils/formatters.ts
@@ -20,23 +20,7 @@ export { formatCurrency };
 // 기존 호출부 시그니처 완전 보존.
 export { formatNumber };
 
-/**
- * 금액 간략 표시 (만원 단위)
- */
-export const formatCurrencyShort = (value: number | undefined | null): string => {
-  if (value === undefined || value === null) return '0원';
-
-  if (value >= 10000) {
-    const man = Math.floor(value / 10000);
-    const remainder = value % 10000;
-    if (remainder > 0) {
-      return `${man}만 ${formatNumber(remainder)}원`;
-    }
-    return `${man}만원`;
-  }
-
-  return `${formatNumber(value)}원`;
-};
+// formatCurrencyShort: 데드 중복 제거 — formatCurrencyCompact(@/utils/formatters/currency) 사용.
 
 /**
  * 이메일 마스킹 (h***@gmail.com)

--- a/uniqn-mobile/supabase/functions/revenuecat-webhook/index.ts
+++ b/uniqn-mobile/supabase/functions/revenuecat-webhook/index.ts
@@ -132,7 +132,12 @@ Deno.serve(async (req: Request) => {
     return badRequest('missing_event_id');
   }
   if (!event.app_user_id || !UUID_REGEX.test(event.app_user_id)) {
-    return badRequest('invalid_app_user_id', { app_user_id: event.app_user_id });
+    // iap-4: RC 익명 id($RCAnonymousID:...) 등 비-UUID 는 특정 사용자에 매핑 불가.
+    //   400 으로 응답하면 RC 가 재시도 후 폐기→결제-미적립 영구 손실. 200(ignored)로 응답해
+    //   재시도 폭주를 막고, 사용자는 useRestorePurchases 로 로그인 uid 재동기화 시 RC 가
+    //   올바른 app_user_id 로 webhook 을 재발행해 복구된다. (관측을 위해 warn 로깅)
+    console.warn(`non_uuid_app_user_id (ignored): ${event.app_user_id} event=${event.id}`);
+    return ok({ ignored: true, reason: 'non_uuid_user', app_user_id: event.app_user_id });
   }
   if (!event.product_id || typeof event.product_id !== 'string') {
     return badRequest('missing_product_id');
@@ -150,6 +155,8 @@ Deno.serve(async (req: Request) => {
   }
   const client = createClient(supabaseUrl, serviceRoleKey);
 
+  const isRefund = decision.action === 'refund';
+
   // 7) product_id → diamonds + bonus_diamonds 조회 (DB 신뢰)
   const { data: product, error: productError } = await client
     .from('diamond_products')
@@ -164,20 +171,40 @@ Deno.serve(async (req: Request) => {
       headers: responseHeaders,
     });
   }
+
+  // iap-1: 환불(REFUND/CANCELLATION)은 product active/존재 게이트를 적용하지 않는다.
+  //   운영자가 구SKU 를 비활성화(active=false)/삭제해도 환불 클로백(차감)이 누락되면
+  //   사용자가 환불금+다이아를 모두 보유하게 되므로, 환불은 게이트보다 우선한다.
+  //   - product 존재(active/inactive 무관): 해당 행의 diamonds 로 차감.
+  //   - product 삭제됨: 차감 금액 산출 불가 → 200(ignored)+로깅(재시도 폭주/오차감 방지).
+  //     ※ iap-3 한계: 환불 차감량을 '현재' diamond_products 설정에서 산출하므로, 구매↔환불
+  //       사이 diamonds/bonus_diamonds 가 변경되면 차감액이 원 적립액과 달라질 수 있다.
+  //       정확한 원거래 역추적은 credit 시 transaction_id 저장(스키마 변경)이 선행돼야 함.
   if (!product) {
+    if (isRefund) {
+      console.warn(`refund_product_not_found (ignored): ${event.product_id} event=${event.id}`);
+      return ok({
+        ignored: true,
+        reason: 'refund_product_not_found',
+        product_id: event.product_id,
+      });
+    }
     console.error(`product_not_found: ${event.product_id}`);
     return badRequest('product_not_found', { product_id: event.product_id });
   }
-  if (product.active === false) {
+  if (!isRefund && product.active === false) {
     return badRequest('product_inactive', { product_id: event.product_id });
   }
 
   const totalDiamonds = (product.diamonds ?? 0) + (product.bonus_diamonds ?? 0);
   if (totalDiamonds <= 0) {
+    if (isRefund) {
+      console.warn(`refund_invalid_amount (ignored): ${event.product_id} event=${event.id}`);
+      return ok({ ignored: true, reason: 'refund_invalid_amount', product_id: event.product_id });
+    }
     return badRequest('invalid_product_amount', { product_id: event.product_id });
   }
 
-  const isRefund = decision.action === 'refund';
   const diamondsToCredit = isRefund ? -totalDiamonds : totalDiamonds;
 
   // 8) credit_diamonds_atomically 호출 (음수=환불, 양수=구매)

--- a/uniqn-mobile/supabase/migrations/20260621090000_harden_anon_rpc_revoke_and_delete_guard.sql
+++ b/uniqn-mobile/supabase/migrations/20260621090000_harden_anon_rpc_revoke_and_delete_guard.sql
@@ -1,0 +1,155 @@
+-- 2026-06-21 보안 하드닝 (P0/P1): anon이 호출 가능한 위험 SECDEF RPC EXECUTE 회수 +
+--   permanently_delete_user 의 NULL-취약 권한 가드 수정.
+--
+-- 배경(prod 실측):
+--  * anon 역할에 공개 anon 키로 호출 가능한 SECURITY DEFINER RPC 다수가 EXECUTE 부여돼 있음
+--    (pitfall_supabase_new_function_anon_default_grant: public 신규 함수는 anon/authenticated
+--     EXECUTE 자동부여 → 하드닝 REVOKE 누락 시 잠복).
+--  * permanently_delete_user 의 가드 `IF auth.uid() != p_user_id AND NOT is_admin()` 는
+--    anon(auth.uid()=NULL)에서 `NULL != x`=NULL, `NULL AND true`=NULL → IF NULL=거짓 → 가드 스킵.
+--    → 미인증 임의 사용자 삭제 가능(probe 실증: anon 호출 시 PERMISSION_DENIED 가 아닌 USER_NOT_FOUND).
+--
+-- REVOKE 안전성:
+--  * 대상 32개 함수는 RLS 정책 표현식에서 호출되지 않음(poison 무관, pg_policy 전수 확인).
+--  * 미인증(가입/공개 공유 페이지) 경로에서 실제 호출되는 함수는 제외(allowlist 유지):
+--    check_email/phone/nickname_exists, increment_view_count,
+--    increment_board_post_view_count, increment_announcement_view_count, get_posting_filled_counts.
+--  * authenticated/service_role 권한은 유지(GRANT 재부여)하여 정상 클라이언트 회귀 없음.
+-- 멱등: 함수 미존재 시 REVOKE/GRANT 가 에러를 던지지 않도록 DO 블록으로 감싼다.
+
+-- 이름 기반 REVOKE: pg_proc 에서 oid 를 찾아 모든 오버로드를 정확한 시그니처로 처리
+-- (하드코딩 시그니처 불일치로 인한 조용한 스킵=보안구멍 잔존 방지).
+DO $$
+DECLARE
+  rec record;
+  names text[] := ARRAY[
+    'permanently_delete_user','update_user_role','confirm_application',
+    'cancel_application_atomically','process_qr_checkin_atomically','apply_with_capacity_check',
+    'create_report','create_workspace','register_as_employer','toggle_comment_reaction',
+    'increment_template_usage','sync_schedule_board','approve_employer_application',
+    'reject_employer_application','review_report','list_all_applications','list_all_event_qr_codes',
+    'list_all_managed_postings','list_all_work_logs','list_all_workspace_members',
+    'get_job_posting_stats','get_latest_employer_application','get_unread_notification_count',
+    'decrement_unread_counter','reset_unread_counter','check_user_rate_limit',
+    'fn_cleanup_expired_fcm_tokens','fn_cleanup_rate_limits','fn_expire_by_last_work_date',
+    'fn_expire_fixed_postings_batch','fn_send_review_reminders','rls_auto_enable'
+  ];
+BEGIN
+  FOR rec IN
+    SELECT p.oid::regprocedure AS sig
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = ANY(names)
+  LOOP
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM PUBLIC, anon', rec.sig);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO authenticated, service_role', rec.sig);
+    RAISE NOTICE 'hardened: %', rec.sig;
+  END LOOP;
+END $$;
+
+-- permanently_delete_user: NULL-안전 가드로 교체 (본문은 prod 실측과 동일, 가드 라인만 수정).
+CREATE OR REPLACE FUNCTION public.permanently_delete_user(p_user_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'auth'
+AS $function$
+DECLARE
+  v_user record;
+  v_deleted_apps int;
+  v_deleted_wlogs int;
+  v_deleted_notifs int;
+BEGIN
+  -- NULL-안전 권한 가드: 미인증(auth.uid() IS NULL) 호출 차단 + 본인/관리자만 허용.
+  IF auth.uid() IS NULL
+     OR (auth.uid() IS DISTINCT FROM p_user_id AND NOT public.is_admin()) THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED: 본인 또는 관리자만 삭제 가능';
+  END IF;
+
+  SELECT * INTO v_user FROM public.users WHERE id = p_user_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'USER_NOT_FOUND: %', p_user_id;
+  END IF;
+
+  -- 1. 지원서 익명화
+  UPDATE public.applications SET
+    applicant_name = '[deleted]', applicant_nickname = NULL,
+    applicant_phone = NULL, applicant_email = NULL,
+    applicant_photo_url = NULL, updated_at = now()
+  WHERE applicant_id = p_user_id;
+  GET DIAGNOSTICS v_deleted_apps = ROW_COUNT;
+
+  -- 2. 근무기록 익명화 (staff)
+  UPDATE public.work_logs SET
+    staff_name = '[deleted]', staff_nickname = NULL,
+    staff_photo_url = NULL, updated_at = now()
+  WHERE staff_id = p_user_id;
+  GET DIAGNOSTICS v_deleted_wlogs = ROW_COUNT;
+
+  -- 3. 근무기록 owner_id NULL (employer 탈퇴)
+  UPDATE public.work_logs SET owner_id = NULL, updated_at = now()
+  WHERE owner_id = p_user_id;
+
+  -- 4. 공고 active → closed + owner_id NULL
+  UPDATE public.job_postings SET
+    status = 'closed', closed_at = now(), closed_reason = 'owner_deleted',
+    owner_id = NULL, updated_at = now()
+  WHERE owner_id = p_user_id AND status = 'active';
+
+  -- 4b. 나머지 공고 owner_id NULL
+  UPDATE public.job_postings SET owner_id = NULL, updated_at = now()
+  WHERE owner_id = p_user_id;
+
+  -- 5. 공지사항 익명화
+  UPDATE public.announcements SET author_id = NULL WHERE author_id = p_user_id;
+
+  -- 6. 게시판 게시물 익명화
+  UPDATE public.board_posts SET author_id = NULL WHERE author_id = p_user_id;
+
+  -- 7. 게시판 댓글 익명화
+  UPDATE public.board_comments SET author_id = NULL WHERE author_id = p_user_id;
+
+  -- 8. 게시판 투표 삭제
+  DELETE FROM public.board_votes WHERE user_id = p_user_id;
+
+  -- 9. 게시판 신고 익명화
+  UPDATE public.board_reports SET reporter_id = NULL WHERE reporter_id = p_user_id;
+
+  -- 10. 이벤트 QR 코드 삭제
+  DELETE FROM public.event_qr_codes WHERE user_id = p_user_id;
+
+  -- 11. 문의사항 익명화
+  UPDATE public.inquiries SET user_id = NULL WHERE user_id = p_user_id;
+
+  -- 12. 신고 익명화
+  UPDATE public.reports SET reporter_id = NULL WHERE reporter_id = p_user_id;
+
+  -- 13. 리뷰 익명화 (FK + 이름 모두)
+  UPDATE public.reviews SET reviewer_id = NULL, reviewer_name = '[deleted]'
+  WHERE reviewer_id = p_user_id;
+  UPDATE public.reviews SET reviewee_id = NULL, reviewee_name = '[deleted]'
+  WHERE reviewee_id = p_user_id;
+
+  -- 14. 알림 삭제
+  DELETE FROM public.notifications WHERE recipient_id = p_user_id;
+  GET DIAGNOSTICS v_deleted_notifs = ROW_COUNT;
+
+  -- 15. 알림 설정 삭제
+  DELETE FROM public.notification_settings WHERE user_id = p_user_id;
+
+  -- 16. public.users 삭제
+  DELETE FROM public.users WHERE id = p_user_id;
+
+  -- 17. auth.users 삭제
+  DELETE FROM auth.users WHERE id = p_user_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'anonymizedApplications', v_deleted_apps,
+    'anonymizedWorkLogs', v_deleted_wlogs,
+    'deletedNotifications', v_deleted_notifs
+  );
+END;
+$function$;
+
+-- permanently_delete_user 는 위 REVOKE 루프로 anon EXECUTE 회수됨(authenticated 유지).

--- a/uniqn-mobile/supabase/migrations/20260621090100_bind_mutation_rpcs_to_auth_uid.sql
+++ b/uniqn-mobile/supabase/migrations/20260621090100_bind_mutation_rpcs_to_auth_uid.sql
@@ -1,0 +1,400 @@
+-- 2026-06-21 보안 하드닝 (P1): 변이 SECDEF RPC 의 행위자 파라미터를 auth.uid() 에 바인딩.
+--
+-- 배경: 아래 RPC 들은 행위자를 auth.uid() 가 아닌 파라미터(p_owner_id/p_actor_id/p_staff_id/
+--   p_applicant_id)로 신뢰해, 인증 사용자 A 가 타인 B 의 uid 를 넘겨 대리 행위를 위조할 수 있었다.
+--   (앞선 마이그레이션의 anon REVOKE 로 미인증 호출은 차단됐으나, 인증 사용자간 위조는 별도 차단 필요.)
+--
+-- 회귀 안전성(호출부 전수 확인):
+--   * confirm_application: 클라이언트는 항상 현재 로그인 user.uid 를 p_owner_id 로 전달.
+--   * cancel_application_atomically: 두 경로(staff_initiates/staff_approves) 모두 user.uid 전달.
+--   * process_qr_checkin_atomically: 직원 본인 셀프스캔만 존재(user.uid==p_staff_id).
+--   * apply_with_capacity_check: 본인 지원만(코드상 현재 미사용이나 방어적으로 바인딩).
+--   admin 은 우회 허용(is_admin()).
+--
+-- 본문은 prod 실측(pg_get_functiondef)과 동일하며, BEGIN 직후 가드 블록만 추가했다.
+-- (적용 후 pg_get_functiondef 재대조로 가드 외 본문 동일성 검증.)
+
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.confirm_application(p_application_id uuid, p_owner_id uuid, p_assignments jsonb DEFAULT '[]'::jsonb, p_original_application jsonb DEFAULT NULL::jsonb, p_confirmation_history jsonb DEFAULT '[]'::jsonb, p_notes text DEFAULT NULL::text, p_is_fixed_posting boolean DEFAULT false, p_assignments_v3 jsonb DEFAULT NULL::jsonb)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_app record;
+  v_job record;
+  v_work_log_ids uuid[] := '{}';
+  v_wl_id uuid;
+  v_assignment jsonb;
+  v_now timestamptz := now();
+  v_existing int;
+  v_capacity int;
+  v_rec record;
+  v_is_fixed boolean;
+BEGIN
+  -- [보안] 호출자 바인딩: p_owner_id 는 호출자 본인(또는 admin)이어야 함.
+  IF auth.uid() IS NULL
+     OR (auth.uid() IS DISTINCT FROM p_owner_id AND NOT public.is_admin()) THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED: 호출자 인증 불일치';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.users WHERE id = p_owner_id AND is_active = true
+  ) THEN
+    RAISE EXCEPTION 'ACCOUNT_DISABLED: owner account is disabled (%)', p_owner_id;
+  END IF;
+
+  SELECT * INTO v_app FROM applications WHERE id = p_application_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'APPLICATION_NOT_FOUND: %', p_application_id; END IF;
+  IF v_app.status != 'applied' THEN
+    RAISE EXCEPTION 'INVALID_STATUS: 현재 상태 %, applied만 확정 가능', v_app.status;
+  END IF;
+
+  SELECT * INTO v_job FROM job_postings WHERE id = v_app.job_posting_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'POSTING_NOT_FOUND: %', v_app.job_posting_id; END IF;
+
+  v_is_fixed := (v_job.schedule->>'kind') = 'fixed';
+
+  IF NOT (
+    v_job.owner_id = p_owner_id
+    OR public.is_workspace_member(v_job.workspace_id, p_owner_id)
+    OR public.is_posting_collaborator(v_job.id, p_owner_id)
+    OR public.is_admin()
+  ) THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED: 공고 관리 권한 없음';
+  END IF;
+
+  IF jsonb_array_length(p_assignments) > 0 THEN
+    FOR v_rec IN
+      SELECT
+        (a->>'date') AS a_date,
+        public._posting_slot_key(a->>'timeSlot') AS slot_key,
+        public._posting_role_key(a->>'role', a->>'customRole') AS role_key,
+        COUNT(*)::int AS requested
+      FROM jsonb_array_elements(p_assignments) a
+      GROUP BY 1, 2, 3
+    LOOP
+      SELECT COUNT(*) INTO v_existing
+      FROM work_logs wl
+      WHERE wl.job_posting_id = v_app.job_posting_id
+        AND wl.date = v_rec.a_date
+        AND public._posting_slot_key(wl.time_slot) = v_rec.slot_key
+        AND public._posting_role_key(wl.role::text, wl.custom_role) = v_rec.role_key
+        AND wl.status NOT IN ('cancelled', 'no_show');
+
+      SELECT COALESCE(MAX((r->>'count')::int), 0) INTO v_capacity
+      FROM jsonb_array_elements(COALESCE(v_job.schedule->'requirements', '[]'::jsonb)) req
+      CROSS JOIN jsonb_array_elements(COALESCE(req->'timeSlots', '[]'::jsonb)) ts
+      CROSS JOIN jsonb_array_elements(COALESCE(ts->'roles', '[]'::jsonb)) r
+      WHERE COALESCE(req->>'date', 'FIXED_SCHEDULE') = v_rec.a_date
+        AND (CASE
+              WHEN COALESCE((ts->>'isTimeToBeAnnounced')::boolean, false) THEN '미정'
+              WHEN COALESCE(ts->>'startTime', ts->>'time') IS NOT NULL
+                THEN public._posting_slot_key(COALESCE(ts->>'startTime', ts->>'time'))
+              WHEN v_is_fixed THEN 'NEGOTIABLE'
+              ELSE public._posting_slot_key(COALESCE(ts->>'startTime', ts->>'time'))
+            END) = v_rec.slot_key
+        AND public._posting_role_key(r->>'role', r->>'customRole') = v_rec.role_key;
+
+      IF v_capacity > 0 AND v_existing + v_rec.requested > v_capacity THEN
+        RAISE EXCEPTION 'MAX_CAPACITY_REACHED: role=% date=% slot=% (% / %)',
+          v_rec.role_key, v_rec.a_date, v_rec.slot_key, v_existing + v_rec.requested, v_capacity;
+      END IF;
+    END LOOP;
+  END IF;
+
+  IF jsonb_array_length(p_assignments) > 0 THEN
+    FOR v_assignment IN SELECT * FROM jsonb_array_elements(p_assignments)
+    LOOP
+      INSERT INTO work_logs (
+        staff_id, job_posting_id, application_id,
+        assignment_group_id, date, time_slot,
+        staff_name, staff_nickname, staff_photo_url, staff_photo_url_blurhash,
+        role, custom_role, owner_id,
+        status, is_fixed_posting,
+        created_at, updated_at
+      ) VALUES (
+        v_app.applicant_id, v_app.job_posting_id, p_application_id,
+        v_assignment->>'groupId', v_assignment->>'date', v_assignment->>'timeSlot',
+        v_app.applicant_name, v_app.applicant_nickname,
+        v_app.applicant_photo_url, v_app.applicant_photo_url_blurhash,
+        COALESCE((v_assignment->>'role')::staff_role, 'staff'::staff_role),
+        v_assignment->>'customRole', p_owner_id,
+        'scheduled', v_is_fixed, v_now, v_now
+      ) RETURNING id INTO v_wl_id;
+      v_work_log_ids := array_append(v_work_log_ids, v_wl_id);
+    END LOOP;
+  END IF;
+
+  UPDATE applications SET
+    status = 'confirmed',
+    assignments = COALESCE(p_assignments_v3, assignments),
+    original_application = COALESCE(p_original_application, original_application),
+    confirmation_history = p_confirmation_history,
+    confirmed_at = v_now,
+    processed_by = p_owner_id::text,
+    processed_at = v_now,
+    notes = COALESCE(p_notes, notes),
+    updated_at = v_now
+  WHERE id = p_application_id;
+
+  RETURN jsonb_build_object(
+    'applicationId', p_application_id,
+    'workLogIds', to_jsonb(v_work_log_ids),
+    'assignmentCount', jsonb_array_length(p_assignments)
+  );
+END;
+$function$;
+
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.cancel_application_atomically(p_application_id uuid, p_actor_type text, p_actor_id uuid, p_cancel_reason text DEFAULT NULL::text, p_rejection_reason text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_application applications%ROWTYPE; v_job_posting job_postings%ROWTYPE;
+  v_active_confirmation_entry jsonb; v_active_confirmation_index int;
+  v_confirmation_history jsonb := '[]'::jsonb; v_deleted_work_log_count int := 0;
+  v_now text := to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"');
+  v_now_ts timestamptz := now(); v_assignment_count int := 0; v_new_filled int;
+  v_new_status text; v_updated_cancellation_request jsonb;
+BEGIN
+  -- [보안] 호출자 바인딩: p_actor_id 는 호출자 본인(또는 admin)이어야 함.
+  IF auth.uid() IS NULL
+     OR (auth.uid() IS DISTINCT FROM p_actor_id AND NOT public.is_admin()) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'unauthorized');
+  END IF;
+
+  SELECT * INTO v_application FROM applications WHERE id = p_application_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'application_not_found'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.users WHERE id = p_actor_id AND is_active = true) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'account_disabled'); END IF;
+  IF p_actor_type = 'staff_initiates' AND v_application.status = 'applied' THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true); END IF;
+  IF p_actor_type = 'staff_approves_cancel_request' AND v_application.status = 'cancelled' THEN
+    RETURN jsonb_build_object('success', true, 'idempotent', true); END IF;
+  IF p_actor_type = 'staff_initiates' THEN
+    IF v_application.status != 'confirmed' THEN RETURN jsonb_build_object('success', false, 'error', 'invalid_status_for_cancellation'); END IF;
+  ELSIF p_actor_type = 'staff_approves_cancel_request' THEN
+    IF v_application.status != 'cancellation_pending' THEN RETURN jsonb_build_object('success', false, 'error', 'invalid_status_for_approval'); END IF;
+    IF (v_application.cancellation_request->>'status') != 'pending' THEN RETURN jsonb_build_object('success', false, 'error', 'cancellation_request_not_pending'); END IF;
+  ELSE RETURN jsonb_build_object('success', false, 'error', 'invalid_actor_type'); END IF;
+  SELECT * INTO v_job_posting FROM job_postings WHERE id = v_application.job_posting_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'job_posting_not_found'); END IF;
+  -- H4: 권한
+  IF p_actor_type = 'staff_approves_cancel_request' THEN
+    IF NOT (v_job_posting.owner_id = p_actor_id OR public.is_workspace_member(v_job_posting.workspace_id, p_actor_id)
+      OR public.is_posting_collaborator(v_job_posting.id, p_actor_id) OR public.is_admin()) THEN
+      RETURN jsonb_build_object('success', false, 'error', 'unauthorized'); END IF;
+  ELSIF p_actor_type = 'staff_initiates' THEN
+    IF v_application.applicant_id != p_actor_id THEN RETURN jsonb_build_object('success', false, 'error', 'unauthorized'); END IF;
+  END IF;
+  -- H5: 출근 후 차단
+  IF EXISTS (SELECT 1 FROM work_logs WHERE application_id = p_application_id AND status IN ('checked_in', 'checked_out')) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'staff_already_checked_in'); END IF;
+  v_confirmation_history := COALESCE(v_application.confirmation_history, '[]'::jsonb);
+  SELECT value, ordinality - 1 INTO v_active_confirmation_entry, v_active_confirmation_index
+  FROM jsonb_array_elements(v_confirmation_history) WITH ORDINALITY WHERE (value->>'cancelled_at') IS NULL LIMIT 1;
+  IF v_active_confirmation_entry IS NULL THEN RETURN jsonb_build_object('success', false, 'error', 'no_active_confirmation'); END IF;
+  v_confirmation_history := jsonb_set(v_confirmation_history, ARRAY[v_active_confirmation_index::text, 'cancelled_at'], to_jsonb(v_now));
+  v_confirmation_history := jsonb_set(v_confirmation_history, ARRAY[v_active_confirmation_index::text, 'cancelled_by'], to_jsonb(p_actor_id));
+  v_confirmation_history := jsonb_set(v_confirmation_history, ARRAY[v_active_confirmation_index::text, 'cancellation_reason'], COALESCE(to_jsonb(p_cancel_reason), 'null'::jsonb));
+  IF p_actor_type = 'staff_initiates' THEN v_new_status := 'applied';
+  ELSE v_new_status := 'cancelled';
+    v_updated_cancellation_request := v_application.cancellation_request || jsonb_build_object('status', 'approved', 'reviewed_at', v_now, 'reviewed_by', p_actor_id);
+  END IF;
+  -- status 변경 UPDATE 가 fn_update_job_posting_stats 트리거를 발화 → filled_positions -1 자동.
+  UPDATE applications SET status = v_new_status::application_status, confirmation_history = v_confirmation_history,
+    cancellation_request = COALESCE(v_updated_cancellation_request, cancellation_request), cancelled_at = v_now_ts, updated_at = v_now_ts
+  WHERE id = p_application_id;
+  SELECT COUNT(*)::int INTO v_assignment_count FROM jsonb_array_elements(v_active_confirmation_entry->'assignments') a
+  CROSS JOIN LATERAL jsonb_array_elements((a->>'dates')::jsonb) d;
+  -- M3 reopen 가드: 트리거가 capacity_full->active 를 이미 처리하나, 멱등 보강 + manual/expired 가드.
+  UPDATE job_postings SET
+    status = CASE
+      WHEN status = 'capacity_full' AND filled_positions < total_positions THEN 'active'::posting_status
+      WHEN status = 'closed' AND closed_reason IN ('expired', 'expired_by_work_date') THEN 'closed'::posting_status
+      WHEN status = 'closed' AND filled_positions < total_positions THEN 'active'::posting_status
+      ELSE status
+    END,
+    updated_at = v_now_ts
+  WHERE id = v_job_posting.id;
+  SELECT filled_positions INTO v_new_filled FROM job_postings WHERE id = v_job_posting.id;
+  DELETE FROM work_logs WHERE application_id = p_application_id AND status = 'scheduled';
+  GET DIAGNOSTICS v_deleted_work_log_count = ROW_COUNT;
+  RETURN jsonb_build_object('success', true, 'application_id', p_application_id, 'new_status', v_new_status,
+    'assignment_count', v_assignment_count, 'new_filled_positions', v_new_filled,
+    'deleted_work_log_count', v_deleted_work_log_count, 'cancelled_at', v_now);
+END;
+$function$;
+
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.process_qr_checkin_atomically(p_work_log_id uuid, p_staff_id uuid, p_job_posting_id uuid, p_action text, p_check_time timestamp with time zone DEFAULT now(), p_expected_date text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_work_log work_logs%ROWTYPE;
+  v_job_posting_status text;
+  v_now text := to_char(p_check_time AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"');
+  v_work_duration numeric := 0;
+  v_duration_minutes numeric;
+BEGIN
+  -- [보안] 호출자 바인딩: 직원 본인 셀프 체크인만(또는 admin).
+  IF auth.uid() IS NULL
+     OR (auth.uid() IS DISTINCT FROM p_staff_id AND NOT public.is_admin()) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'unauthorized');
+  END IF;
+
+  SELECT * INTO v_work_log FROM work_logs WHERE id = p_work_log_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'work_log_not_found'); END IF;
+
+  SELECT status INTO v_job_posting_status FROM job_postings WHERE id = p_job_posting_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'job_posting_not_found'); END IF;
+
+  IF v_work_log.staff_id IS DISTINCT FROM p_staff_id THEN RETURN jsonb_build_object('success', false, 'error', 'staff_id_mismatch'); END IF;
+  IF v_work_log.job_posting_id IS DISTINCT FROM p_job_posting_id THEN RETURN jsonb_build_object('success', false, 'error', 'job_posting_id_mismatch'); END IF;
+  IF p_expected_date IS NOT NULL AND COALESCE(v_work_log.is_fixed_posting, false) = false AND v_work_log.date IS DISTINCT FROM p_expected_date THEN RETURN jsonb_build_object('success', false, 'error', 'date_mismatch'); END IF;
+  IF v_job_posting_status::text != 'active' THEN RETURN jsonb_build_object('success', false, 'error', 'job_posting_inactive'); END IF;
+  IF v_work_log.payroll_status::text = 'completed' THEN RETURN jsonb_build_object('success', false, 'error', 'already_settled'); END IF;
+
+  IF p_action = 'checkIn' THEN
+    IF v_work_log.status::text IN ('checked_in', 'checked_out') THEN RETURN jsonb_build_object('success', false, 'error', 'already_checked_in'); END IF;
+    UPDATE work_logs SET status = 'checked_in', check_in_ts = p_check_time, updated_at = p_check_time WHERE id = p_work_log_id;
+    RETURN jsonb_build_object('success', true, 'action', 'checkIn', 'check_in_time', v_now, 'work_duration', 0);
+  ELSIF p_action = 'checkOut' THEN
+    IF v_work_log.status::text != 'checked_in' THEN RETURN jsonb_build_object('success', false, 'error', 'not_checked_in'); END IF;
+    IF v_work_log.check_in_ts IS NOT NULL THEN
+      v_duration_minutes := EXTRACT(EPOCH FROM (p_check_time - v_work_log.check_in_ts)) / 60;
+      v_work_duration := GREATEST(0, ROUND((v_duration_minutes / 60)::numeric * 100) / 100);
+    END IF;
+    UPDATE work_logs SET status = 'checked_out', check_out_ts = p_check_time, work_duration = v_work_duration, updated_at = p_check_time WHERE id = p_work_log_id;
+    RETURN jsonb_build_object('success', true, 'action', 'checkOut', 'check_out_time', v_now, 'work_duration', v_work_duration);
+  ELSE
+    RETURN jsonb_build_object('success', false, 'error', 'invalid_action');
+  END IF;
+END;
+$function$;
+
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.apply_with_capacity_check(p_applicant_id uuid, p_job_posting_id uuid, p_applicant_name text, p_applicant_phone text DEFAULT NULL::text, p_applicant_email text DEFAULT NULL::text, p_applicant_nickname text DEFAULT NULL::text, p_applicant_photo_url text DEFAULT NULL::text, p_applicant_role text DEFAULT NULL::text, p_custom_role text DEFAULT NULL::text, p_job_posting_title text DEFAULT NULL::text, p_job_posting_date text DEFAULT NULL::text, p_recruitment_type text DEFAULT NULL::text, p_message text DEFAULT NULL::text, p_assignments jsonb DEFAULT '[]'::jsonb, p_pre_question_answers jsonb DEFAULT NULL::jsonb)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_posting record;
+  v_existing record;
+  v_total_positions int;
+  v_active_count int;
+  v_application_id uuid;
+  v_now timestamptz := now();
+  v_is_reapply boolean := false;
+BEGIN
+  -- [보안] 호출자 바인딩: 본인 명의 지원만(또는 admin).
+  IF auth.uid() IS NULL
+     OR (auth.uid() IS DISTINCT FROM p_applicant_id AND NOT public.is_admin()) THEN
+    RETURN jsonb_build_object('success', false, 'error_code', 'PERMISSION_DENIED', 'message', '본인만 지원할 수 있습니다.');
+  END IF;
+
+  -- 1. 공고 행 잠금 (동시 지원 직렬화)
+  SELECT id, status, total_positions, filled_positions, schedule
+  INTO v_posting
+  FROM job_postings
+  WHERE id = p_job_posting_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error_code', 'NOT_FOUND', 'message', '공고를 찾을 수 없습니다.');
+  END IF;
+
+  -- 2. 공고 상태 확인
+  IF v_posting.status != 'active' THEN
+    RETURN jsonb_build_object('success', false, 'error_code', 'POSTING_CLOSED', 'message', '지원이 마감된 공고입니다.');
+  END IF;
+
+  -- 3. 기존 지원 확인
+  SELECT id, status INTO v_existing
+  FROM applications
+  WHERE job_posting_id = p_job_posting_id
+    AND applicant_id = p_applicant_id;
+
+  IF FOUND THEN
+    IF v_existing.status != 'cancelled' THEN
+      RETURN jsonb_build_object('success', false, 'error_code', 'ALREADY_APPLIED', 'message', '이미 지원한 공고입니다.', 'application_id', v_existing.id);
+    END IF;
+    -- cancelled 상태면 재지원 허용
+    v_is_reapply := true;
+    v_application_id := v_existing.id;
+  END IF;
+
+  -- 4. 정원 확인 (active 지원 수 = applied + confirmed + cancellation_pending)
+  v_total_positions := COALESCE(v_posting.total_positions, 0);
+
+  IF v_total_positions > 0 THEN
+    SELECT count(*) INTO v_active_count
+    FROM applications
+    WHERE job_posting_id = p_job_posting_id
+      AND status IN ('applied', 'confirmed', 'cancellation_pending');
+
+    IF v_active_count >= v_total_positions THEN
+      RETURN jsonb_build_object('success', false, 'error_code', 'CAPACITY_FULL', 'message', '모집 인원이 마감되었습니다.', 'total_positions', v_total_positions, 'active_count', v_active_count);
+    END IF;
+  END IF;
+
+  -- 5. Application INSERT 또는 UPDATE
+  IF v_is_reapply THEN
+    UPDATE applications SET
+      status = 'applied',
+      applicant_name = p_applicant_name,
+      applicant_phone = p_applicant_phone,
+      applicant_email = p_applicant_email,
+      applicant_nickname = p_applicant_nickname,
+      applicant_photo_url = p_applicant_photo_url,
+      applicant_role = p_applicant_role::staff_role,
+      custom_role = p_custom_role,
+      job_posting_title = p_job_posting_title,
+      job_posting_date = p_job_posting_date,
+      recruitment_type = p_recruitment_type,
+      message = p_message,
+      assignments = p_assignments,
+      pre_question_answers = p_pre_question_answers,
+      is_read = false,
+      cancelled_at = NULL,
+      cancellation_request = NULL,
+      rejection_reason = NULL,
+      updated_at = v_now
+    WHERE id = v_application_id;
+  ELSE
+    INSERT INTO applications (
+      applicant_id, job_posting_id, status,
+      applicant_name, applicant_phone, applicant_email,
+      applicant_nickname, applicant_photo_url,
+      applicant_role, custom_role,
+      job_posting_title, job_posting_date,
+      recruitment_type, message,
+      assignments, pre_question_answers,
+      is_read, created_at, updated_at
+    ) VALUES (
+      p_applicant_id, p_job_posting_id, 'applied',
+      p_applicant_name, p_applicant_phone, p_applicant_email,
+      p_applicant_nickname, p_applicant_photo_url,
+      p_applicant_role::staff_role, p_custom_role,
+      p_job_posting_title, p_job_posting_date,
+      p_recruitment_type, p_message,
+      p_assignments, p_pre_question_answers,
+      false, v_now, v_now
+    )
+    RETURNING id INTO v_application_id;
+  END IF;
+
+  -- 6. 성공 반환
+  RETURN jsonb_build_object('success', true, 'application_id', v_application_id, 'is_reapply', v_is_reapply);
+END;
+$function$;

--- a/uniqn-mobile/supabase/migrations/20260621090200_vcs_prod_drift_parity.sql
+++ b/uniqn-mobile/supabase/migrations/20260621090200_vcs_prod_drift_parity.sql
@@ -1,0 +1,44 @@
+-- 2026-06-21 VCS↔prod 드리프트 정합화.
+-- prod 에는 수기 DDL 로 존재하나 마이그레이션(VCS)엔 없는 보안 객체들을 멱등 코드화하여,
+-- fresh 스택(로컬 dev / CI db-tests / DR 재구축)이 prod 와 동일한 보안 자세를 갖도록 한다.
+-- prod 적용 시: 대부분 멱등 no-op, 단 sec-auth-4 의 중복 sync 트리거만 실제 제거(이중 쓰기 해소).
+
+-- ─── (sec-auth-1) 권한상승 차단 함수 + 트리거 (prod 실측 본문) ──────────────
+CREATE OR REPLACE FUNCTION public.prevent_role_self_escalation()
+ RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF OLD.role = NEW.role THEN
+    RETURN NEW;
+  END IF;
+  IF public.is_admin() THEN
+    RETURN NEW;
+  END IF;
+  -- 일반 사용자의 직접 role 변경 차단 (register_as_employer 등 SECURITY DEFINER RPC 는 우회).
+  RAISE EXCEPTION 'ROLE_CHANGE_DENIED: 역할 변경은 전용 API를 통해서만 가능합니다';
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS prevent_role_escalation ON public.users;
+CREATE TRIGGER prevent_role_escalation
+  BEFORE UPDATE OF role ON public.users
+  FOR EACH ROW EXECUTE FUNCTION public.prevent_role_self_escalation();
+
+-- ─── (sec-auth-2) base_schema 의 광역 SELECT 정책 제거 ───────────────────────
+-- users_select_self_or_admin 는 USING 에 auth.role()='authenticated' 가 있어 인증 사용자
+-- 누구나 전 users PII 를 읽을 수 있다. prod 엔 이미 없으나 fresh 스택엔 남아있음 → 멱등 DROP.
+-- 정식 정책 users_select(self/admin) 는 20260414015346 에서 이미 생성됨.
+DROP POLICY IF EXISTS users_select_self_or_admin ON public.users;
+
+-- ─── (dataint-1) applications 중복지원 방지 UNIQUE (prod 존재, fresh 누락) ────
+-- prod 에는 applications_job_posting_id_applicant_id_key 가 존재하나 VCS 엔 없음.
+-- apply_with_capacity_check 는 cancelled 행 UPDATE 재지원이라 full UNIQUE 와 정합.
+CREATE UNIQUE INDEX IF NOT EXISTS applications_job_posting_id_applicant_id_key
+  ON public.applications (job_posting_id, applicant_id);
+
+-- ─── (sec-auth-4) role→app_metadata 동기화 중복 트리거 제거 ──────────────────
+-- prod 에 on_public_user_role_changed(→sync_user_role_to_app_metadata) 와
+-- users_role_sync(→sync_role_to_auth) 가 공존해 role UPDATE 마다 auth.users 이중 쓰기.
+-- 정식 경로(sync_user_role_to_app_metadata, VCS 20260412082628)만 남기고 중복 제거.
+DROP TRIGGER IF EXISTS users_role_sync ON public.users;
+DROP FUNCTION IF EXISTS public.sync_role_to_auth();

--- a/uniqn-mobile/supabase/tests/anon_rpc_security_hardening.test.sql
+++ b/uniqn-mobile/supabase/tests/anon_rpc_security_hardening.test.sql
@@ -8,7 +8,7 @@
 -- auth.uid()/role 은 request.jwt.claims 로 시뮬레이션. 안전: BEGIN/ROLLBACK.
 -- ============================================================
 BEGIN;
-SELECT plan(20);
+SELECT plan(19);
 
 -- ─── 1) EXECUTE 권한: anon 회수 / authenticated 유지 ─────────────────────────
 SELECT ok(NOT has_function_privilege('anon', 'public.permanently_delete_user(uuid)', 'EXECUTE'),

--- a/uniqn-mobile/supabase/tests/anon_rpc_security_hardening.test.sql
+++ b/uniqn-mobile/supabase/tests/anon_rpc_security_hardening.test.sql
@@ -1,0 +1,101 @@
+-- ============================================================
+-- 2026-06-21 anon RPC 보안 하드닝 회귀 가드
+--   (20260621090000 / 20260621090100 / 20260621090200)
+-- 검증:
+--   1) 위험 SECDEF RPC 의 anon EXECUTE 회수 (authenticated 유지)
+--   2) 변이 RPC 의 auth.uid() 호출자 바인딩 가드 (미인증/타인 위조 차단, 본인 통과)
+--   3) VCS↔prod 드리프트 정합화 구조 단언
+-- auth.uid()/role 은 request.jwt.claims 로 시뮬레이션. 안전: BEGIN/ROLLBACK.
+-- ============================================================
+BEGIN;
+SELECT plan(20);
+
+-- ─── 1) EXECUTE 권한: anon 회수 / authenticated 유지 ─────────────────────────
+SELECT ok(NOT has_function_privilege('anon', 'public.permanently_delete_user(uuid)', 'EXECUTE'),
+  'anon cannot EXECUTE permanently_delete_user');
+SELECT ok(NOT has_function_privilege('anon', 'public.update_user_role(uuid, text)', 'EXECUTE'),
+  'anon cannot EXECUTE update_user_role');
+SELECT ok(NOT has_function_privilege('anon', 'public.confirm_application(uuid, uuid, jsonb, jsonb, jsonb, text, boolean, jsonb)', 'EXECUTE'),
+  'anon cannot EXECUTE confirm_application');
+SELECT ok(NOT has_function_privilege('anon', 'public.cancel_application_atomically(uuid, text, uuid, text, text)', 'EXECUTE'),
+  'anon cannot EXECUTE cancel_application_atomically');
+SELECT ok(NOT has_function_privilege('anon', 'public.process_qr_checkin_atomically(uuid, uuid, uuid, text, timestamptz, text)', 'EXECUTE'),
+  'anon cannot EXECUTE process_qr_checkin_atomically');
+SELECT ok(NOT has_function_privilege('anon', 'public.list_all_applications(application_status)', 'EXECUTE'),
+  'anon cannot EXECUTE list_all_applications');
+SELECT ok(has_function_privilege('authenticated', 'public.confirm_application(uuid, uuid, jsonb, jsonb, jsonb, text, boolean, jsonb)', 'EXECUTE'),
+  'authenticated retains EXECUTE on confirm_application (no regression)');
+-- allowlist 유지 (가입/공개 경로)
+SELECT ok(has_function_privilege('anon', 'public.check_email_exists(text)', 'EXECUTE'),
+  'anon retains EXECUTE on check_email_exists (signup path)');
+SELECT ok(has_function_privilege('anon', 'public.get_posting_filled_counts(uuid[])', 'EXECUTE'),
+  'anon retains EXECUTE on get_posting_filled_counts (public share)');
+
+-- ─── 2) permanently_delete_user 호출자 바인딩 가드 ──────────────────────────
+-- 미인증(auth.uid() IS NULL) → PERMISSION_DENIED
+SELECT set_config('request.jwt.claims', '', true);
+SELECT throws_ok(
+  $$ SELECT public.permanently_delete_user('11111111-1111-1111-1111-111111111111') $$,
+  NULL, 'PERMISSION_DENIED: 본인 또는 관리자만 삭제 가능',
+  'permanently_delete_user blocks anon (NULL auth.uid)');
+
+-- 타인(caller<>target, 비admin) → PERMISSION_DENIED
+SELECT set_config('request.jwt.claims',
+  jsonb_build_object('sub', '22222222-2222-2222-2222-222222222222', 'app_metadata', jsonb_build_object('role','staff'))::text, true);
+SELECT throws_ok(
+  $$ SELECT public.permanently_delete_user('33333333-3333-3333-3333-333333333333') $$,
+  NULL, 'PERMISSION_DENIED: 본인 또는 관리자만 삭제 가능',
+  'permanently_delete_user blocks authenticated forging another user');
+
+-- 본인(caller==target) → 가드 통과(존재X 라 USER_NOT_FOUND, PERMISSION_DENIED 아님)
+SELECT set_config('request.jwt.claims',
+  jsonb_build_object('sub', '44444444-4444-4444-4444-444444444444', 'app_metadata', jsonb_build_object('role','staff'))::text, true);
+SELECT throws_ok(
+  $$ SELECT public.permanently_delete_user('44444444-4444-4444-4444-444444444444') $$,
+  NULL, 'USER_NOT_FOUND: 44444444-4444-4444-4444-444444444444',
+  'permanently_delete_user allows self past guard (USER_NOT_FOUND, not PERMISSION_DENIED)');
+
+-- ─── 3) confirm_application 호출자 바인딩 ────────────────────────────────────
+-- caller<>p_owner_id (비admin) → PERMISSION_DENIED: 호출자 인증 불일치
+SELECT set_config('request.jwt.claims',
+  jsonb_build_object('sub', '55555555-5555-5555-5555-555555555555', 'app_metadata', jsonb_build_object('role','employer'))::text, true);
+SELECT throws_ok(
+  $$ SELECT public.confirm_application('00000000-0000-0000-0000-000000000000', '66666666-6666-6666-6666-666666666666') $$,
+  NULL, 'PERMISSION_DENIED: 호출자 인증 불일치',
+  'confirm_application blocks caller<>owner forgery');
+
+-- ─── 4) cancel_application_atomically 호출자 바인딩 (RETURN unauthorized) ─────
+SELECT set_config('request.jwt.claims',
+  jsonb_build_object('sub', '77777777-7777-7777-7777-777777777777', 'app_metadata', jsonb_build_object('role','staff'))::text, true);
+SELECT is(
+  (public.cancel_application_atomically('00000000-0000-0000-0000-000000000000','staff_initiates','88888888-8888-8888-8888-888888888888')->>'error'),
+  'unauthorized',
+  'cancel_application_atomically blocks caller<>actor forgery');
+
+-- 미인증 → unauthorized
+SELECT set_config('request.jwt.claims', '', true);
+SELECT is(
+  (public.cancel_application_atomically('00000000-0000-0000-0000-000000000000','staff_initiates','88888888-8888-8888-8888-888888888888')->>'error'),
+  'unauthorized',
+  'cancel_application_atomically blocks anon (NULL auth.uid)');
+
+-- ─── 5) process_qr_checkin_atomically 호출자 바인딩 (RETURN unauthorized) ─────
+SELECT set_config('request.jwt.claims',
+  jsonb_build_object('sub', '99999999-9999-9999-9999-999999999999', 'app_metadata', jsonb_build_object('role','staff'))::text, true);
+SELECT is(
+  (public.process_qr_checkin_atomically('00000000-0000-0000-0000-000000000000','aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa','00000000-0000-0000-0000-000000000000','checkIn', now(), NULL)->>'error'),
+  'unauthorized',
+  'process_qr_checkin_atomically blocks caller<>staff forgery');
+
+SELECT set_config('request.jwt.claims', '', true);
+
+-- ─── 6) 드리프트 정합화 구조 단언 ───────────────────────────────────────────
+SELECT has_trigger('public', 'users', 'prevent_role_escalation',
+  'prevent_role_escalation trigger exists on users (sec-auth-1)');
+SELECT has_index('public', 'applications', 'applications_job_posting_id_applicant_id_key',
+  'applications (job_posting_id, applicant_id) UNIQUE exists (dataint-1)');
+SELECT hasnt_function('public', 'sync_role_to_auth',
+  'duplicate sync_role_to_auth function removed (sec-auth-4)');
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## 배경
전체 코드베이스 2차 감사에서 **라이브 prod P0**를 발견(1차 정적감사 "0 P0"를 prod 직접 probe가 뒤집음). 공개 anon 키로 미인증 임의 사용자 삭제가 가능했음.

## 변경 (4 묶음)
### 🔴 보안 (P0/P1) — 마이그 3종 prod 적용+RED→GREEN 실측 완료
- **P0**: `permanently_delete_user` NULL-취약 가드(`!=`→`IS DISTINCT FROM`+`auth.uid() IS NULL` 차단)
- 위험 SECDEF RPC **32종 anon EXECUTE 회수**(authenticated 유지, signup/공개 allowlist 보존, RLS poison 0 검증)
- **P1**: confirm_application·cancel_application_atomically·process_qr_checkin_atomically·apply_with_capacity_check `auth.uid()` 호출자 바인딩(인증 사용자 위조 차단, prod 본문 기준 CREATE OR REPLACE)
- 드리프트 정합화: prevent_role 트리거+함수·광역 users SELECT 정책 DROP·applications UNIQUE·중복 sync 트리거 제거
- pgTAP 회귀가드 `anon_rpc_security_hardening.test.sql`

### 🟠 머니 정합 (iap-1~4)
- 환불 시 product active 게이트 우회(클로백 누락 방지)·비-UUID 200 처리·환불 drift 문서화
- `show_purchase_ui` 원격 킬스위치 배선(WalletRepository.getMonetizationConfig + PurchaseSheet) + 단위테스트 5종
- ⚠️ revenuecat-webhook 재배포는 수익모델 ON 체크리스트와 함께

### 🟡 빠른수정 + 성능
- extractUserMessage sanitize·handleSilentError throw 제거·formatCurrencyShort 데드제거·formatTime 중복제거
- 정산 getMySettlementSummary 직렬 N+1 → Promise.all 병렬화

## 검증
- 마이그 3종 prod 적용 + anon/인증-위조 차단 prod 실측(RED→GREEN)
- tsc 0 · 변경 lint 0 · 영향 테스트 76 pass
- 적대 리뷰(fresh-context, prod 대조): RPC 본문 무회귀·바인딩 정상경로 무파손·REVOKE poison 0·환불 credit 구멍 0 확인. 발견 1건(pgTAP plan)은 수정 반영.

## 후속(미포함)
시각/성능 검증 필요 3건(상대시간 통일·gradient→LinearGradient·schedule FlashList) / leaked password protection 대시보드 ON / 웹·EAS OTA 배포

🤖 Generated with [Claude Code](https://claude.com/claude-code)