### PR TITLE
fix(notifications): 푸시 알림 토글 저장 실패 — upsert onConflict=user_id 누락

### DIFF
--- a/uniqn-mobile/src/repositories/supabase/NotificationRepository.ts
+++ b/uniqn-mobile/src/repositories/supabase/NotificationRepository.ts
@@ -474,11 +474,18 @@ export class SupabaseNotificationRepository implements INotificationRepository {
     try {
       const snakeData = toSnakeCase(settings as unknown as Record<string, unknown>);
 
-      const { error } = await supabase.from(TABLES.NOTIFICATION_SETTINGS).upsert({
-        user_id: userId,
-        ...snakeData,
-        updated_at: new Date().toISOString(),
-      });
+      // onConflict 필수: 테이블은 PK(id) + UNIQUE(user_id) 구조다. onConflict 미지정 시
+      // PostgREST 는 PK(id) 기준으로 충돌을 해소하는데, payload 에 id 가 없어 매번 새 id 가
+      // 생성되어 id 충돌이 안 나고 대신 UNIQUE(user_id)를 위반(23505)해 INSERT 가 실패한다.
+      // → 설정 행이 한 번 생긴 뒤 모든 저장 실패 = '푸시 알림' 토글이 되돌아감.
+      const { error } = await supabase.from(TABLES.NOTIFICATION_SETTINGS).upsert(
+        {
+          user_id: userId,
+          ...snakeData,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id' }
+      );
 
       if (error) {
         handleSupabaseError(error, {

--- a/uniqn-mobile/src/repositories/supabase/__tests__/NotificationRepository.saveSettings.test.ts
+++ b/uniqn-mobile/src/repositories/supabase/__tests__/NotificationRepository.saveSettings.test.ts
@@ -1,0 +1,93 @@
+/**
+ * 회귀 가드 — 알림 설정 저장(푸시 알림 토글) upsert onConflict
+ *
+ * @description notification_settings 는 PK(id) + UNIQUE(user_id) 구조다.
+ *   saveSettings 의 upsert 가 onConflict 를 지정하지 않으면 PostgREST 는 PK(id)
+ *   기준으로 충돌을 해소한다. payload 에 id 가 없어 매번 새 id 가 생성되므로
+ *   id 충돌은 절대 발생하지 않고, 대신 UNIQUE(user_id) 제약을 위반해 23505
+ *   (duplicate key value violates "notification_settings_user_id_key") 로 INSERT
+ *   가 실패한다. 결과적으로 설정 행이 한 번 생긴 뒤로는 모든 저장이 실패하고,
+ *   설정 화면의 '푸시 알림' 토글이 되돌아간다(작동 안 함).
+ *
+ *   따라서 upsert 는 반드시 { onConflict: 'user_id' } 로 호출되어 기존 행을
+ *   UPDATE 병합해야 한다. 이 테스트는 그 계약을 고정한다.
+ */
+
+import { SupabaseNotificationRepository } from '../NotificationRepository';
+import { createDefaultNotificationSettings } from '@/types/notification';
+
+// ── Mock Supabase ────────────────────────────────────────────────────────────
+const mockFrom = jest.fn();
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    channel: jest.fn(),
+  },
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('@/utils/supabase', () => {
+  const actual = jest.requireActual('@/utils/supabase');
+  return {
+    ...actual,
+    handleSupabaseError: (error: { message?: string } | null) => {
+      if (error) throw new Error(`supabase: ${error.message ?? 'unknown'}`);
+    },
+  };
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+const USER_ID = '8d5d1990-054f-4f58-80df-dcc2bc3b3925';
+
+function makeChain(returnValue: { error: unknown }) {
+  const chain: Record<string, unknown> = {};
+  chain.upsert = jest.fn(() => chain);
+  (chain as { then?: unknown }).then = function then<TResult1 = unknown, TResult2 = never>(
+    onfulfilled?: ((value: unknown) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): PromiseLike<TResult1 | TResult2> {
+    return Promise.resolve(returnValue).then(onfulfilled, onrejected);
+  };
+  return chain as Record<string, jest.Mock> & PromiseLike<unknown>;
+}
+
+beforeEach(() => {
+  mockFrom.mockReset();
+});
+
+describe('SupabaseNotificationRepository.saveSettings — upsert onConflict 회귀 가드', () => {
+  const repo = new SupabaseNotificationRepository();
+
+  it('notification_settings 테이블에 upsert 한다', async () => {
+    const chain = makeChain({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    await repo.saveSettings(USER_ID, {
+      ...createDefaultNotificationSettings(),
+      pushEnabled: false,
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith('notification_settings');
+    expect(chain.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('user_id UNIQUE 충돌을 병합하도록 { onConflict: "user_id" } 로 upsert 한다', async () => {
+    const chain = makeChain({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    await repo.saveSettings(USER_ID, {
+      ...createDefaultNotificationSettings(),
+      pushEnabled: false,
+    });
+
+    const [payload, options] = (chain.upsert as jest.Mock).mock.calls[0];
+    // payload 에는 user_id + push_enabled(snake_case) 가 실려야 한다.
+    expect(payload).toEqual(expect.objectContaining({ user_id: USER_ID, push_enabled: false }));
+    // 회귀 핵심: onConflict 누락 시 PK(id) 기준 해소 → user_id 23505. user_id 병합 필수.
+    expect(options).toEqual({ onConflict: 'user_id' });
+  });
+});


### PR DESCRIPTION
## 문제
설정 화면의 '푸시 알림' 토글이 작동하지 않음. 낙관적으로 잠깐 켜졌다가 되돌아가고 에러 토스트 발생.

## 근본 원인
`notification_settings` 는 `PRIMARY KEY(id)` + `UNIQUE(user_id)` 구조다. `NotificationRepository.saveSettings` 의 `.upsert()` 가 `onConflict` 를 지정하지 않아 PostgREST 가 PK(`id`) 기준으로 충돌을 해소했다. payload 에 `id` 가 없어 매번 새 `id` 가 생성 → `id` 충돌은 발생하지 않고 대신 `UNIQUE(user_id)` 를 위반(`23505`)해 INSERT 실패. 설정 행이 한 번 생긴 뒤로는 **모든 저장이 실패**한다.

## 수정
- upsert 에 `{ onConflict: 'user_id' }` 추가 → 기존 행 UPDATE 병합
- 회귀 가드 테스트 2건 추가

## 증거 (prod DB 실측)
- 제약: `notification_settings_user_id_key UNIQUE (user_id)` + `PRIMARY KEY (id)`
- 재현: `ON CONFLICT (id)` → `23505 duplicate key ... notification_settings_user_id_key`
- 수정 검증: `ON CONFLICT (user_id)` → UPDATE 성공 (롤백, 실제 행 무변경)
- 전체 DB에 설정 행 1개뿐 = 저장 깨짐 정황
- 서버측 `send-push-notification` 은 이미 `push_enabled` 존중 (별도 버그 없음)

## 검증
- jest 315 passed (repository + notifications)
- tsc 0 errors, eslint 0, prettier clean
- Red→Green 확인 (수정 전 `options=undefined` 실패 → 수정 후 통과)

## 배포 메모
순수 클라이언트(repository) 코드 → 사용자 도달에 EAS OTA/빌드 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)