### PR TITLE
fix(security): app-wide XSS 검증 하드닝 — 절단 여는태그·이벤트 갭·인코딩 우회 차단 + 오탐 수정

### DIFF
--- a/uniqn-mobile/src/utils/__tests__/security.test.ts
+++ b/uniqn-mobile/src/utils/__tests__/security.test.ts
@@ -342,3 +342,145 @@ describe('security', () => {
     });
   });
 });
+
+// ============================================================================
+// #4 app-wide XSS 하드닝 — 여는태그 단독/이벤트 일반화/data·인코딩 보강 + 오탐 수정
+// 근거: XSS_PATTERNS가 닫는태그/닫는> 강제 → 절단형 통과, on* allowlist 갭,
+//       프로토콜/data 인코딩 구멍. 동시에 expression(/JavaScript: 등 정상입력 오탐.
+// ============================================================================
+describe('security #4 XSS 하드닝', () => {
+  describe('여는태그 단독/절단형 탐지', () => {
+    it('닫는 </script> 없는 절단 script 탐지', () => {
+      expect(hasXSSPattern('<script>alert(1)')).toBe(true);
+      expect(hasXSSPattern('<script>alert(document.cookie)')).toBe(true);
+      expect(hasXSSPattern('<SCRIPT>alert(1)')).toBe(true);
+    });
+
+    it('닫는태그 없는 외부 src script 탐지', () => {
+      expect(hasXSSPattern('<script src=//evil.com/x.js>')).toBe(true);
+      expect(hasXSSPattern('<script src=https://evil.com/x.js>')).toBe(true);
+    });
+
+    it('닫는 > 없는 절단 iframe/object/embed/svg 탐지', () => {
+      expect(hasXSSPattern('<iframe src=//evil.com/clickjack')).toBe(true);
+      expect(hasXSSPattern('<iframe src=//evil.com')).toBe(true);
+      expect(hasXSSPattern('<object data=//evil.com/x')).toBe(true);
+      expect(hasXSSPattern('<embed src=//evil.com/x')).toBe(true);
+      expect(hasXSSPattern('<svg onpointerover=alert(1)')).toBe(true);
+    });
+
+    it('미목록 위험태그(base/meta/style/form/math/link/template) 탐지', () => {
+      expect(hasXSSPattern('<base href=//evil.com>')).toBe(true);
+      expect(hasXSSPattern('<meta http-equiv=refresh content="0;url=//evil.com">')).toBe(true);
+      expect(hasXSSPattern("<style>@import'//evil'</style>")).toBe(true);
+      expect(hasXSSPattern('<form action=//evil><input formaction=javascript:alert(1)>')).toBe(
+        true
+      );
+      expect(hasXSSPattern('<math href=javascript:alert(1)>click')).toBe(true);
+    });
+  });
+
+  describe('이벤트 핸들러 일반화(allowlist 갭)', () => {
+    it('allowlist 미포함 자동발화 이벤트 탐지', () => {
+      expect(hasXSSPattern('<details open ontoggle=alert(1)>')).toBe(true);
+      expect(hasXSSPattern('<details open onbeforetoggle=alert(1)>')).toBe(true);
+      expect(hasXSSPattern('<input autofocus onfocusin=alert(1)>')).toBe(true);
+      expect(hasXSSPattern('<body onpageshow=alert(1)>')).toBe(true);
+    });
+
+    it('allowlist 미포함 상호작용 이벤트 탐지', () => {
+      expect(hasXSSPattern('<img src=x onpointerover=alert(1)>')).toBe(true);
+      expect(hasXSSPattern('<img src=x onmouseenter=alert(1)>')).toBe(true);
+      expect(hasXSSPattern('<input onbeforeinput=alert(1)>')).toBe(true);
+      expect(hasXSSPattern('<div oncopy=alert(1)>copy</div>')).toBe(true);
+      expect(hasXSSPattern('<a onauxclick=alert(1)>x</a>')).toBe(true);
+      expect(hasXSSPattern('<xss onwheel=alert(1)>scroll</xss>')).toBe(true);
+    });
+
+    it('개행 속성구분자 이벤트 탐지', () => {
+      expect(hasXSSPattern('<img src=x\nonpointerdown=alert(1)>')).toBe(true);
+    });
+
+    it('bare on이벤트 핸들러 탐지 유지(기존 동작 보존)', () => {
+      expect(hasXSSPattern('onclick=alert(1)')).toBe(true);
+    });
+  });
+
+  describe('data:/프로토콜/인코딩 보강', () => {
+    it('비-base64 data: 스크립트 스킴 탐지', () => {
+      expect(hasXSSPattern('data:text/javascript,alert(1)')).toBe(true);
+      expect(hasXSSPattern('data:application/xhtml+xml;charset=utf-8;base64,PD94bWw=')).toBe(true);
+    });
+
+    it('프로토콜 내 제어문자 분절 탐지(탭/개행)', () => {
+      expect(hasXSSPattern('java\tscript:alert(1)')).toBe(true);
+      expect(hasXSSPattern('java\nscript:alert(1)')).toBe(true);
+    });
+
+    it('엔티티 난독 프로토콜 탐지(세미콜론없음/명명엔티티)', () => {
+      expect(hasXSSPattern('jav&#9;ascript:alert(1)')).toBe(true);
+      expect(hasXSSPattern('javascript&#58alert(1)')).toBe(true);
+      expect(hasXSSPattern('javascript&colon;alert(1)')).toBe(true);
+      expect(hasXSSPattern('javascript&colon;alert&lpar;1&rpar;')).toBe(true);
+      expect(hasXSSPattern('<a href=&#106;avascript:alert(1)>')).toBe(true);
+    });
+
+    it('고립 % 로 인한 URL디코드 무력화 우회 탐지', () => {
+      expect(hasXSSPattern('%3Cscript%3Ealert(1)%3C/script%3E%')).toBe(true);
+    });
+  });
+
+  describe('프로토콜 협소화 우회 차단(연산자/숫자 시작) + split-entity', () => {
+    it('콜론 뒤 연산자/숫자로 시작하는 javascript: 실행형 탐지', () => {
+      expect(hasXSSPattern('javascript:0||alert(1)')).toBe(true);
+      expect(hasXSSPattern('javascript:!alert(1)')).toBe(true);
+      expect(hasXSSPattern('javascript:+alert(1)')).toBe(true);
+      expect(hasXSSPattern('javascript:1?alert(1):0')).toBe(true);
+      expect(hasXSSPattern('javascript:/**/alert(1)')).toBe(true);
+      expect(hasXSSPattern('vbscript:0+msgbox(1)')).toBe(true);
+    });
+
+    it('이중 인코딩(split-entity) 여는태그 탐지', () => {
+      expect(hasXSSPattern('&#38;#60;script>alert(1)')).toBe(true);
+      expect(hasXSSPattern('&#38;#60;iframe>')).toBe(true);
+    });
+  });
+
+  describe('오탐 수정 — 정상입력 통과(현행 오탐 제거)', () => {
+    it('expression(...) 영단어/수식 산문 통과', () => {
+      expect(hasXSSPattern('그 expression(표현)이 자연스러워요')).toBe(false);
+      expect(hasXSSPattern('정규 expression(regex)을 평가하면')).toBe(false);
+      expect(hasXSSPattern('정규 expression (regex) 패턴')).toBe(false);
+      expect(hasXSSPattern('f(expression(x)) 중첩')).toBe(false);
+    });
+
+    it('콜론 동반 기술스택 라벨 통과(JavaScript:/VBScript:)', () => {
+      expect(hasXSSPattern('JavaScript: 중급 이상 (경력 3년)')).toBe(false);
+      expect(hasXSSPattern('VBScript: 레거시 유지보수')).toBe(false);
+    });
+
+    it('실제 CSS expression XSS는 여전히 차단(콜론 컨텍스트)', () => {
+      expect(hasXSSPattern('<div style="width:expression(alert(1))">')).toBe(true);
+    });
+
+    it('부등호/이모티콘/태그명 단어 통과(bare < 미차단)', () => {
+      expect(hasXSSPattern('조건 a < b, 1<2, x<=y, if(a<b){}')).toBe(false);
+      expect(hasXSSPattern('우리팀 최고 <3 // 헤어짐 </3')).toBe(false);
+      expect(hasXSSPattern('script 작성법을 알려주세요')).toBe(false);
+      expect(hasXSSPattern('iframe 사용법 문의')).toBe(false);
+      expect(hasXSSPattern('공지 <br> 흐름 -> 결과, <- 이전 단계')).toBe(false);
+      expect(hasXSSPattern('<details>요약 토글</details> 사용')).toBe(false);
+    });
+  });
+
+  describe('sanitizeInput — 절단형 위험태그 제거', () => {
+    it('닫는 > 없는 절단 위험태그도 제거', () => {
+      expect(sanitizeInput('hi<script src=//evil.com/x.js')).toBe('hi');
+      expect(sanitizeInput('x<iframe src=//evil')).toBe('x');
+    });
+
+    it('위험태그 아닌 부등호는 보존', () => {
+      expect(sanitizeInput('a<b 비교')).toBe('a<b 비교');
+    });
+  });
+});

