### PR TITLE
chore(wallet): 결제/수익모델 잔재 정리 — is_featured SELECT 제거 + 낡은 주석 정정

### DIFF
--- a/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/JobPostingRepository.ts
@@ -357,7 +357,7 @@ export class SupabaseJobPostingRepository implements IJobPostingRepository {
     try {
       logger.info('공고 생성', { ownerId: context.ownerId, title: input.title });
       const now = new Date();
-      // 클라 생성 UUID — 결제 RPC의 멱등키(ON CONFLICT id)로 사용해 재시도 이중과금 방지
+      // 클라 생성 UUID — 직접 INSERT의 멱등키(ON CONFLICT id)로 사용해 재시도 시 중복 생성 방지
       const postingId = generateUUID();
       const current: Partial<JobPosting> = {
         id: postingId,

--- a/uniqn-mobile/src/repositories/supabase/SettlementRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/SettlementRepository.ts
@@ -57,7 +57,7 @@ const BATCH_CHUNK_SIZE = 100;
 const WORK_LOG_COLUMNS =
   'id,application_id,assignment_group_id,check_in_ts,check_out_ts,created_at,custom_allowances,custom_role,custom_salary_info,custom_tax_settings,date,has_time_modification_logs,is_fixed_posting,job_posting_id,modification_history,no_show_at,no_show_reason,notes,owner_id,payroll_amount,payroll_date,payroll_notes,payroll_status,role,role_change_history,settlement_modification_history,staff_id,staff_name,staff_nickname,staff_photo_url,staff_photo_url_blurhash,status,time_slot,updated_at' as const;
 const JOB_POSTING_COLUMNS =
-  'id,closed_at,closed_reason,compensation,contact_phone,created_at,description,filled_positions,fixed_config,is_featured,last_work_date,location,og_image_url,owner_id,owner_name,posting_type,questions,rejection_reason,role_catalog,role_keys,schedule,schema_version,stats,status,tags,title,total_positions,tournament_config,updated_at,urgent_config,view_count,work_date,work_dates,workspace_id' as const;
+  'id,closed_at,closed_reason,compensation,contact_phone,created_at,description,filled_positions,fixed_config,last_work_date,location,og_image_url,owner_id,owner_name,posting_type,questions,rejection_reason,role_catalog,role_keys,schedule,schema_version,stats,status,tags,title,total_positions,tournament_config,updated_at,urgent_config,view_count,work_date,work_dates,workspace_id' as const;
 
 // ============================================================================
 // Internal Types

--- a/uniqn-mobile/supabase/fixtures/jpc_helpers.sql
+++ b/uniqn-mobile/supabase/fixtures/jpc_helpers.sql
@@ -41,8 +41,8 @@
 --       workspace_archive). master #175(2026-06-18) 에서 16/16 subtest fail.
 -- 해결: 테스트 스택 grant 를 prod 와 동일하게 맞춰 CLI 버전과 무관하게 결정적으로.
 --       RLS 가 실제 행 접근의 보안 경계이므로 테이블 GRANT 확대는 prod 동치이며 안전.
--- ⚠️ 함수는 GRANT 금지: 결제 RPC 하드닝(#172, wallet_grants_hardening.test.sql)이
---    anon/authenticated 에서 REVOKE 한 EXECUTE 를 되살리면 회귀. 테이블/시퀀스만.
+-- ⚠️ 함수는 GRANT 금지: anon SECDEF RPC 하드닝(#195)이 anon/authenticated 에서
+--    REVOKE 한 EXECUTE 를 되살리면 회귀. 테이블/시퀀스만.
 -- ⚠️ 이 파일은 fixtures 전용(prod 등록 금지) — 로컬/CI 테스트 DB 에만 적용된다.
 GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
 GRANT ALL ON ALL TABLES IN SCHEMA public TO anon, authenticated, service_role;


### PR DESCRIPTION
## 배경
지갑/IAP 제거(#196/#199) 후속 **결제·수익모델 잔재 전수감사(2026-06-24)** 에서 발견한 코드 측 잔재 정리. 감사 결과 앱코드·의존성·prod DB는 클린이었고, 유일한 실잔재였던 prod 고아 Edge Function `revenuecat-webhook`은 이번 세션에서 대시보드로 삭제(MCP `list_edge_functions` 17→16 실측). 본 PR은 남은 무해 흔적 중 **코드 측**을 정리한다.

## 변경
- **SettlementRepository**: `JOB_POSTING_COLUMNS` SELECT에서 죽은 `is_featured` 컬럼 제거. Lane D(featured 유료노출) 잔재로 소비처 없음(`true` 행 0, 도메인 타입/스키마 미참조).
- **JobPostingRepository**: 없어진 "결제 RPC" 언급 주석 → "직접 INSERT" 정정.
- **jpc_helpers.sql (fixture)**: "결제 RPC 하드닝(#172)" → "anon SECDEF RPC 하드닝(#195)" 정정(코멘트, 동작 무관).

## ⚠️ 후속 (별도 PR — 의도적 분리)
`job_postings.is_featured` **DB DROP COLUMN**은 본 PR에 미포함 — 현재 배포된 웹/모바일이 아직 이 컬럼을 SELECT 중이라, 컬럼을 먼저 드롭하면 읽기 증발. **본 PR 배포(웹+모바일 OTA) 후** DROP 마이그를 별도 적용해야 안전.

## 테스트
- 영향 리포지토리 테스트 **58/58 통과** (회귀 가드: stats·owner_id SELECT 보존, is_featured 미소비 확인)
- `npm run quality` **GREEN** (type-check 0, lint 0 errors, format OK)

## 스코프 외
- 낡은 wallet/monetization 기획 문서 아카이브 — repo-root `docs/`와 `uniqn-mobile/docs/` 두 트리로 갈려 별도 docs-hygiene 작업으로 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)