### PR TITLE
chore(wallet): IAP 제거 후속 정리 — 위키 갱신 + app_config monetization 키 드롭

### DIFF
--- a/uniqn-mobile/supabase/migrations/20260623120000_drop_app_config_monetization.sql
+++ b/uniqn-mobile/supabase/migrations/20260623120000_drop_app_config_monetization.sql
@@ -1,0 +1,12 @@
+-- 지갑/IAP 수익모델 제거 후속: app_config 'monetization' 피처플래그 키 제거.
+--
+-- 배경:
+--   - 20260427000900_seed_app_config_monetization.sql 가 'monetization' 키를 시드함.
+--   - 지갑/IAP 전체 제거(PR #196, 20260621200000_drop_wallet_tables_and_rpcs)로
+--     이 키를 읽던 RPC(_calc_posting_cost, get_posting_cost 등)가 모두 DROP됨 → 키는 dead.
+--   - prod 에서는 이 마이그와 별개로 2026-06-23 단발 DELETE 로 이미 제거됨.
+--   - seed 마이그 파일이 repo 에 남아 있어 fresh 스택(db reset)에서 키가 재생성되므로,
+--     seed 이후 시점의 이 마이그로 정합화한다.
+--
+-- 멱등: DELETE ... WHERE 라 이미 없으면 0행 삭제 no-op. prod 재적용/db push 안전.
+DELETE FROM public.app_config WHERE key = 'monetization';

--- a/wiki/architecture/rls-model.md
+++ b/wiki/architecture/rls-model.md
@@ -1,10 +1,12 @@
 ---
 area: architecture
-updated: 2026-06-19
+updated: 2026-06-23
 status: current
 sources:
   - uniqn-mobile/supabase/migrations/20260525153952_fix_job_postings_anon_public_select.sql
   - uniqn-mobile/supabase/migrations/20260515030000_jpc_extend_existing_rls.sql
+  - uniqn-mobile/supabase/tests/jpc_job_postings_rls.test.sql
+  - memory/pitfall_job_postings_insert_loose_rls_by_design.md
   - memory/pitfall_anon_rls_secdef_function_poison.md
   - memory/pitfall_rls_jpc_recursion_widespread.md
   - memory/pitfall_rls_with_check_self_select_recursion.md
@@ -53,6 +55,12 @@ WITH CHECK 안 `SELECT count(*) FROM workspaces WHERE owner_id = auth.uid()` →
 
 수정 패턴: self-SELECT를 `plpgsql STABLE SECURITY DEFINER` 함수로 분리. SQL 함수는 inline 가능성 있어 SECDEF 무효화 위험.
 
+## 원칙: job_postings INSERT는 의도적으로 느슨 (검증됨)
+
+`job_postings`의 INSERT RLS는 **느슨**하다: `job_postings_insert_authenticated` WITH CHECK `auth.uid() IS NOT NULL`. 실제 권한(owner/workspace 멤버/협업자)은 **앱 레이어**가 검사하는 설계. pgTAP `jpc_job_postings_rls.test.sql`이 계약으로 명시 — owner/editor/collaborator/**outsider 모두 INSERT=ALLOW**("정책상 ALLOW — app layer 권한 검사 필수").
+
+→ "owner_id 위조 가능"으로 보여 `owner_id = auth.uid()`로 순진하게 조이면 워크스페이스 editor/collaborator 정당 INSERT가 막혀 `jpc_job_postings_rls`가 4/16 깨진다(실측). 결제 RPC가 가졌던 `p_owner_id=auth.uid()` 바인딩은 **결제 경로 한정**이었고 일반 INSERT 계약 아님. 조이려면 협업 경로 전수검증 + 테스트 계약 변경이 필요한 별도 작업. ([[wallet-iap-removal]] 중 한 세션이 조였다가 "느슨 유지" 결정으로 철회.)
+
 ## 주요 테이블별 RLS 요약 (주장: memory 기반)
 
 | 테이블 | anon | authenticated |
@@ -68,3 +76,5 @@ WITH CHECK 안 `SELECT count(*) FROM workspaces WHERE owner_id = auth.uid()` →
 - [[roles]] — UserRole과 RLS authenticated 계층 매핑
 - [[enum-divergence]] — RLS와 함께 발생한 읽기 증발 패턴
 - [[test-db-grants]] — 테이블 GRANT 레이어를 테스트에서 명시화한 결정
+- [[wallet-pgtap-caller-binding]] — SECDEF RPC 호출자 바인딩 가드 + pgTAP 회귀
+- [[wallet-iap-removal]] — 느슨 INSERT 설계 확정 맥락(조임 철회)

--- a/wiki/decisions/test-db-grants.md
+++ b/wiki/decisions/test-db-grants.md
@@ -1,6 +1,6 @@
 ---
 area: decisions
-updated: 2026-06-19
+updated: 2026-06-23
 status: current
 sources:
   - uniqn-mobile/supabase/fixtures/jpc_helpers.sql
@@ -29,7 +29,7 @@ prod 는 Supabase 기본 default-privilege 로 GRANT 를 보유하지만, CI 의
 ## 규칙
 
 1. **테스트 grant 는 명시적으로** — `GRANT ALL ON ALL TABLES/SEQUENCES IN SCHEMA public TO anon, authenticated, service_role`로 prod grant 상태와 동치화 → CLI 버전 무관 결정적. **두는 위치는 무대별로 다름**: pgTAP은 `jpc_helpers.sql`(fixtures 전용, `npm run test:db:helpers`가 로컬 컨테이너에만 등록); e2e는 전체 앱을 로컬 스택에 띄우므로 **마이그레이션**(`20260619133156_..._local_stack_parity.sql`, PR#183)으로 스키마 자체를 정합화(prod 멱등 no-op).
-2. **함수는 grant 확대 금지** — 결제 RPC 하드닝이 anon/authenticated 에서 REVOKE 한 EXECUTE 를 되살리면 회귀(`wallet_grants_hardening.test.sql`). 테이블/시퀀스만. 마이그레이션 경로는 추가로 wallet 4테이블 DML REVOKE 재적용(`20260605000010` 미러)으로 anon/auth 확대 방지.
+2. **함수는 grant 확대 금지** — 결제 RPC 하드닝이 anon/authenticated 에서 REVOKE 한 EXECUTE 를 되살리면 회귀(`wallet_grants_hardening.test.sql`). 테이블/시퀀스만. 마이그레이션 경로는 추가로 wallet 4테이블 DML REVOKE 재적용(`20260605000010` 미러)으로 anon/auth 확대 방지. **예외(모순 아님)**: 가입경로 **allowlist** 함수(`check_email_exists` 등)는 anon EXECUTE가 정당 → PR#198이 명시 `GRANT ... TO anon` 추가([[wallet-pgtap-caller-binding]]). 하드닝 REVOKE 대상(결제·관리 RPC)과 구분.
 3. **setup-cli 버전 pin** — `version: 2.107.0` + `github-token`(PR#180). `latest` 는 (a) 익명 GitHub API rate-limit, (b) 이미지 드리프트 두 사고의 단일 뿌리. 3개 워크플로우 일괄.
 4. **fixtures 는 prod 등록 금지** — SECDEF 헬퍼 포함, prod 적용 시 RLS 우회 가능(catastrophic).
 
@@ -42,3 +42,4 @@ prod 는 Supabase 기본 default-privilege 로 GRANT 를 보유하지만, CI 의
 - [[db-tests-cli-grant-drift]] — db-tests(pgTAP) 쪽 원천 소스(RED→GREEN 증거)
 - [[e2e-cli-grant-drift]] — e2e 쪽 원천 소스(pin≠fix 반증 + 마이그레이션 수정)
 - [[enum-divergence]] — DB 스키마/환경 드리프트가 읽기를 깨는 또 다른 클래스
+- [[wallet-pgtap-caller-binding]] — 같은 계열 테스트-DB 함정(하드닝이 pgTAP 깨뜨림)

--- a/wiki/decisions/wallet-pgtap-caller-binding.md
+++ b/wiki/decisions/wallet-pgtap-caller-binding.md
@@ -1,0 +1,37 @@
+---
+area: decisions
+updated: 2026-06-23
+status: current
+sources:
+  - uniqn-mobile/supabase/migrations/20260621090100_bind_mutation_rpcs_to_auth_uid.sql
+  - uniqn-mobile/supabase/tests/anon_rpc_security_hardening.test.sql
+  - memory/pitfall_195_caller_binding_broke_pgtap_dbtests.md
+  - PR#195
+  - PR#198
+tags: [db-tests, pgtap, rls, security, auth, regression]
+---
+
+# pgTAP caller-binding 회귀 — 하드닝이 테스트 하네스를 깨뜨림
+
+**결정/교훈:** 변이 RPC에 `auth.uid()` 호출자 바인딩 가드를 추가하면 **pgTAP 테스트도 함께 갱신**해야 한다. 안 하면 db-tests가 RED가 되고, 그 RED는 "방금 변경"이 아니라 **선행 하드닝 회귀**일 수 있다.
+
+## 무슨 일
+PR#195가 변이 SECDEF RPC(`confirm_application`·`cancel_application_atomically`·`process_qr_checkin_atomically`·`apply_with_capacity_check`)에 가드 추가:
+`IF auth.uid() IS NULL OR (auth.uid() IS DISTINCT FROM <actor_param> AND NOT is_admin()) THEN 거부` (`20260621090100_bind_mutation_rpcs_to_auth_uid.sql`).
+
+pgTAP는 superuser `DO` 블록에서 RPC를 직접 호출 → `auth.uid()`=NULL → 전부 거부("unauthorized" / "PERMISSION_DENIED: 호출자 인증 불일치"). **프로덕션·e2e는 JWT 보유라 정상** = 테스트 하네스만 깨진 것. #195는 db-tests RED인 채 master 직접 머지됨([[test-db-grants]] 동일 클래스: 머지 게이트가 required check 강제 안 함).
+
+## 수정 (PR#198, CI GREEN 검증)
+- 각 하드닝 RPC 호출 **직전**에 actor와 동일 uuid로 JWT 주입:
+  `PERFORM set_config('request.jwt.claims', json_build_object('sub', <actor>, 'role','authenticated')::text, true);`
+  (`auth.uid()`는 `request.jwt.claims` JSON의 `sub`를 읽음.)
+- `anon_rpc_security_hardening.test.sql`: `has_function_privilege`는 **미존재 함수에 ERROR로 중단** → phantom `list_all_applications(application_status)` 단언 제거. `check_email_exists(text)`는 가입경로 anon 호출이라 `GRANT EXECUTE ... TO anon` 명시 추가(암묵→명시 grant 갭, [[test-db-grants]] / [[e2e-cli-grant-drift]] 패턴).
+
+## 운영 규칙
+- db-tests RED 시 "방금 변경" 의심 전에 **직전 머지의 db-tests 결과를 `gh run`으로 실측 대조**. 실패 테스트가 변경과 무관하면 선행 회귀.
+- db-tests는 `supabase/**` 변경 PR만 실행 → 회귀 잠복([[test-db-grants]]).
+
+## 관련
+- [[test-db-grants]] — 같은 테스트-DB 함정 계열(grant 드리프트)
+- [[rls-model]] — 호출자 바인딩은 RLS 외 SECDEF RPC 권한 레이어
+- [[wallet-iap-removal]] — 이 회귀 발견 맥락(지갑 제거 PR의 db-tests RED 추적 중 확정)

--- a/wiki/domain/revenue-model.md
+++ b/wiki/domain/revenue-model.md
@@ -1,9 +1,11 @@
 ---
 area: domain
-updated: 2026-06-18
+updated: 2026-06-23
 status: current
 sources:
   - memory/project_revenue_model_audit_20260609.md
+  - memory/project_wallet_iap_removal_20260622.md
+  - PR#196
   - PR#172
   - PR#168
 tags: [domain, revenue, wallet, iap, revenuecat, diamond, heart]
@@ -11,7 +13,9 @@ tags: [domain, revenue, wallet, iap, revenuecat, diamond, heart]
 
 # 수익 모델
 
-**한 줄:** 이중통화(하트·다이아) + 공고 게시 차감 + IAP 충전. 현재 출시 게이트 OFF(서버 `_calc_posting_cost`=0) 휴면 상태. (주장: memory/project_revenue_model_audit_20260609.md)
+> ⚠️ **2026-06-22~23 방향 전환 — ✅전체 제거 완료** ([[wallet-iap-removal]], PR#196 머지 `967e9f5e2` + prod drop 마이그 + 웹 배포·스모크). 아래 이중통화/IAP 구조는 **폐기됨**(코드/DB/RC 제거). 결론: 구인구직 잡보드 수수료로는 수익이 안 됨(시장 작고 이탈 심함, 직업안정법상 구직자 과금 제한). 진짜 수익처는 "딜러 임금이 흐르는 정산-레일 + 노쇼 보증"이나 PG제휴·세무·법률이 묶인 별도 핀테크라 보류. 안티스팸은 가상화폐 대신 PortOne 본인인증 + 지원/공고 한도 + 평판으로 대체. (출처: [[wallet-iap-removal]])
+
+**한 줄(폐기 전 기준):** 이중통화(하트·다이아) + 공고 게시 차감 + IAP 충전. 출시 게이트 OFF(서버 `_calc_posting_cost`=0) 휴면이었고, 이제 제거 진행. (주장: memory/project_revenue_model_audit_20260609.md)
 
 ## 통화 구조
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -13,12 +13,14 @@
 - [[worktime-ssot]] — 근무시간 표시 SSOT(WorkTimeDisplay) 우회 금지
 - [[capacity-full]] — 공고 자동마감 capacity_full + dead counter 제거
 - [[test-db-grants]] — 테스트 DB는 명시 GRANT + setup-cli 버전 pin (기본 default-privilege 의존 금지)
+- [[wallet-pgtap-caller-binding]] — 변이 RPC auth.uid() 바인딩 하드닝이 pgTAP db-tests 깨뜨림 (PR#195→#198, JWT 주입 수정)
 
 ## domain
 - [[roles]] — UserRole(앱권한: admin/employer/staff) vs StaffRole(직무: dealer/floor/serving)
 - [[target-market]] — 홀덤펍 + 대회사 (포커룸 비타깃)
-- [[revenue-model]] — 이중통화(하트·다이아)·IAP·RevenueCat (게이트 OFF 휴면)
+- [[revenue-model]] — ⚠️ 이중통화(하트·다이아)·IAP — **전체 제거 완료**(PR#196 머지 `967e9f5e2`, [[wallet-iap-removal]])
 
 ## sources
 - [[db-tests-cli-grant-drift]] — pg_prove red 근본원인: setup-cli `version:latest` 드리프트로 implicit 테이블 GRANT 소실 (PR#179/#180)
 - [[e2e-cli-grant-drift]] — e2e ~96% red 같은 드리프트, pin(2.107.0)으론 미해결 → 명시 GRANT 마이그레이션이 수정 (PR#183)
+- [[wallet-iap-removal]] — 지갑/IAP 수익모델 전체 제거 (구인구직엔 불필요) — ✅PR#196/#198 머지·prod 마이그·웹 배포

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -10,3 +10,5 @@
 ## [2026-06-19] ingest | db-tests CLI grant 드리프트 — sources/db-tests-cli-grant-drift + decisions/test-db-grants 생성, rls-model 갱신(테이블 GRANT 레이어 보강). 출처 PR#179/#180
 
 ## [2026-06-19] ingest | e2e CLI grant 드리프트 — sources/e2e-cli-grant-drift 생성(같은 드리프트가 e2e도 타격, pin 2.107.0으론 미해결 반증, 명시 GRANT 마이그레이션이 수정). decisions/test-db-grants 보정(pin≠fix, 무대별 grant 위치). 출처 PR#183(run 27769458739/27787809344/27829125384)
+
+## [2026-06-23] ingest | 지갑/IAP 수익모델 전체 제거 + db-tests 회귀 — sources/wallet-iap-removal + decisions/wallet-pgtap-caller-binding 생성. revenue-model 휴면→폐기 전환(모순 플래그), rls-model 느슨 INSERT 의도 원칙 보강, test-db-grants allowlist 함수 grant 예외 명확화. 출처 memory(project_wallet_iap_removal_20260622·pitfall 2건)·PR#196(제거,✅머지 967e9f5e2+prod마이그+웹배포)·PR#198(db-tests green)

--- a/wiki/sources/wallet-iap-removal.md
+++ b/wiki/sources/wallet-iap-removal.md
@@ -1,0 +1,42 @@
+---
+area: sources
+updated: 2026-06-23
+status: current
+sources:
+  - memory/project_wallet_iap_removal_20260622.md
+  - memory/pitfall_195_caller_binding_broke_pgtap_dbtests.md
+  - memory/pitfall_job_postings_insert_loose_rls_by_design.md
+  - PR#196
+  - PR#198
+tags: [wallet, iap, revenue, removal, db-tests, rls, pgtap]
+---
+
+# 소스: 지갑/IAP 수익모델 전체 제거 (2026-06-22~23)
+
+가상화폐(하트/다이아) 지갑 + RevenueCat IAP 수익모델을 **전체 제거**하기로 결정하고 작업한 세션의 요약. **✅ PR#198·#196 둘 다 master 머지 + prod drop 마이그 적용 + 웹 배포·라이브 스모크 통과 완료(2026-06-23).** 잔여는 모바일 EAS OTA(사용자 보류)와 스토어 IAP 수동 해지.
+
+## 결정 (why)
+- 구인구직 잡보드 공고 수수료로는 돈 안 됨: 시장 작음, 이탈(disintermediation) 심함, 직업안정법상 **구직자 과금 제한**.
+- 진짜 수익처 = "딜러 임금이 흐르는 **정산-레일** + **노쇼 보증**"이나 PG제휴·세무·법률이 묶인 별도 핀테크 사업 → 지금은 보류.
+- 안티스팸(무분별 공고/지원)은 가상화폐 대신 **기존 PortOne 본인인증 + 지원/공고 한도 + 평판**으로 충분.
+- 상세 비판: [[revenue-model]] 전략 갭 참조.
+
+## PR #196 — 제거 + 공고 생성 경로 복원 (✅머지 `967e9f5e2`)
+- 들어냄: `src/components/wallet/`(PurchaseSheet·PaywallModal 등), `src/services/purchases/`(RevenueCat), 지갑 훅, `diamond_products`/`wallet_ledger`/`wallets`/`heart_lots` 테이블 + RPC, `revenuecat-webhook`, IAP footer, signup 하트 grant.
+- **핵심**: 공고 생성/취소가 `create_job_posting_with_payment_atomically` RPC를 통과했는데 → 결제 없는 직접 `supabase.insert()`/`status=cancelled UPDATE`로 복원. flag-off legacy 동등성 보장 R1 회귀테스트 근거.
+- 보강: drop 마이그 DROP 시그니처 정합(`wallet_reason` 타입, CASCADE 의존 제거), `handle_new_user()` 하트블록 제거(dangling 참조 경고 해소), `react-native-purchases` + eas RC키 제거.
+- 유지: 출퇴근/정산 전부, 공고 게시/지원/확정 핵심 동선.
+
+## PR #198 — db-tests 회귀 수정 (master 대상, CI GREEN)
+- pg_prove RED의 원인은 지갑이 아니라 [[wallet-pgtap-caller-binding]] — PR#195 하드닝이 pgTAP를 깨뜨림. JWT 주입으로 수정.
+
+## 잔여 (2026-06-23 기준)
+- ✅완료: #196 머지·웹 Cloudflare 배포·라이브 웹 스모크(공고 작성→등록 201→삭제 204, wallet RPC 0)·prod drop 마이그·`supabase.ts` 재생성·잔액확인(유료 0)·RevenueCat 웹훅삭제+상품15 archive·PR#160 폐기·app_config monetization 키 제거.
+- 🔲 사용자: 모바일 EAS OTA(`eas update --channel production`, android/ 임시 mv + `--environment production`)·신규 빌드(보류)·App Store Connect/Play Console IAP 수동 해지.
+- 🔲 owner_id 위조 조임은 [[rls-model]] 느슨 INSERT 설계 때문에 별도 PR(설계 doc 작성됨).
+
+## 관련
+- [[revenue-model]] — 폐기 대상 구조 + 전략 갭
+- [[target-market]] — 정산-레일 수익처는 대회사/홀덤펍 임금 흐름
+- [[wallet-pgtap-caller-binding]] — db-tests 회귀(PR#198)
+- [[rls-model]] — 공고 INSERT 느슨 RLS는 의도(조임 금지)


### PR DESCRIPTION
## 배경
지갑/IAP 수익모델 전체 제거(#196, 머지 `967e9f5e2`)의 **후속 정리** PR입니다. prod DB·웹 배포·RevenueCat 정리는 이미 완료됐고, 이 PR은 리포 정합(위키 지식 + dead 피처플래그 마이그)만 담습니다.

## 변경
### 1. 위키 지식베이스 갱신 (`wiki/`)
- **신규** `sources/wallet-iap-removal.md` — 제거 결정(why)·PR#196/#198 요약·잔여 작업
- **신규** `decisions/wallet-pgtap-caller-binding.md` — #195 하드닝이 pgTAP db-tests 깨뜨린 회귀 + #198 JWT 주입 수정
- `domain/revenue-model.md` — 이중통화/IAP 구조 휴면→**폐기** 전환 명시
- `architecture/rls-model.md` — `job_postings` INSERT가 **의도적으로 느슨**(app-layer authz)이라는 원칙 추가 (owner_id 순진 조임 금지)
- `decisions/test-db-grants.md` — allowlist 함수(`check_email_exists`) anon GRANT 예외 명확화
- `index.md` / `log.md` — 카탈로그·변경로그 반영

### 2. 마이그레이션
- `20260623120000_drop_app_config_monetization.sql` — `app_config`의 dead `monetization` 피처플래그 키 제거
  - seed 마이그(`20260427000900`)가 남아 있어 fresh 스택(db reset)에서 키가 재생성되므로 seed 이후 시점에 정합화
  - **멱등**(`DELETE ... WHERE`): 이미 없으면 0행 no-op
  - **prod에는 2026-06-23 단발 DELETE로 이미 적용됨** (이 마이그는 fresh 스택/parity용)

## 검증
- 앱 코드 변경 없음(위키 + SQL only). `monetization` 키를 읽던 RPC는 #196에서 전부 DROP됨(`grep`으로 src/app 참조 0 확인).
- prod 적용 후 실측: `SELECT count(*) FROM app_config WHERE key='monetization'` = 0.

## 별개 후속
- 공고 INSERT `owner_id` 조임은 느슨 INSERT 설계상 별도 PR(설계 doc 동반).

🤖 Generated with [Claude Code](https://claude.com/claude-code)