### PR TITLE
chore(settlements): 공고상세 진입 라벨을 '스태프 관리/정산'으로 변경

### DIFF
--- a/uniqn-mobile/app/(employer)/my-postings/[id]/index.tsx
+++ b/uniqn-mobile/app/(employer)/my-postings/[id]/index.tsx
@@ -509,7 +509,7 @@ export default function JobPostingDetailScreen() {
             {!isFixed && (
               <ActionCard
                 icon={<BanknotesIcon size={24} color={STATUS_COLORS.success} />}
-                title="스태프 정산 관리"
+                title="스태프 관리/정산"
                 description="확정 스태프 관리와 정산을 진행합니다."
                 badge={
                   filledPositions > 0

--- a/uniqn-mobile/app/(employer)/my-postings/[id]/settlements.tsx
+++ b/uniqn-mobile/app/(employer)/my-postings/[id]/settlements.tsx
@@ -116,7 +116,7 @@ export default function StaffSettlementsScreen() {
 
   const stackHeader = (
     <StackHeader
-      title="정산 관리"
+      title="스태프 관리/정산"
       titleSuffix={headerTitleSuffix}
       fallbackHref={headerBackHref}
       rightAction={headerRightAction}

--- a/uniqn-mobile/e2e/tests/p1-important/employer-settlement.spec.ts
+++ b/uniqn-mobile/e2e/tests/p1-important/employer-settlement.spec.ts
@@ -166,11 +166,13 @@ test.describe('구인자 정산 관리', () => {
     await cleanupJobPosting(testJobId);
   });
 
-  test('공고 상세에서 정산 관리 화면으로 이동한다', async ({ page }) => {
+  test('공고 상세에서 스태프 관리/정산 화면으로 이동한다', async ({ page }) => {
     await page.goto(`/my-postings/${testJobId}`, { waitUntil: 'domcontentloaded' });
     await waitForReady(page);
 
-    const settlementAction = page.locator('button:visible', { hasText: /정산 관리/ }).first();
+    const settlementAction = page
+      .locator('button:visible', { hasText: /스태프 관리\/정산/ })
+      .first();
     await expect(settlementAction).toBeVisible();
     await settlementAction.click();
     await page.waitForURL(/settlements/, { timeout: 15_000 });


### PR DESCRIPTION
## 요약
공고상세의 '스태프 정산 관리' 진입 라벨을 **'스태프 관리/정산'** 으로 변경. 순수 라벨 리네임 — 구조/탭/데이터/훅/모달/라우트 변경 없음.

## 변경
- 공고상세 ActionCard 제목: `스태프 정산 관리` → `스태프 관리/정산` (`my-postings/[id]/index.tsx`)
- settlements 화면 헤더: `정산 관리` → `스태프 관리/정산` (카드와 일치, `settlements.tsx`)
- e2e 셀렉터 정규식 갱신: `/정산 관리/` → `/스태프 관리\/정산/` (안 고치면 셀렉터가 새 라벨 못 잡아 테스트 깨짐)

## 변경 안 함 (의도적)
- 분석 화면명(`useNavigationTracking.ts`)·코드 주석·약관 문서의 '정산 관리' 표현 — 사용자 비노출이라 추적 이력 보존 위해 유지
- `testID="job-posting-manage-settlements"` 등 라우트/식별자 동일

## 테스트
- pre-push 품질 게이트 통과: `tsc --noEmit` 0 errors / lint 0 errors / format OK / CSS 변수 동기화 OK
- [ ] e2e `employer-settlement.spec.ts` 셀렉터 검증 (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)