--- a/uniqn-mobile/src/utils/security.ts
+++ b/uniqn-mobile/src/utils/security.ts
@@ -42,20 +42,49 @@ const HOMOGLYPH_MAP: Record<string, string> = {
 };
 
 /**
- * HTML 엔티티 디코딩 (보안 검사용)
+ * HTML 엔티티 1회 디코딩 (보안 검사용)
  *
- * `&#60;` → `<`, `&#x3c;` → `<`, `&lt;` → `<`
+ * `&#60;` → `<`, `&#x3c;` → `<`, `&lt;` → `<`, `&colon;` → `:`
  * XSS 검사 경로에서만 사용 (저장 경로에서는 원본 유지)
  */
+function decodeHtmlEntitiesOnce(text: string): string {
+  return (
+    text
+      // 세미콜론 옵셔널: `&#58alert`처럼 종결자 없는 수치 참조도 디코딩(HTML5 파서 동등)
+      .replace(/&#(\d+);?/g, (_, dec: string) => String.fromCharCode(parseInt(dec, 10)))
+      // 16진은 a-f가 후속 글자와 과매칭될 수 있어 세미콜론 유지
+      .replace(/&#x([0-9a-fA-F]+);/gi, (_, hex: string) => String.fromCharCode(parseInt(hex, 16)))
+      .replace(/&lt;/gi, '<')
+      .replace(/&gt;/gi, '>')
+      .replace(/&amp;/gi, '&')
+      .replace(/&quot;/gi, '"')
+      .replace(/&#39;/gi, "'")
+      // 명명 엔티티 난독 우회 방어: `javascript&colon;alert&lpar;1&rpar;`
+      .replace(/&colon;/gi, ':')
+      .replace(/&lpar;/gi, '(')
+      .replace(/&rpar;/gi, ')')
+      .replace(/&sol;/gi, '/')
+      .replace(/&Tab;/gi, '\t')
+      .replace(/&NewLine;/gi, '\n')
+  );
+}
+
+/**
+ * HTML 엔티티를 안정될 때까지 반복 디코딩 (최대 3회)
+ *
+ * URL 디코딩이 2회 반복하는 것과 대칭 — `&#38;#60;`(= `&` + `#60;` → `<`)처럼
+ * 인코딩을 한 단계 덧씌워 `<`를 숨기는 split-entity 우회를 방어. 정상 입력은 1회 만에 안정.
+ */
 function decodeHtmlEntities(text: string): string {
-  return text
-    .replace(/&#(\d+);/g, (_, dec: string) => String.fromCharCode(parseInt(dec, 10)))
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex: string) => String.fromCharCode(parseInt(hex, 16)))
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/&amp;/gi, '&')
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/gi, "'");
+  let prev = text;
+  let decoded = decodeHtmlEntitiesOnce(prev);
+  let iterations = 1;
+  while (decoded !== prev && iterations < 3) {
+    prev = decoded;
+    decoded = decodeHtmlEntitiesOnce(prev);
+    iterations += 1;
+  }
+  return decoded;
 }
 
 /**
@@ -87,6 +116,10 @@ export function normalizeForSecurity(input: string): string {
   // 2. HTML 엔티티 디코딩
   normalized = decodeHtmlEntities(normalized);
 
+  // 2.5. 고립 '%'(유효한 %XX 아님)를 %25로 escape → decodeURIComponent throw로
+  //      URL 디코딩이 통째로 중단되어 인코딩 페이로드가 살아남는 우회 방지
+  normalized = normalized.replace(/%(?![0-9a-fA-F]{2})/g, '%25');
+
   // 3. URL 디코딩 (최대 2회, double encoding 방어)
   for (let i = 0; i < 2; i++) {
     try {
@@ -109,31 +142,45 @@ export function normalizeForSecurity(input: string): string {
 // ============================================================================
 
 /**
+ * javascript: 프로토콜 — 콜론 뒤(공백 허용) 출력 가능 ASCII 문자([!-~]) 요구.
+ * 'JavaScript: 중급'처럼 콜론 뒤 공백+비-ASCII(한글) 기술스택 라벨은 통과시키되,
+ * `javascript:alert`·`javascript:0||alert`·`javascript:!alert`처럼 콜론 뒤 코드(문자/숫자/연산자)는 차단.
+ */
+const JS_PROTOCOL_PATTERN = /javascript:\s*[!-~]/gi;
+/** vbscript: 프로토콜 — 동일 협소화('VBScript:' 산문은 통과) */
+const VB_PROTOCOL_PATTERN = /vbscript:\s*[!-~]/gi;
+
+/**
  * 위험한 XSS 패턴 목록
  *
  * 다음 패턴을 차단:
- * - <script> 태그
- * - javascript: 프로토콜
- * - on* 이벤트 핸들러 (onclick, onerror 등)
- * - data:text/html URL, data:*;base64 (이미지 제외)
- * - <iframe>, <object>, <embed>, <svg> 태그
- * - vbscript: 프로토콜
- * - expression() CSS
+ * - 여는 태그 단독/절단형: script/iframe/object/embed/svg + style/base/meta/link/form/math/template
+ *   (닫는 </tag>·닫는 '>' 불요 — `<script>alert(1)`·`<iframe src=//evil` 같은 절단형 우회 차단)
+ * - on* 이벤트 핸들러 전체 (일반형 — allowlist 갭으로 통과하던 ontoggle/onpointerover 등 일소)
+ * - javascript:/vbscript: 프로토콜 (콜론 뒤 코드문자 동반 시)
+ * - data: 스크립트 스킴(text/javascript 등) + 비-이미지 base64
+ * - CSS expression() (콜론 컨텍스트 한정)
+ *
+ * @note `<` 직후 태그명, on 직후 이벤트명을 강제 → '<3'·'a < b'·단어 'script'·'JavaScript:'
+ *       같은 정상 입력은 통과(app-wide 오탐 방지). 스킴 내 제어문자/엔티티 분절 우회는
+ *       normalizeForSecurity + hasXSSPattern의 제어문자 제거 사본에서 추가 방어.
  */
 export const XSS_PATTERNS: RegExp[] = [
-  /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
-  /<script[^>]*>.*?<\/script>/gi,
-  /javascript:/gi,
-  /vbscript:/gi,
-  /\bon(click|load|error|mouseover|mouseout|mousedown|mouseup|mousemove|focus|blur|submit|change|input|keydown|keyup|keypress|touchstart|touchend|touchmove|dragstart|drag|drop|scroll|resize|unload|beforeunload|abort|contextmenu)\s*=/gi,
-  /data:text\/html/gi,
+  /<(?:script|iframe|object|embed|svg|style|base|meta|link|form|math|template)\b/gi,
+  /\bon[a-z]+\s*=/gi,
+  JS_PROTOCOL_PATTERN,
+  VB_PROTOCOL_PATTERN,
+  /data:text\/(?:html|javascript|xml)|data:application\/(?:javascript|x?html|xml)/gi,
   /data:(?!image\/)[^;,]*;base64/gi,
-  /<iframe[^>]*>/gi,
-  /<object[^>]*>/gi,
-  /<embed[^>]*>/gi,
-  /<svg[^>]*>/gi,
-  /expression\s*\(/gi,
+  /:\s*expression\s*\(/gi,
 ];
+
+/**
+ * 프로토콜 패턴(javascript:/vbscript:) — 스킴 내 제어문자(java<TAB>script:)로 분절하는
+ * 우회를 잡기 위해 제어문자 제거 사본에도 추가 검사. 전역 제거는 이벤트 패턴의 개행
+ * 속성 구분자를 손상시키므로 프로토콜 패턴에만 한정.
+ */
+const PROTOCOL_PATTERNS: RegExp[] = [JS_PROTOCOL_PATTERN, VB_PROTOCOL_PATTERN];
 
 /**
  * SQL Injection 패턴 목록
@@ -168,9 +215,19 @@ export const SQL_INJECTION_PATTERNS: RegExp[] = [
 export function hasXSSPattern(text: string): boolean {
   if (!text || typeof text !== 'string') return false;
   const normalized = normalizeForSecurity(text);
-  return XSS_PATTERNS.some((pattern) => {
+  const matchesNormalized = XSS_PATTERNS.some((pattern) => {
     pattern.lastIndex = 0; // /g 플래그 regex의 sticky lastIndex 버그 방지
     return pattern.test(normalized);
+  });
+  if (matchesNormalized) return true;
+
+  // 스킴 내부 제어문자(java<TAB>script:)로 패턴을 분절하는 우회 방어:
+  // 제어문자를 제거한 사본에 프로토콜 패턴만 추가 검사
+  const controlStripped = normalized.replace(/[\x00-\x1F]/g, '');
+  if (controlStripped === normalized) return false;
+  return PROTOCOL_PATTERNS.some((pattern) => {
+    pattern.lastIndex = 0;
+    return pattern.test(controlStripped);
   });
 }
 
@@ -219,12 +276,19 @@ export function xssValidation(text: string): boolean {
 export function sanitizeInput(input: string): string {
   if (!input || typeof input !== 'string') return '';
   const normalized = normalizeForSecurity(input);
-  return normalized
-    .replace(/<script[^>]*>.*?<\/script>/gi, '')
-    .replace(/<[^>]+>/g, '')
-    .replace(/javascript:/gi, '')
-    .replace(/on\w+\s*=/gi, '')
-    .trim();
+  return (
+    normalized
+      .replace(/<script[^>]*>.*?<\/script>/gi, '')
+      // 닫는 '>' 없는 절단형 위험 여는태그도 제거 (<[^>]+>는 '>'를 요구해 절단형이 잔존)
+      .replace(
+        /<\/?(?:script|iframe|object|embed|svg|style|base|meta|link|form|math|template)\b[^>]*>?/gi,
+        ''
+      )
+      .replace(/<[^>]+>/g, '')
+      .replace(/javascript:/gi, '')
+      .replace(/on\w+\s*=/gi, '')
+      .trim()
+  );
 }
 
 /**


### PR DESCRIPTION
## 요약
`src/utils/security.ts`의 app-wide XSS 입력검증(27개 Zod 스키마의 `xssValidation`에 사용)을 하드닝합니다. 닫는태그/닫는 `>`를 강제하던 패턴 때문에 **절단형 여는태그가 통과**하고, on* allowlist 갭·data/프로토콜 인코딩 구멍으로 **우회**되던 문제를 수정하고, 동시에 정상 입력을 부당 차단하던 **현행 오탐**을 제거합니다.

> 배경: T-HOLDEM ops 1b(#210) 출시 중 비차단 권고 #4(Stream 2)로 분리·승인된 보안 하드닝. ops와 독립적인 앱 전역 변경입니다.

## 근거 (실측 확정)
현재 `security.ts`는 진리표 실측 기준 **우회 36건 통과 + 오탐 9건**:
- 절단 여는태그: `<script>alert(1)`(닫는태그 없음)·`<iframe src=//evil`(닫는 `>` 없음)
- 이벤트 allowlist 갭: `ontoggle`/`onpointerover`/`onfocusin`/`onbeforetoggle` 등 미포함 이벤트
- 미목록 위험태그: `<base href>`(URL 하이재킹)·`<meta http-equiv=refresh>`·`<style>@import`
- 인코딩 분절: `java<TAB>script:`·`jav&#9;ascript:`·`javascript&colon;`·고립 `%`로 URL디코드 무력화
- 프로토콜 협소화 우회(red-team): `javascript:0||alert(1)`·`javascript:!alert(1)` 등 연산자/숫자 시작
- split-entity: `&#38;#60;script>`(이중 인코딩으로 `<` 은닉)
- 현행 오탐: `expression(표현)`·`정규 expression (regex)`·`JavaScript: 중급`·`VBScript:` 부당 차단

## 변경 내용
| 영역 | 변경 |
|------|------|
| 여는태그 | `/<(?:script\|iframe\|object\|embed\|svg\|style\|base\|meta\|link\|form\|math\|template)\b/` — 닫는태그/`>` 불요로 절단형 차단 |
| 이벤트 | allowlist → 일반형 `/\bon[a-z]+\s*=/` (갭 일소, `sanitizeInput`과 정합) |
| 프로토콜 | `javascript:\s*[!-~]` — 콜론 뒤 출력ASCII 요구(연산자우회 차단 + `JavaScript:` 산문 통과) |
| data: | 스크립트 스킴(`text/javascript`·`application/xhtml` 등) 추가, **이미지 base64(svg+xml 포함)는 허용 유지** |
| normalize | 고립 `%` → `%25` escape + 엔티티 **반복 디코드**(split-entity 방어, URL디코드 2회와 대칭) |
| hasXSSPattern | 제어문자 제거 사본에 프로토콜 패턴 추가 검사 |
| sanitizeInput | 절단형 위험 여는태그도 제거 |
| expression | `/:\s*expression\s*\(/` 콜론 컨텍스트 한정(산문 오탐 제거) |

## 검증
- 신규 `security.test.ts` **75 통과** (TDD RED→GREEN, 우회/오탐/회귀 케이스)
- **전체 jest 336 스위트 / 4508 통과** (app-wide 27 스키마 무회귀)
- `tsc --noEmit` **0 errors** · `npm run quality`(css-vars/type-check/lint 0err/format) 통과
- 적대 워크플로(9에이전트 find→verify→synth)로 우회 36 적출 + Node 진리표로 에이전트 자기보고 재검증 + red-team 2차로 연산자/split-entity 12건 추가 적출·수정

## 수용된 트레이드오프 (비차단, 도메인상 영향 희박)
- 일반형 이벤트가 `online=`/`onsale=`/`onClick={fn}`·`el.onload=` 등 영단어+`=` 코드성 문자열 차단(한글 홀덤 도메인에서 희박, `sanitizeInput` 기존 동작과 정합). 필요 시 태그컨텍스트형으로 전환 가능.
- 본문 리터럴 `<form>`/`<style>` 등 차단(드묾).
- `:expression(` 잔여 오탐 2종은 현행 bare `expression(` 대비 **오탐 축소**(개선).
- 정규식 사정권 밖: `<frame>`/`<portal>` 태그·mXSS(noscript/title)·DOM clobbering → 출력싱크 인코딩/CSP 영역(별도).

## 테스트 플랜
- [x] `npx jest src/utils/__tests__/security.test.ts` (75 통과)
- [x] 전체 `npx jest` (4508 통과)
- [x] `npm run quality` 통과
- [ ] CI 9종 green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
