### PR TITLE
docs(ops): 1c 출하 변경이력 — wiki/log + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,16 @@
 형식은 [Keep a Changelog](https://keepachangelog.com/ko/1.0.0/)를 기반으로 하며,
 이 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 준수합니다.
 
-## [Unreleased] - 2026-06-19
+## [Unreleased] - 2026-06-28
 
 ### Added
+- **라이브 대회 운영(ops) 도구 1a~1c 출하** (PR #207·#210·#212·#213·#214, prod 적용 완료·advisor 0 ERROR):
+  - 1a 등록데스크 + `ops_events` 감사 척추(#207), 1b 테이블/좌석/Redraw(#210)
+  - 1c-1/1c-2 블라인드 서버동기 클럭(`computeClockRemaining` 서버앵커+offset) + 트리거 기반 `ops_live_stats` 단일행 재계산 + STATUS/LEVELS/HISTORY 탭(#212)
+  - 1c-3 공개 모니터(전광판) — `ops_get_monitor_snapshot(token)` anon SECDEF 비-PII 화이트리스트 투영 + `app/(public)/monitor/[token]` + B2 배포 멀티 프로젝트 파라미터화(`deploy:ops`)(#213)
+  - 1c-4 공개 플레이어뷰 — `ops_get_player_view(claim_token)` anon SECDEF 본인 안전필드 투영 + claim 계정 바인딩/운영자 unclaim 복구 + `app/(public)/live/[claim_token]`(#214)
+  - 보안: anon ops 테이블 직접 SELECT 0 — token→스코프 SECDEF RPC + 화이트리스트 투영만(#195 PII 유출 클래스 차단). 적대리뷰 WF(1c-1 7차원·1c-4 5렌즈 find→verify) 통과
+  - ⚠️ 1d(bust/재진입) 착수 전 claim view/write 토큰 분리 + 신원게이트 재설계 필요(player_user_id 권한키 승급 전제)
 - LLM Wiki 지식 합성 레이어 부트스트랩 (PR #176): `wiki/`(architecture·decisions·domain·sources) + `/ingest`·`/query`·`/lint` 운영 + staleness 자동 감지(memory 전용 인용은 UNVERIFIABLE 표기)
 - 전체 워크플로우 UX 감사 후속 9결함 수정 (PR #175): 가입 빈 비밀번호 가드, 지원자 일괄확정 배선, 수동 출퇴근 타임스탬프→정산 차단 해소, 정산 CSV export 등
 - 공고 자동마감(Approach B): `posting_status` enum에 `capacity_full` 추가 (M1). 정원 도달 시 자동 마감, 빈자리 발생 시 자동 복귀 대기 상태

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -20,3 +20,11 @@
 - [2026-04-18] `job_posting_templates.description` 컬럼 추가(migration+types). JobPostingTemplate 리팩토링(userId/updatedAt 추가, createdBy/lastUsedAt 제거, usageCount 필수). edit.tsx 템플릿 저장 + TemplateModal 통합.
 - [2026-04-17] Firebase 레거시 규칙/스펙 archive(docs/archive/firebase-legacy/2026-04/), Firebase MCP 제거.
 - [2026-04-13] Expo 55/RN 0.83.4 업그레이드, Supabase 이전 완료, Black & Gold 완료.
+
+## [2026-06-28] note | T-HOLDEM 라이브 운영 슬라이스 1c 전체 출하 — 클럭/모니터/플레이어뷰
+- 1c-1/1c-2 클럭+live_stats+STATUS (PR#212, master `150f81e11`): 서버앵커(`level_started_at`)+클라틱+offset 보정 클럭(`computeClockRemaining` 순수함수)·트리거 기반 `ops_live_stats` 단일행 재계산(16 RPC 무수정)·5탭(PLAYERS/STATUS/TABLES/LEVELS/HISTORY). push 전 7차원 적대리뷰 WF(confirmed 4, CRITICAL/HIGH 0): 편집폼 stale state·actor-guard/DELETE/폴백 회귀테스트.
+- 1c-3 B2배포+모니터 (PR#213, `f4d7a625e`): `deploy-cloudflare.js --project-name` CLI인자>env>기본값 파라미터화(cross-env 미사용, Windows 호환)+`deploy:ops`. 공개 전광판 `ops_get_monitor_snapshot(token)` anon SECDEF 비-PII 화이트리스트 투영·`app/(public)/monitor/[token]`.
+- 1c-4 플레이어뷰 (PR#214, `3f215a622`): `ops_get_player_view(claim_token)` anon SECDEF **본인 안전필드만**(phone/nationality/claim_token/player_user_id/note/타참가자 미반환)·claim 바인딩+운영자 unclaim 복구. 적대검증 WF 5렌즈→claim 하이재킹(LOW~MED)→확인다이얼로그+복구RPC+PII pgTAP.
+- **보안 패턴(#195 차단)**: anon 은 ops 테이블 직접 SELECT 0 — token→스코프 SECDEF RPC + 반환값 화이트리스트 투영만. prod advisor anon-executable SECDEF = `ops_get_monitor_snapshot`·`ops_get_player_view` 2개만(화이트리스트 예외, 0 ERROR).
+- **🔑🔑 1d 착수 전 BLOCKING**: `player_user_id` 가 권한키로 승급(재진입/플레이어액션)되기 전 **claim view/write 토큰 분리 + PIN(또는 운영자승인) 신원게이트 재설계 필수**. 현 capability-URL은 player_user_id 가 dead column(인가 미사용)인 1c 한정 안전.
+- prod 7마이그(P1 3·P2 2·P3 2) MCP apply·advisor 0 ERROR·supabase.ts MCP gen 정합. OTA 보류(prod ops 0행). ops.uniqn.app 2nd CF Pages=사용자 게이트(공개링크 origin 동적). 검증 pgTAP 35/315·jest 4521. → memory `project_tholdem_ops_revival_20260623`. ⚠️ 1b·1c 함정 wiki /ingest 졸업 미수행(백로그).


### PR DESCRIPTION
라이브 운영 1c 전체 출하(P1 #212·P2 #213·P3 #214) 변경이력 기록. /session-wrap 산출.

🤖 Generated with [Claude Code](https://claude.com/claude-code)