### PR TITLE
feat(grid): 운영처 생성 UI — 주간 배치 그리드 출하차단 결함 해소

### DIFF
--- a/docs/superpowers/plans/2026-07-01-venue-create-ui.md
+++ b/docs/superpowers/plans/2026-07-01-venue-create-ui.md
@@ -1,0 +1,709 @@
+# 운영처 생성 UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 운영자가 주간 배치 그리드에서 운영처(venue 컨테이너)를 생성할 수 있게 한다(현재 생성 UI 부재로 기능 전체가 막다른 길 — 출하 차단 결함).
+
+**Architecture:** 백엔드(RPC `get_or_create_venue_container` + repository `getOrCreateVenueContainer` + 이름 XSS 검증)는 이미 완성. 본 작업은 **UI 배선만** 추가한다: Hook→Service→Repository 아키텍처를 따라 `gridWriteService.createVenueContainer` + `useCreateVenueContainer` 변이 훅을 추가하고, 전용 `VenueCreateSheet`(SheetModal)와 두 진입점(빈 상태 버튼 / 선택기 "+ 운영처 추가")을 붙인다.
+
+**Tech Stack:** React Native(Expo) · TypeScript(strict) · NativeWind · TanStack Query(useMutation) · Jest + @testing-library/react-native · Supabase RPC.
+
+## Global Constraints
+
+- 언어: 주석·커밋·UI 카피 **한글**.
+- 아키텍처: 그리드 **쓰기 변이는 Repository 직접호출 금지** — `gridWriteService`(Service) 경유 필수.
+- 변이 훅은 **mutation only** — 토스트/낙관 UI는 호출부(컴포넌트) 책임.
+- v1 범위: **생성만, 이름만, `kind='dated'` 고정**. 이름변경/삭제·kind 토글·기간(period)은 범위 밖.
+- 이름 XSS 검증(S1)·워크스페이스 권한 게이트·get-or-create 멱등은 **레포/RPC 경계가 담당**(클라에서 중복 검증하지 않음).
+- 다크모드: 색상은 토큰 리터럴 클래스(`text-content-*`, `border-primary-*` 등), 동적 className 금지.
+- onSuccess 무효화 키: `queryKeys.weeklyGrid.all`(prefix 일괄, 기존 그리드 변이 훅과 일관).
+- 커밋 메시지 끝: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- 테스트 실행: `npx jest <패턴>` · 최종 게이트 `npm run quality`(작업 디렉토리 `uniqn-mobile/`).
+
+---
+
+### Task 1: Service + 생성 변이 훅 (`useCreateVenueContainer`)
+
+**Files:**
+- Modify: `uniqn-mobile/src/services/weeklyGrid/gridWriteService.ts`
+- Create: `uniqn-mobile/src/hooks/weeklyGrid/useCreateVenueContainer.ts`
+- Modify: `uniqn-mobile/src/hooks/weeklyGrid/index.ts` (배럴 export)
+- Test: `uniqn-mobile/src/hooks/weeklyGrid/__tests__/useCreateVenueContainer.test.ts`
+
+**Interfaces:**
+- Consumes: `jobPostingRepository.getOrCreateVenueContainer(workspaceId: string, options: { name: string; kind: string; period?: string }): Promise<VenueContainer>` (from `@/repositories`), `queryKeys.weeklyGrid.all` (from `@/lib/queryClient`).
+- Produces:
+  - `createVenueContainer(workspaceId: string, name: string): Promise<VenueContainer>` (gridWriteService).
+  - `useCreateVenueContainer(workspaceId: string | undefined)` → TanStack mutation. `mutate(name: string, { onSuccess?: (c: VenueContainer) => void; onError?: (e: unknown) => void })`. `isPending: boolean`.
+  - `VenueContainer` type (from `@/domains/weeklyGrid`): `{ id: string; name: string; workspaceId: string; ownerId: string | null; venueId: string | null; kind: string; softTargets: Record<string, number> }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `uniqn-mobile/src/hooks/weeklyGrid/__tests__/useCreateVenueContainer.test.ts`:
+
+```tsx
+/**
+ * useCreateVenueContainer — 운영처 컨테이너 생성 변이 훅 테스트
+ *
+ * (1) 이름을 kind='dated' 로 레포 getOrCreateVenueContainer 에 위임,
+ * (2) 성공 시 weeklyGrid 쿼리 일괄 invalidate, (3) workspaceId 부재 시 레포 미호출+에러.
+ * 토스트는 호출부 책임이라 훅에서 검증하지 않는다(mutation only).
+ */
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/queryClient';
+import { jobPostingRepository } from '@/repositories';
+import { useCreateVenueContainer } from '../useCreateVenueContainer';
+
+jest.mock('@tanstack/react-query', () => jest.requireActual('@tanstack/react-query'));
+
+jest.mock('@/repositories', () => ({
+  jobPostingRepository: { getOrCreateVenueContainer: jest.fn() },
+}));
+
+// gridWriteService 가 모듈 로드 시 import 하는 sibling 레포 — 실제 supabase 체인 로드 회피용 스텁.
+jest.mock('@/repositories/weeklyGrid', () => ({ weeklyGridRepository: {} }));
+
+const mockCreate = jobPostingRepository.getOrCreateVenueContainer as jest.Mock;
+
+const FAKE_VENUE = {
+  id: 'venue-1',
+  name: '강남 홀덤펍',
+  workspaceId: 'ws-1',
+  ownerId: 'owner-1',
+  venueId: 'venue-1',
+  kind: 'dated',
+  softTargets: {},
+};
+
+function createClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function createWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useCreateVenueContainer', () => {
+  beforeEach(() => mockCreate.mockReset());
+
+  it('이름을 kind=dated 로 레포에 위임', async () => {
+    mockCreate.mockResolvedValueOnce(FAKE_VENUE);
+    const client = createClient();
+    const { result } = renderHook(() => useCreateVenueContainer('ws-1'), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync('강남 홀덤펍');
+    });
+
+    expect(mockCreate).toHaveBeenCalledWith('ws-1', { name: '강남 홀덤펍', kind: 'dated' });
+  });
+
+  it('성공 시 weeklyGrid 관련 쿼리를 일괄 invalidate', async () => {
+    mockCreate.mockResolvedValueOnce(FAKE_VENUE);
+    const client = createClient();
+    const invalidateSpy = jest.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useCreateVenueContainer('ws-1'), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync('강남 홀덤펍');
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.weeklyGrid.all });
+  });
+
+  it('workspaceId 부재 시 레포 미호출 + 에러', async () => {
+    const client = createClient();
+    const { result } = renderHook(() => useCreateVenueContainer(undefined), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync('강남 홀덤펍').catch(() => {});
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd uniqn-mobile && npx jest useCreateVenueContainer`
+Expected: FAIL — `Cannot find module '../useCreateVenueContainer'`.
+
+- [ ] **Step 3: Add the service function**
+
+Modify `uniqn-mobile/src/services/weeklyGrid/gridWriteService.ts` — add import + function (after the existing `updateSlot`):
+
+```ts
+import { jobPostingRepository } from '@/repositories';
+import type { VenueContainer } from '@/domains/weeklyGrid';
+```
+
+```ts
+/**
+ * 운영처 컨테이너 생성(get-or-create, 멱등). 이름 XSS 검증(S1)·워크스페이스 권한 게이트는
+ * 레포/RPC 경계가 담당. v1 은 kind='dated' 고정(날짜 기반 그리드 전제).
+ */
+export function createVenueContainer(workspaceId: string, name: string): Promise<VenueContainer> {
+  return jobPostingRepository.getOrCreateVenueContainer(workspaceId, { name, kind: 'dated' });
+}
+```
+
+- [ ] **Step 4: Create the hook**
+
+Create `uniqn-mobile/src/hooks/weeklyGrid/useCreateVenueContainer.ts`:
+
+```ts
+/**
+ * useCreateVenueContainer — 운영처 컨테이너 생성 변이 훅(TanStack useMutation).
+ *
+ * mutationFn 은 Service(gridWriteService.createVenueContainer) 경유(아키텍처 Hook→Service→Repository).
+ * 이름 XSS 검증(S1)·워크스페이스 권한 게이트·get-or-create 멱등은 레포/RPC 경계가 담당.
+ * onSuccess: weeklyGrid prefix 일괄 invalidate → useVenueContainers(목록) 재조회.
+ * 토스트/낙관 UI 는 호출부 책임(훅은 변이만). workspaceId 부재 시 변이는 거부(레포 미호출).
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/queryClient';
+import { createVenueContainer } from '@/services/weeklyGrid/gridWriteService';
+
+export function useCreateVenueContainer(workspaceId: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (name: string) => {
+      if (!workspaceId) {
+        return Promise.reject(new Error('WORKSPACE_REQUIRED'));
+      }
+      return createVenueContainer(workspaceId, name);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.weeklyGrid.all });
+    },
+  });
+}
+
+export default useCreateVenueContainer;
+```
+
+- [ ] **Step 5: Export the hook from the barrel**
+
+Modify `uniqn-mobile/src/hooks/weeklyGrid/index.ts` — add:
+
+```ts
+export { useCreateVenueContainer } from './useCreateVenueContainer';
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd uniqn-mobile && npx jest useCreateVenueContainer`
+Expected: PASS (3 passed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add uniqn-mobile/src/services/weeklyGrid/gridWriteService.ts \
+        uniqn-mobile/src/hooks/weeklyGrid/useCreateVenueContainer.ts \
+        uniqn-mobile/src/hooks/weeklyGrid/index.ts \
+        uniqn-mobile/src/hooks/weeklyGrid/__tests__/useCreateVenueContainer.test.ts
+git commit -m "feat(grid): 운영처 생성 변이 훅 + Service 경계(useCreateVenueContainer)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: 운영처 생성 시트 (`VenueCreateSheet`)
+
+**Files:**
+- Create: `uniqn-mobile/src/components/weeklyGrid/VenueCreateSheet.tsx`
+- Modify: `uniqn-mobile/src/components/weeklyGrid/index.ts` (배럴 export)
+- Test: `uniqn-mobile/src/components/weeklyGrid/__tests__/VenueCreateSheet.test.tsx`
+
+**Interfaces:**
+- Consumes: `useCreateVenueContainer(workspaceId)` (Task 1), `SheetModal` (`@/components/ui/SheetModal`), `Input` (`@/components/ui/Input`), `Button` (`@/components/ui/Button`), `useToastStore` (`@/stores/toastStore`, selector `s.success`/`s.error`), `isAppError` (`@/errors`).
+- Produces: `VenueCreateSheet` 컴포넌트. Props: `{ visible: boolean; workspaceId: string | undefined; onClose: () => void; onCreated: (container: VenueContainer) => void }`. 제출 버튼 a11y 라벨 = `"운영처 만들기"`, 이름 입력 라벨 = `"운영처 이름"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `uniqn-mobile/src/components/weeklyGrid/__tests__/VenueCreateSheet.test.tsx`:
+
+```tsx
+/**
+ * VenueCreateSheet — 운영처 생성 시트 테스트
+ *
+ * SheetModal(reanimated)은 가벼운 children+footer 렌더로 모킹하고, 변이 훅을 모킹해
+ * (1) 이름 입력 후 제출이 trim 된 이름으로 mutate 호출, (2) 빈 이름은 제출 비활성을 검증한다.
+ */
+import { render, fireEvent } from '@testing-library/react-native';
+import React from 'react';
+import { VenueCreateSheet } from '../VenueCreateSheet';
+import { useCreateVenueContainer } from '@/hooks/weeklyGrid';
+import { useToastStore } from '@/stores/toastStore';
+
+// 무거운 의존(SheetModal=RNModal+reanimated) 모킹: visible 일 때 children+footer 만 렌더
+jest.mock('@/components/ui/SheetModal', () => {
+  const { View } = require('react-native');
+  return {
+    SheetModal: ({ visible, children, footer }: any) =>
+      visible ? (
+        <View>
+          {children}
+          {footer}
+        </View>
+      ) : null,
+  };
+});
+
+jest.mock('@/hooks/weeklyGrid', () => ({ useCreateVenueContainer: jest.fn() }));
+jest.mock('@/stores/toastStore', () => ({ useToastStore: jest.fn() }));
+
+const mockUseCreate = useCreateVenueContainer as unknown as jest.Mock;
+const mockUseToast = useToastStore as unknown as jest.Mock;
+
+beforeEach(() => {
+  mockUseToast.mockImplementation((sel: any) =>
+    sel({ success: jest.fn(), error: jest.fn(), info: jest.fn() })
+  );
+});
+
+it('이름 입력 후 제출 시 trim 된 이름으로 mutate 호출', () => {
+  const mutate = jest.fn();
+  mockUseCreate.mockReturnValue({ mutate, isPending: false });
+
+  const { getByLabelText } = render(
+    <VenueCreateSheet visible workspaceId="ws-1" onClose={jest.fn()} onCreated={jest.fn()} />
+  );
+
+  fireEvent.changeText(getByLabelText('운영처 이름'), '  강남 홀덤펍  ');
+  fireEvent.press(getByLabelText('운영처 만들기'));
+
+  expect(mutate).toHaveBeenCalledTimes(1);
+  expect(mutate.mock.calls[0][0]).toBe('강남 홀덤펍');
+});
+
+it('빈 이름이면 제출 버튼 비활성(미호출)', () => {
+  const mutate = jest.fn();
+  mockUseCreate.mockReturnValue({ mutate, isPending: false });
+
+  const { getByLabelText } = render(
+    <VenueCreateSheet visible workspaceId="ws-1" onClose={jest.fn()} onCreated={jest.fn()} />
+  );
+
+  fireEvent.press(getByLabelText('운영처 만들기'));
+  expect(mutate).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd uniqn-mobile && npx jest VenueCreateSheet`
+Expected: FAIL — `Cannot find module '../VenueCreateSheet'`.
+
+- [ ] **Step 3: Create the component**
+
+Create `uniqn-mobile/src/components/weeklyGrid/VenueCreateSheet.tsx`:
+
+```tsx
+/**
+ * VenueCreateSheet — 운영처(컨테이너) 생성 시트.
+ *
+ * 빈 상태 버튼 / 선택기 "+ 운영처 추가" 두 진입점이 공유하는 단일 컴포넌트.
+ * v1: 이름만 입력(kind='dated' 고정). 제출 → useCreateVenueContainer → get-or-create(멱등).
+ * 성공 시 onCreated(c) + 닫기. 토스트는 이 컴포넌트(호출부) 책임. 닫힐 때 입력 초기화.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { View } from 'react-native';
+import { SheetModal } from '@/components/ui/SheetModal';
+import { Input } from '@/components/ui/Input';
+import { Button } from '@/components/ui/Button';
+import { useToastStore } from '@/stores/toastStore';
+import { useCreateVenueContainer } from '@/hooks/weeklyGrid';
+import { isAppError } from '@/errors';
+import type { VenueContainer } from '@/domains/weeklyGrid';
+
+export interface VenueCreateSheetProps {
+  visible: boolean;
+  workspaceId: string | undefined;
+  onClose: () => void;
+  onCreated: (container: VenueContainer) => void;
+}
+
+export function VenueCreateSheet({
+  visible,
+  workspaceId,
+  onClose,
+  onCreated,
+}: VenueCreateSheetProps) {
+  const [name, setName] = useState('');
+  const create = useCreateVenueContainer(workspaceId);
+  const toastSuccess = useToastStore((s) => s.success);
+  const toastError = useToastStore((s) => s.error);
+
+  // 닫힐 때 입력 초기화(재오픈 시 이전 값 잔존 방지).
+  useEffect(() => {
+    if (!visible) setName('');
+  }, [visible]);
+
+  const trimmed = name.trim();
+  const canSubmit = trimmed.length > 0 && !!workspaceId && !create.isPending;
+
+  const handleSubmit = useCallback(() => {
+    const value = name.trim();
+    if (!value || !workspaceId || create.isPending) return;
+    create.mutate(value, {
+      onSuccess: (container) => {
+        toastSuccess('운영처를 만들었어요.');
+        onCreated(container);
+      },
+      onError: (err) => {
+        const msg =
+          isAppError(err) && err.userMessage ? err.userMessage : '운영처 생성에 실패했어요.';
+        toastError(msg);
+      },
+    });
+  }, [name, workspaceId, create, toastSuccess, toastError, onCreated]);
+
+  const footer = (
+    <View className="flex-row gap-2 p-4">
+      <Button variant="outline" onPress={onClose} className="flex-1" accessibilityLabel="취소">
+        취소
+      </Button>
+      <Button
+        variant="primary"
+        onPress={handleSubmit}
+        disabled={!canSubmit}
+        loading={create.isPending}
+        className="flex-1"
+        accessibilityLabel="운영처 만들기"
+      >
+        만들기
+      </Button>
+    </View>
+  );
+
+  return (
+    <SheetModal
+      visible={visible}
+      onClose={onClose}
+      title="운영처 만들기"
+      isLoading={create.isPending}
+      footer={footer}
+    >
+      <View className="p-5">
+        <Input
+          label="운영처 이름"
+          value={name}
+          onChangeText={setName}
+          placeholder="예: 강남 홀덤펍"
+          onSubmitEditing={handleSubmit}
+          returnKeyType="done"
+          maxLength={40}
+        />
+      </View>
+    </SheetModal>
+  );
+}
+
+export default VenueCreateSheet;
+```
+
+- [ ] **Step 4: Export from the barrel**
+
+Modify `uniqn-mobile/src/components/weeklyGrid/index.ts` — add (alongside existing exports):
+
+```ts
+export { VenueCreateSheet } from './VenueCreateSheet';
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd uniqn-mobile && npx jest VenueCreateSheet`
+Expected: PASS (2 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add uniqn-mobile/src/components/weeklyGrid/VenueCreateSheet.tsx \
+        uniqn-mobile/src/components/weeklyGrid/index.ts \
+        uniqn-mobile/src/components/weeklyGrid/__tests__/VenueCreateSheet.test.tsx
+git commit -m "feat(grid): 운영처 생성 시트 VenueCreateSheet(이름 입력·SheetModal)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: 선택기 "+ 운영처 추가" 진입점 (`VenueSelector`)
+
+**Files:**
+- Modify: `uniqn-mobile/src/components/weeklyGrid/VenueSelector.tsx`
+- Test: `uniqn-mobile/src/components/weeklyGrid/__tests__/VenueSelector.test.tsx`
+
+**Interfaces:**
+- Consumes: 기존 `VenueSelectorProps` + 신규 `onAddVenue?: () => void`.
+- Produces: `onAddVenue` 제공 시 운영처 칩 줄 끝(0개일 때는 "없어요" 텍스트 옆)에 a11y 라벨 `"운영처 추가"` 버튼 노출. 누르면 `onAddVenue()` 호출.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `uniqn-mobile/src/components/weeklyGrid/__tests__/VenueSelector.test.tsx`:
+
+```tsx
+/**
+ * VenueSelector — "+ 운영처 추가" 진입점 테스트
+ *
+ * onAddVenue 제공 시 운영처 0개/N개 모두에서 "운영처 추가" 버튼이 노출되고
+ * 누르면 콜백이 호출되는지 검증(순수 표현 컴포넌트).
+ */
+import { render, fireEvent } from '@testing-library/react-native';
+import React from 'react';
+import { VenueSelector } from '../VenueSelector';
+
+const NOOP = () => {};
+
+function renderSelector(overrides: Partial<React.ComponentProps<typeof VenueSelector>> = {}) {
+  return render(
+    <VenueSelector
+      workspaces={[{ id: 'ws-1', name: '워크스페이스' } as never]}
+      activeWorkspaceId="ws-1"
+      onSelectWorkspace={NOOP}
+      containers={[]}
+      selectedVenueId={null}
+      onSelectVenue={NOOP}
+      {...overrides}
+    />
+  );
+}
+
+it('운영처 0개에서도 onAddVenue 제공 시 추가 버튼 노출 + 콜백 호출', () => {
+  const onAddVenue = jest.fn();
+  const { getByLabelText } = renderSelector({ onAddVenue });
+  fireEvent.press(getByLabelText('운영처 추가'));
+  expect(onAddVenue).toHaveBeenCalledTimes(1);
+});
+
+it('onAddVenue 미제공 시 추가 버튼 미노출', () => {
+  const { queryByLabelText } = renderSelector();
+  expect(queryByLabelText('운영처 추가')).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd uniqn-mobile && npx jest VenueSelector`
+Expected: FAIL — `Unable to find ... "운영처 추가"`.
+
+- [ ] **Step 3: Add `onAddVenue` to props**
+
+Modify `uniqn-mobile/src/components/weeklyGrid/VenueSelector.tsx` — extend the props interface:
+
+```ts
+export interface VenueSelectorProps {
+  workspaces: Workspace[];
+  activeWorkspaceId: string | undefined;
+  onSelectWorkspace: (id: string) => void;
+  containers: VenueContainer[];
+  selectedVenueId: string | null;
+  onSelectVenue: (id: string) => void;
+  isLoadingContainers?: boolean;
+  /** 제공 시 운영처 칩 줄에 "+ 운영처 추가" 진입점 노출. */
+  onAddVenue?: () => void;
+}
+```
+
+And add `onAddVenue` to the destructured params:
+
+```ts
+export function VenueSelector({
+  workspaces,
+  activeWorkspaceId,
+  onSelectWorkspace,
+  containers,
+  selectedVenueId,
+  onSelectVenue,
+  isLoadingContainers = false,
+  onAddVenue,
+}: VenueSelectorProps) {
+```
+
+- [ ] **Step 4: Replace the venue-section render branch**
+
+In `VenueSelector.tsx`, replace the whole `{isLoadingContainers ? (...) : containers.length === 0 ? (...) : (...)}` block (the loading / empty / chips ternary under the `운영처` label) with a single ScrollView that always appends the add affordance:
+
+```tsx
+      {isLoadingContainers ? (
+        <View className="h-10 flex-row items-center">
+          <ActivityIndicator size="small" />
+          <Text className="ml-2 text-sm text-content-secondary">운영처 불러오는 중…</Text>
+        </View>
+      ) : (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{ paddingRight: 8, alignItems: 'center' }}
+        >
+          {containers.length === 0 ? (
+            <View className="mr-2 h-10 justify-center">
+              <Text className="text-sm text-content-secondary">
+                이 워크스페이스에 등록된 운영처가 없어요
+              </Text>
+            </View>
+          ) : (
+            containers.map((c) => (
+              <Chip
+                key={c.id}
+                label={c.name}
+                selected={c.id === selectedVenueId}
+                onPress={handleSelectVenue(c.id)}
+                a11yLabel={`운영처 ${c.name}`}
+              />
+            ))
+          )}
+          {onAddVenue ? (
+            <Pressable
+              onPress={onAddVenue}
+              accessibilityRole="button"
+              accessibilityLabel="운영처 추가"
+              className="min-h-[40px] flex-row items-center justify-center rounded-full border border-dashed border-primary-400 px-4 py-2"
+            >
+              <Text className="text-sm font-sans-medium text-primary-500">+ 운영처 추가</Text>
+            </Pressable>
+          ) : null}
+        </ScrollView>
+      )}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd uniqn-mobile && npx jest VenueSelector`
+Expected: PASS (2 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add uniqn-mobile/src/components/weeklyGrid/VenueSelector.tsx \
+        uniqn-mobile/src/components/weeklyGrid/__tests__/VenueSelector.test.tsx
+git commit -m "feat(grid): 운영처 선택기에 '+ 운영처 추가' 진입점(onAddVenue)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: 그리드 화면 배선 + 품질 게이트 (`weekly-grid.tsx`)
+
+**Files:**
+- Modify: `uniqn-mobile/app/(employer)/weekly-grid.tsx`
+
+**Interfaces:**
+- Consumes: `VenueCreateSheet` (Task 2), `VenueSelector onAddVenue` (Task 3). 화면이 두 진입점(빈 상태 버튼 / 선택기 칩)에서 동일한 `VenueCreateSheet` 를 열고, 생성 성공 시 새 운영처를 선택한다.
+- Produces: 화면 통합(신규 인터페이스 없음). 본 작업으로 운영처 0개 워크스페이스에서 그리드가 막다른 길이 아니게 된다.
+
+- [ ] **Step 1: Import the sheet**
+
+Modify `uniqn-mobile/app/(employer)/weekly-grid.tsx` — extend the weeklyGrid components import (line 37):
+
+```ts
+import { VenueSelector, VenueDayPanel, VenueCreateSheet } from '@/components/weeklyGrid';
+```
+
+- [ ] **Step 2: Add sheet visibility state**
+
+After the `selectedDate` state (line 91), add:
+
+```ts
+  const [createSheetVisible, setCreateSheetVisible] = useState(false);
+```
+
+- [ ] **Step 3: Wire the VenueSelector "+ 추가" entry point**
+
+In the `<VenueSelector ... />` usage (around line 184-192), add the `onAddVenue` prop:
+
+```tsx
+      <VenueSelector
+        workspaces={workspaces}
+        activeWorkspaceId={activeWorkspace?.id}
+        onSelectWorkspace={setActiveWorkspaceId}
+        containers={containers}
+        selectedVenueId={selectedVenueId}
+        onSelectVenue={setSelectedVenueId}
+        isLoadingContainers={wsLoading || containersQuery.isLoading}
+        onAddVenue={() => setCreateSheetVisible(true)}
+      />
+```
+
+- [ ] **Step 4: Wire the empty-state button**
+
+In the empty-state `<EmptyState ... />` (around line 200-204), add `actionLabel` + `onAction`:
+
+```tsx
+            <EmptyState
+              icon={<MapPinIcon size={48} color={SECONDARY_PALETTE[400]} />}
+              title="운영처가 없어요"
+              description="이 워크스페이스에 운영처(상시 배치 장소)를 먼저 만들어주세요."
+              actionLabel="운영처 만들기"
+              onAction={() => setCreateSheetVisible(true)}
+            />
+```
+
+- [ ] **Step 5: Render the sheet**
+
+Immediately before the closing `</SafeAreaView>` (line 297), add:
+
+```tsx
+      <VenueCreateSheet
+        visible={createSheetVisible}
+        workspaceId={activeWorkspace?.id}
+        onClose={() => setCreateSheetVisible(false)}
+        onCreated={(container) => {
+          setSelectedVenueId(container.id);
+          setCreateSheetVisible(false);
+        }}
+      />
+```
+
+- [ ] **Step 6: Type-check + lint + format gate**
+
+Run: `cd uniqn-mobile && npm run quality`
+Expected: EXIT 0 (tsc 0 errors, eslint 0 errors, prettier clean). If prettier flags formatting, run `npx prettier --write` on the changed files and re-run.
+
+- [ ] **Step 7: Run the full weeklyGrid test suite**
+
+Run: `cd uniqn-mobile && npx jest weeklyGrid`
+Expected: PASS — existing grid suites + new `useCreateVenueContainer`, `VenueCreateSheet`, `VenueSelector` tests all green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add "uniqn-mobile/app/(employer)/weekly-grid.tsx"
+git commit -m "feat(grid): 운영처 생성 진입점 배선 — 빈상태 버튼 + 선택기 '+ 추가'
+
+운영처 0개 워크스페이스에서 그리드 막다른 길 해소(QA 적발 출하차단 결함).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## 검증 (전체 완료 후)
+
+- [ ] `cd uniqn-mobile && npm run quality` — EXIT 0.
+- [ ] `cd uniqn-mobile && npx jest weeklyGrid` — 신규 3 테스트 포함 전부 PASS.
+- [ ] 수동(웹 dev 빌드, 로컬 플래그 ON): 운영처 0개 → 빈 상태 "운영처 만들기"/선택기 "+ 운영처 추가" → 이름 입력 → 만들기 → 새 운영처 자동 선택 + 그리드 진입. 같은 이름 재생성 시 중복 안 생김(멱등). 빈 이름 제출 비활성. 다크모드 색상 정상.
+
+## 범위 밖 (후속 — 본 계획에서 구현하지 않음)
+
+- 운영처 이름변경 / 삭제(soft delete).
+- kind 토글(상시/대회) · 대회 기간(period) 입력.
+- 운영처 정렬/검색.

--- a/docs/superpowers/specs/2026-07-01-venue-create-ui-design.md
+++ b/docs/superpowers/specs/2026-07-01-venue-create-ui-design.md
@@ -1,0 +1,94 @@
+# 설계 — 운영처(venue) 생성 UI
+
+> 작성일: 2026-07-01 · 브랜치: `feat/venue-create-ui`(origin/master 기준) · 워크트리: `T-HOLDEM-weekly-grid`
+
+## 1. 배경 / 문제
+
+주간 배치 그리드(PR #219, 플래그 `weekly_grid_enabled` OFF)의 **QA 중 발견한 출하 차단 결함**: 운영처(venue)를 **만드는 UI가 앱에 없다.**
+
+- 운영처가 0개인 새 워크스페이스(=실제 운영자 첫 상태)에서 그리드 빈 상태는 "운영처를 먼저 만들어주세요"라고 안내하지만, **만들 수 있는 버튼·입력·경로가 어디에도 없다.**
+- 운영처가 없으면 그리드의 모든 다운스트림(스태프 추가·슬롯 편집·소프트타깃·QR·정산·지난주 복사)이 불가 → 기능 전체가 막다른 길.
+- 백엔드는 완성·검증됨. 생성 RPC `get_or_create_venue_container`는 `apply_migration`으로 PROD/로컬 적용 완료이고, repository 메서드 `getOrCreateVenueContainer(workspaceId, { name, kind, period? })`가 **XSS 검증(`venueContainerNameSchema.refine(xssValidation)`)까지 포함**해 구현돼 있다. **호출하는 UI 배선만 누락**됐다.
+
+근거(코드 실측):
+- `VenueSelector`의 props에 생성 콜백 없음, "0개면 안내 텍스트"만.
+- `weekly-grid.tsx` 빈 상태는 `EmptyState`(제목/설명)만, 액션 없음.
+- `getOrCreateVenueContainer` 호출자 = repository 메서드 정의(`JobPostingRepository.ts`)뿐, **훅·서비스·화면 0건**.
+- QA에서 로컬 DB에 RPC를 직접 호출해 운영처 1개를 시드하자 나머지 흐름(그리드·스태프 추가·시간 피커·슬롯 편집·소프트타깃)은 **정상 동작 확인** → 결함은 **생성 UI 배선만**.
+
+## 2. 목표 / 비목표
+
+**목표 (v1)**
+- 운영자가 주간 그리드 화면에서 **첫 운영처 및 추가 운영처를 생성**할 수 있다.
+- 생성 즉시 목록 갱신 + 새 운영처 자동 선택.
+
+**비목표 (후속)**
+- 운영처 이름변경 / 삭제(soft delete) 등 관리 기능.
+- 생성 폼의 종류(kind dated/fixed) 토글, 대회 기간(period) 입력. → v1은 **이름만, `kind='dated'` 고정**. 주간 그리드는 날짜 기반 캘린더라 `dated`가 코어 동작의 전제이며, 대회사도 대회 날짜에 인원을 꽂으면 같은 dated 그리드로 운영된다. 종류/기간 분기는 구체적 대회사 요구가 생기면 도입.
+
+## 3. 결정 / 접근법
+
+채택: **전용 생성 시트(`VenueCreateSheet`) + 단일 컴포넌트로 두 진입점 공유.**
+
+| 접근법 | 평가 | 판정 |
+|---|---|---|
+| **1. 전용 생성 시트 `VenueCreateSheet`** | 앱의 모달 기반 생성 컨벤션·다크모드·키보드 일관. 두 진입점(빈 상태/선택기)이 단일 컴포넌트 공유(유지보수 1곳) | ✅ **채택** |
+| 2. 인라인 입력 | 파일 최소이나 인라인 입력이 두 군데라 중복·앱 컨벤션과 덜 일관 | ❌ |
+| 3. 범용 프롬프트 모달 | 향후 rename/delete 재사용 가치이나 지금 쓰는 곳 1개 → YAGNI 위반 | ❌ |
+
+## 4. 구성 단위 (파일)
+
+| # | 파일 | 변경 | 역할 / 인터페이스 | 의존 |
+|---|---|---|---|---|
+| 1 | `src/hooks/weeklyGrid/useCreateVenueContainer.ts` | 신규 | `useCreateVenueContainer(workspaceId)` → `useMutation`. `mutationFn: (name) => jobPostingRepository.getOrCreateVenueContainer(workspaceId, { name, kind: 'dated' })`. `onSuccess: invalidateQueries(queryKeys.weeklyGrid.containers(workspaceId))`. 반환: `VenueContainer`. `useCreateWorkspace` 미러 | repository, queryKeys |
+| 2 | `src/components/weeklyGrid/VenueCreateSheet.tsx` | 신규 | `SheetModal`(title "운영처 만들기") + 이름 `TextInput` + footer(취소/만들기). 로컬 name 상태, 제출 시 훅 `mutateAsync(name)`, 성공 시 `onCreated(container)` 콜백 + 닫기. 빈 이름 제출 비활성, `isLoading`/다크모드. ≤120줄 | SheetModal, 훅#1 |
+| 3 | `src/components/weeklyGrid/VenueSelector.tsx` | 수정 | 컨테이너 칩 줄 끝에 "+ 운영처 추가" 칩 추가 + `onAddVenue?: () => void` prop. 이 칩은 **항상 노출**(0개일 때 "없어요" 안내와 함께). VenueSelector는 화면 상단에 항상 렌더되므로(weekly-grid.tsx:184) 운영처가 있든 없든 추가 진입점이 됨 | — |
+| 4 | `app/(employer)/weekly-grid.tsx` | 수정 | `createSheetVisible` 상태; 빈 상태 `EmptyState`에 `actionLabel="운영처 만들기"` + onAction → 시트 열기; `<VenueCreateSheet>` 렌더; `VenueSelector`에 `onAddVenue` 연결; `onCreated(c)` → `setSelectedVenueId(c.id)`. (0개일 때 선택기 칩 + 빈 상태 버튼 둘 다 노출되나 동일 시트를 열어 무해) | 컴포넌트#2·#3 |
+| 5 | `src/components/weeklyGrid/index.ts` | 수정 | `VenueCreateSheet` export | — |
+| 6 | `src/hooks/weeklyGrid/__tests__/useCreateVenueContainer.test.ts` | 신규 | 훅이 `kind:'dated'`로 repo 호출·성공 시 invalidate 검증 | — |
+| 7 | `src/components/weeklyGrid/__tests__/VenueCreateSheet.test.tsx` | 신규 | 이름 입력→제출→mutation 호출; 빈 이름 제출 비활성 | — |
+
+## 5. 데이터 흐름
+
+```
+운영자
+  └ "운영처 만들기"(빈 상태) 또는 "+ 운영처 추가"(VenueSelector) 탭
+      └ VenueCreateSheet 열림 → 이름 입력 → [만들기]
+          └ useCreateVenueContainer.mutateAsync(name)
+              └ jobPostingRepository.getOrCreateVenueContainer(workspaceId, { name, kind:'dated' })
+                  ├ S1: venueContainerNameSchema(XSS 검증) — 실패 시 ValidationError, RPC 미호출
+                  └ rpc('get_or_create_venue_container', { p_workspace_id, p_name, p_kind:'dated' })  ← SECDEF + 워크스페이스 게이트 + ON CONFLICT 멱등
+                      └ VenueContainer 반환
+                          └ onSuccess: invalidate queryKeys.weeklyGrid.containers(workspaceId)
+                              └ useVenueContainers 재조회 → 새 운영처 목록 반영
+                                  └ onCreated(c) → setSelectedVenueId(c.id) + 성공 토스트 + 시트 닫힘
+```
+
+## 6. 에러 처리
+
+| 케이스 | 처리 |
+|---|---|
+| 빈/공백 이름 | 제출 버튼 **비활성(클라)** + repo `INVALID_INPUT`(심층 방어) |
+| 이름 XSS | repo `ValidationError(SECURITY_XSS_DETECTED)` → `toast.error(userMessage)` |
+| 같은 이름 재생성 | **get-or-create 멱등** → 기존 운영처 반환(에러 아님) → 그걸 선택(중복 안 생김) |
+| 네트워크/RPC 실패 | AppError 매핑 → `toast.error` |
+| 권한 없음(비멤버) | RPC가 `FORBIDDEN` → AppError 매핑 → `toast.error` |
+
+## 7. 테스트 (TDD)
+
+- **훅 단위**(`useCreateVenueContainer.test.ts`): repository를 목 → `mutateAsync('강남펍')` 호출 시 `getOrCreateVenueContainer(ws, { name:'강남펍', kind:'dated' })` 호출 검증(RED→GREEN), 성공 시 `invalidateQueries` 호출 검증.
+- **컴포넌트**(`VenueCreateSheet.test.tsx`): 이름 입력 후 제출 → 훅 mutate 호출; 빈 이름이면 제출 버튼 disabled.
+- 기존 `src/components/weeklyGrid/__tests__` / `src/hooks/weeklyGrid/__tests__` 패턴 준수.
+- `npm run quality`(type-check+lint+format) EXIT0 + 영향 jest 스위트 통과.
+
+## 8. 출하 / 배포
+
+- 본 변경은 **JS만**(네이티브 무변경) → 신규 RPC·마이그 없음(이미 적용됨). 추가 PROD 마이그 **불필요**.
+- 플래그 `weekly_grid_enabled`는 이 UI가 들어간 뒤에야 ON 검토(이 결함이 ON 차단 사유였음).
+- 후속 핸드오프 문서(QA)에서 "운영처 생성 불가" 차단 항목 해소로 갱신.
+
+## 9. 범위 밖 (명시적 후속)
+
+- 운영처 이름변경 / 삭제(관리 화면).
+- kind 토글(상시/대회) · 대회 기간(period) 입력.
+- 다중 운영처 정렬/검색(현재 칩 줄로 충분).

--- a/uniqn-mobile/app/(employer)/weekly-grid.tsx
+++ b/uniqn-mobile/app/(employer)/weekly-grid.tsx
@@ -34,7 +34,7 @@ import {
   BellIcon,
 } from '@/components/icons';
 import { CalendarGrid } from '@/components/jobs/DateCalendar/CalendarGrid';
-import { VenueSelector, VenueDayPanel } from '@/components/weeklyGrid';
+import { VenueSelector, VenueDayPanel, VenueCreateSheet } from '@/components/weeklyGrid';
 import { useWeeklyGridEnabled } from '@/hooks';
 import { useActiveWorkspace } from '@/hooks/workspace';
 import {
@@ -89,6 +89,7 @@ export default function WeeklyGridScreen() {
   const [selectedVenueId, setSelectedVenueId] = useState<string | null>(null);
   const [visibleMonth, setVisibleMonth] = useState<Date>(() => startOfMonth(new Date()));
   const [selectedDate, setSelectedDate] = useState<Date>(() => new Date());
+  const [createSheetVisible, setCreateSheetVisible] = useState(false);
 
   // 컨테이너 로드/변경 시 선택 venue 자기-치유: 없거나 목록에 없으면 첫 번째로.
   useEffect(() => {
@@ -189,6 +190,7 @@ export default function WeeklyGridScreen() {
         selectedVenueId={selectedVenueId}
         onSelectVenue={setSelectedVenueId}
         isLoadingContainers={wsLoading || containersQuery.isLoading}
+        onAddVenue={() => setCreateSheetVisible(true)}
       />
 
       {/* U4: 운영처 0 — 컨테이너 쿼리가 로딩을 마쳤고(not loading) 컨테이너가 0개일 때만 빈상태.
@@ -201,6 +203,8 @@ export default function WeeklyGridScreen() {
               icon={<MapPinIcon size={48} color={SECONDARY_PALETTE[400]} />}
               title="운영처가 없어요"
               description="이 워크스페이스에 운영처(상시 배치 장소)를 먼저 만들어주세요."
+              actionLabel="운영처 만들기"
+              onAction={() => setCreateSheetVisible(true)}
             />
           ) : (
             <Loading />
@@ -294,6 +298,15 @@ export default function WeeklyGridScreen() {
           </View>
         </View>
       )}
+      <VenueCreateSheet
+        visible={createSheetVisible}
+        workspaceId={activeWorkspace?.id}
+        onClose={() => setCreateSheetVisible(false)}
+        onCreated={(container) => {
+          setSelectedVenueId(container.id);
+          setCreateSheetVisible(false);
+        }}
+      />
     </SafeAreaView>
   );
 }

--- a/uniqn-mobile/src/components/weeklyGrid/VenueCreateSheet.tsx
+++ b/uniqn-mobile/src/components/weeklyGrid/VenueCreateSheet.tsx
@@ -1,0 +1,101 @@
+/**
+ * VenueCreateSheet — 운영처(컨테이너) 생성 시트.
+ *
+ * 빈 상태 버튼 / 선택기 "+ 운영처 추가" 두 진입점이 공유하는 단일 컴포넌트.
+ * v1: 이름만 입력(kind='dated' 고정). 제출 → useCreateVenueContainer → get-or-create(멱등).
+ * 성공 시 onCreated(c) + 닫기. 토스트는 이 컴포넌트(호출부) 책임. 닫힐 때 입력 초기화.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { View } from 'react-native';
+import { SheetModal } from '@/components/ui/SheetModal';
+import { Input } from '@/components/ui/Input';
+import { Button } from '@/components/ui/Button';
+import { useToastStore } from '@/stores/toastStore';
+import { useCreateVenueContainer } from '@/hooks/weeklyGrid';
+import { isAppError } from '@/errors';
+import type { VenueContainer } from '@/domains/weeklyGrid';
+
+export interface VenueCreateSheetProps {
+  visible: boolean;
+  workspaceId: string | undefined;
+  onClose: () => void;
+  onCreated: (container: VenueContainer) => void;
+}
+
+export function VenueCreateSheet({
+  visible,
+  workspaceId,
+  onClose,
+  onCreated,
+}: VenueCreateSheetProps) {
+  const [name, setName] = useState('');
+  const create = useCreateVenueContainer(workspaceId);
+  const toastSuccess = useToastStore((s) => s.success);
+  const toastError = useToastStore((s) => s.error);
+
+  // 닫힐 때 입력 초기화(재오픈 시 이전 값 잔존 방지).
+  useEffect(() => {
+    if (!visible) setName('');
+  }, [visible]);
+
+  const trimmed = name.trim();
+  const canSubmit = trimmed.length > 0 && !!workspaceId && !create.isPending;
+
+  const handleSubmit = useCallback(() => {
+    const value = name.trim();
+    if (!value || !workspaceId || create.isPending) return;
+    create.mutate(value, {
+      onSuccess: (container) => {
+        toastSuccess('운영처를 만들었어요.');
+        onCreated(container);
+      },
+      onError: (err) => {
+        const msg =
+          isAppError(err) && err.userMessage ? err.userMessage : '운영처 생성에 실패했어요.';
+        toastError(msg);
+      },
+    });
+  }, [name, workspaceId, create, toastSuccess, toastError, onCreated]);
+
+  const footer = (
+    <View className="flex-row gap-2 p-4">
+      <Button variant="outline" onPress={onClose} className="flex-1" accessibilityLabel="취소">
+        취소
+      </Button>
+      <Button
+        variant="primary"
+        onPress={handleSubmit}
+        disabled={!canSubmit}
+        loading={create.isPending}
+        className="flex-1"
+        accessibilityLabel="운영처 만들기"
+      >
+        만들기
+      </Button>
+    </View>
+  );
+
+  return (
+    <SheetModal
+      visible={visible}
+      onClose={onClose}
+      title="운영처 만들기"
+      isLoading={create.isPending}
+      footer={footer}
+    >
+      <View className="p-5">
+        <Input
+          label="운영처 이름"
+          value={name}
+          onChangeText={setName}
+          placeholder="예: 강남 홀덤펍"
+          onSubmitEditing={handleSubmit}
+          returnKeyType="done"
+          maxLength={40}
+        />
+      </View>
+    </SheetModal>
+  );
+}
+
+export default VenueCreateSheet;

--- a/uniqn-mobile/src/components/weeklyGrid/VenueCreateSheet.tsx
+++ b/uniqn-mobile/src/components/weeklyGrid/VenueCreateSheet.tsx
@@ -3,7 +3,8 @@
  *
  * 빈 상태 버튼 / 선택기 "+ 운영처 추가" 두 진입점이 공유하는 단일 컴포넌트.
  * v1: 이름만 입력(kind='dated' 고정). 제출 → useCreateVenueContainer → get-or-create(멱등).
- * 성공 시 onCreated(c) + 닫기. 토스트는 이 컴포넌트(호출부) 책임. 닫힐 때 입력 초기화.
+ * 성공 시 onCreated(c) 호출(시트 닫기는 호출부 onCreated 책임). 토스트는 이 컴포넌트(호출부) 책임.
+ * 닫힐 때 입력 초기화.
  */
 import React, { useCallback, useEffect, useState } from 'react';
 import { View } from 'react-native';
@@ -29,7 +30,8 @@ export function VenueCreateSheet({
   onCreated,
 }: VenueCreateSheetProps) {
   const [name, setName] = useState('');
-  const create = useCreateVenueContainer(workspaceId);
+  // mutate 는 안정적 참조, isPending 만 상태 변화 → 콜백/JSX 불필요 재생성 방지 위해 분해.
+  const { mutate, isPending } = useCreateVenueContainer(workspaceId);
   const toastSuccess = useToastStore((s) => s.success);
   const toastError = useToastStore((s) => s.error);
 
@@ -39,12 +41,12 @@ export function VenueCreateSheet({
   }, [visible]);
 
   const trimmed = name.trim();
-  const canSubmit = trimmed.length > 0 && !!workspaceId && !create.isPending;
+  const canSubmit = trimmed.length > 0 && !!workspaceId && !isPending;
 
   const handleSubmit = useCallback(() => {
     const value = name.trim();
-    if (!value || !workspaceId || create.isPending) return;
-    create.mutate(value, {
+    if (!value || !workspaceId || isPending) return;
+    mutate(value, {
       onSuccess: (container) => {
         toastSuccess('운영처를 만들었어요.');
         onCreated(container);
@@ -55,7 +57,7 @@ export function VenueCreateSheet({
         toastError(msg);
       },
     });
-  }, [name, workspaceId, create, toastSuccess, toastError, onCreated]);
+  }, [name, workspaceId, isPending, mutate, toastSuccess, toastError, onCreated]);
 
   const footer = (
     <View className="flex-row gap-2 p-4">
@@ -66,7 +68,7 @@ export function VenueCreateSheet({
         variant="primary"
         onPress={handleSubmit}
         disabled={!canSubmit}
-        loading={create.isPending}
+        loading={isPending}
         className="flex-1"
         accessibilityLabel="운영처 만들기"
       >
@@ -80,7 +82,7 @@ export function VenueCreateSheet({
       visible={visible}
       onClose={onClose}
       title="운영처 만들기"
-      isLoading={create.isPending}
+      isLoading={isPending}
       footer={footer}
     >
       <View className="p-5">

--- a/uniqn-mobile/src/components/weeklyGrid/VenueSelector.tsx
+++ b/uniqn-mobile/src/components/weeklyGrid/VenueSelector.tsx
@@ -22,6 +22,8 @@ export interface VenueSelectorProps {
   selectedVenueId: string | null;
   onSelectVenue: (id: string) => void;
   isLoadingContainers?: boolean;
+  /** 제공 시 운영처 칩 줄에 "+ 운영처 추가" 진입점 노출. */
+  onAddVenue?: () => void;
 }
 
 interface ChipProps {
@@ -64,6 +66,7 @@ export function VenueSelector({
   selectedVenueId,
   onSelectVenue,
   isLoadingContainers = false,
+  onAddVenue,
 }: VenueSelectorProps) {
   const handleSelectWorkspace = useCallback(
     (id: string) => () => onSelectWorkspace(id),
@@ -102,27 +105,39 @@ export function VenueSelector({
           <ActivityIndicator size="small" />
           <Text className="ml-2 text-sm text-content-secondary">운영처 불러오는 중…</Text>
         </View>
-      ) : containers.length === 0 ? (
-        <View className="h-10 justify-center">
-          <Text className="text-sm text-content-secondary">
-            이 워크스페이스에 등록된 운영처가 없어요
-          </Text>
-        </View>
       ) : (
         <ScrollView
           horizontal
           showsHorizontalScrollIndicator={false}
-          contentContainerStyle={{ paddingRight: 8 }}
+          contentContainerStyle={{ paddingRight: 8, alignItems: 'center' }}
         >
-          {containers.map((c) => (
-            <Chip
-              key={c.id}
-              label={c.name}
-              selected={c.id === selectedVenueId}
-              onPress={handleSelectVenue(c.id)}
-              a11yLabel={`운영처 ${c.name}`}
-            />
-          ))}
+          {containers.length === 0 ? (
+            <View className="mr-2 h-10 justify-center">
+              <Text className="text-sm text-content-secondary">
+                이 워크스페이스에 등록된 운영처가 없어요
+              </Text>
+            </View>
+          ) : (
+            containers.map((c) => (
+              <Chip
+                key={c.id}
+                label={c.name}
+                selected={c.id === selectedVenueId}
+                onPress={handleSelectVenue(c.id)}
+                a11yLabel={`운영처 ${c.name}`}
+              />
+            ))
+          )}
+          {onAddVenue ? (
+            <Pressable
+              onPress={onAddVenue}
+              accessibilityRole="button"
+              accessibilityLabel="운영처 추가"
+              className="min-h-[40px] flex-row items-center justify-center rounded-full border border-dashed border-primary-400 px-4 py-2"
+            >
+              <Text className="text-sm font-sans-medium text-primary-500">+ 운영처 추가</Text>
+            </Pressable>
+          ) : null}
         </ScrollView>
       )}
     </View>

--- a/uniqn-mobile/src/components/weeklyGrid/__tests__/VenueCreateSheet.test.tsx
+++ b/uniqn-mobile/src/components/weeklyGrid/__tests__/VenueCreateSheet.test.tsx
@@ -3,12 +3,14 @@
  *
  * SheetModal(reanimated)은 가벼운 children+footer 렌더로 모킹하고, 변이 훅을 모킹해
  * (1) 이름 입력 후 제출이 trim 된 이름으로 mutate 호출, (2) 빈 이름은 제출 비활성을 검증한다.
+ * (3) mutate 콜백 경로: onSuccess → onCreated + 성공 토스트, onError → 에러 토스트.
  */
 import { render, fireEvent } from '@testing-library/react-native';
 import React from 'react';
 import { VenueCreateSheet } from '../VenueCreateSheet';
 import { useCreateVenueContainer } from '@/hooks/weeklyGrid';
 import { useToastStore } from '@/stores/toastStore';
+import type { VenueContainer } from '@/domains/weeklyGrid';
 
 // 무거운 의존(SheetModal=RNModal+reanimated) 모킹: visible 일 때 children+footer 만 렌더
 jest.mock('@/components/ui/SheetModal', () => {
@@ -30,11 +32,28 @@ jest.mock('@/stores/toastStore', () => ({ useToastStore: jest.fn() }));
 const mockUseCreate = useCreateVenueContainer as unknown as jest.Mock;
 const mockUseToast = useToastStore as unknown as jest.Mock;
 
+// 안정적인 토스트 스파이: 테스트 간 참조 가능하도록 모듈 스코프에 선언
+const toastSuccessSpy = jest.fn();
+const toastErrorSpy = jest.fn();
+
 beforeEach(() => {
-  mockUseToast.mockImplementation((sel: any) =>
-    sel({ success: jest.fn(), error: jest.fn(), info: jest.fn() })
+  toastSuccessSpy.mockReset();
+  toastErrorSpy.mockReset();
+  // 셀렉터(s) 가 success/error/info 를 꺼내므로 안정적인 스파이를 반환
+  mockUseToast.mockImplementation((sel: (s: object) => unknown) =>
+    sel({ success: toastSuccessSpy, error: toastErrorSpy, info: jest.fn() })
   );
 });
+
+const FAKE_CONTAINER: VenueContainer = {
+  id: 'venue-new',
+  name: '강남 홀덤펍',
+  workspaceId: 'ws-1',
+  ownerId: null,
+  venueId: 'venue-new',
+  kind: 'dated',
+  softTargets: {},
+};
 
 it('이름 입력 후 제출 시 trim 된 이름으로 mutate 호출', () => {
   const mutate = jest.fn();
@@ -61,4 +80,47 @@ it('빈 이름이면 제출 버튼 비활성(미호출)', () => {
 
   fireEvent.press(getByLabelText('운영처 만들기'));
   expect(mutate).not.toHaveBeenCalled();
+});
+
+it('onSuccess 콜백: onCreated 호출 + 성공 토스트', () => {
+  const mutate = jest.fn();
+  const onCreated = jest.fn();
+  mockUseCreate.mockReturnValue({ mutate, isPending: false });
+
+  const { getByLabelText } = render(
+    <VenueCreateSheet visible workspaceId="ws-1" onClose={jest.fn()} onCreated={onCreated} />
+  );
+
+  fireEvent.changeText(getByLabelText('운영처 이름'), '강남 홀덤펍');
+  fireEvent.press(getByLabelText('운영처 만들기'));
+
+  // mutate 의 2번째 인자(콜백 객체)를 직접 호출해 경로 검증
+  const opts = mutate.mock.calls[0][1] as {
+    onSuccess: (c: VenueContainer) => void;
+    onError: (e: Error) => void;
+  };
+  opts.onSuccess(FAKE_CONTAINER);
+
+  expect(onCreated).toHaveBeenCalledWith(FAKE_CONTAINER);
+  expect(toastSuccessSpy).toHaveBeenCalled();
+});
+
+it('onError 콜백: 에러 토스트 호출', () => {
+  const mutate = jest.fn();
+  mockUseCreate.mockReturnValue({ mutate, isPending: false });
+
+  const { getByLabelText } = render(
+    <VenueCreateSheet visible workspaceId="ws-1" onClose={jest.fn()} onCreated={jest.fn()} />
+  );
+
+  fireEvent.changeText(getByLabelText('운영처 이름'), '강남 홀덤펍');
+  fireEvent.press(getByLabelText('운영처 만들기'));
+
+  const opts = mutate.mock.calls[0][1] as {
+    onSuccess: (c: VenueContainer) => void;
+    onError: (e: Error) => void;
+  };
+  opts.onError(new Error('서버 오류'));
+
+  expect(toastErrorSpy).toHaveBeenCalled();
 });

--- a/uniqn-mobile/src/components/weeklyGrid/__tests__/VenueCreateSheet.test.tsx
+++ b/uniqn-mobile/src/components/weeklyGrid/__tests__/VenueCreateSheet.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * VenueCreateSheet — 운영처 생성 시트 테스트
+ *
+ * SheetModal(reanimated)은 가벼운 children+footer 렌더로 모킹하고, 변이 훅을 모킹해
+ * (1) 이름 입력 후 제출이 trim 된 이름으로 mutate 호출, (2) 빈 이름은 제출 비활성을 검증한다.
+ */
+import { render, fireEvent } from '@testing-library/react-native';
+import React from 'react';
+import { VenueCreateSheet } from '../VenueCreateSheet';
+import { useCreateVenueContainer } from '@/hooks/weeklyGrid';
+import { useToastStore } from '@/stores/toastStore';
+
+// 무거운 의존(SheetModal=RNModal+reanimated) 모킹: visible 일 때 children+footer 만 렌더
+jest.mock('@/components/ui/SheetModal', () => {
+  const { View } = require('react-native');
+  return {
+    SheetModal: ({ visible, children, footer }: any) =>
+      visible ? (
+        <View>
+          {children}
+          {footer}
+        </View>
+      ) : null,
+  };
+});
+
+jest.mock('@/hooks/weeklyGrid', () => ({ useCreateVenueContainer: jest.fn() }));
+jest.mock('@/stores/toastStore', () => ({ useToastStore: jest.fn() }));
+
+const mockUseCreate = useCreateVenueContainer as unknown as jest.Mock;
+const mockUseToast = useToastStore as unknown as jest.Mock;
+
+beforeEach(() => {
+  mockUseToast.mockImplementation((sel: any) =>
+    sel({ success: jest.fn(), error: jest.fn(), info: jest.fn() })
+  );
+});
+
+it('이름 입력 후 제출 시 trim 된 이름으로 mutate 호출', () => {
+  const mutate = jest.fn();
+  mockUseCreate.mockReturnValue({ mutate, isPending: false });
+
+  const { getByLabelText } = render(
+    <VenueCreateSheet visible workspaceId="ws-1" onClose={jest.fn()} onCreated={jest.fn()} />
+  );
+
+  fireEvent.changeText(getByLabelText('운영처 이름'), '  강남 홀덤펍  ');
+  fireEvent.press(getByLabelText('운영처 만들기'));
+
+  expect(mutate).toHaveBeenCalledTimes(1);
+  expect(mutate.mock.calls[0][0]).toBe('강남 홀덤펍');
+});
+
+it('빈 이름이면 제출 버튼 비활성(미호출)', () => {
+  const mutate = jest.fn();
+  mockUseCreate.mockReturnValue({ mutate, isPending: false });
+
+  const { getByLabelText } = render(
+    <VenueCreateSheet visible workspaceId="ws-1" onClose={jest.fn()} onCreated={jest.fn()} />
+  );
+
+  fireEvent.press(getByLabelText('운영처 만들기'));
+  expect(mutate).not.toHaveBeenCalled();
+});

--- a/uniqn-mobile/src/components/weeklyGrid/__tests__/VenueSelector.test.tsx
+++ b/uniqn-mobile/src/components/weeklyGrid/__tests__/VenueSelector.test.tsx
@@ -8,7 +8,7 @@ import { render, fireEvent } from '@testing-library/react-native';
 import React from 'react';
 import { VenueSelector } from '../VenueSelector';
 
-const NOOP = () => {};
+const NOOP = jest.fn();
 
 function renderSelector(overrides: Partial<React.ComponentProps<typeof VenueSelector>> = {}) {
   return render(
@@ -27,6 +27,16 @@ function renderSelector(overrides: Partial<React.ComponentProps<typeof VenueSele
 it('운영처 0개에서도 onAddVenue 제공 시 추가 버튼 노출 + 콜백 호출', () => {
   const onAddVenue = jest.fn();
   const { getByLabelText } = renderSelector({ onAddVenue });
+  fireEvent.press(getByLabelText('운영처 추가'));
+  expect(onAddVenue).toHaveBeenCalledTimes(1);
+});
+
+it('운영처 N개(칩 노출)에서도 onAddVenue 제공 시 추가 버튼 노출 + 콜백 호출', () => {
+  const onAddVenue = jest.fn();
+  const { getByLabelText } = renderSelector({
+    containers: [{ id: 'v1', name: '강남 홀덤펍' } as never],
+    onAddVenue,
+  });
   fireEvent.press(getByLabelText('운영처 추가'));
   expect(onAddVenue).toHaveBeenCalledTimes(1);
 });

--- a/uniqn-mobile/src/components/weeklyGrid/__tests__/VenueSelector.test.tsx
+++ b/uniqn-mobile/src/components/weeklyGrid/__tests__/VenueSelector.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * VenueSelector — "+ 운영처 추가" 진입점 테스트
+ *
+ * onAddVenue 제공 시 운영처 0개/N개 모두에서 "운영처 추가" 버튼이 노출되고
+ * 누르면 콜백이 호출되는지 검증(순수 표현 컴포넌트).
+ */
+import { render, fireEvent } from '@testing-library/react-native';
+import React from 'react';
+import { VenueSelector } from '../VenueSelector';
+
+const NOOP = () => {};
+
+function renderSelector(overrides: Partial<React.ComponentProps<typeof VenueSelector>> = {}) {
+  return render(
+    <VenueSelector
+      workspaces={[{ id: 'ws-1', name: '워크스페이스' } as never]}
+      activeWorkspaceId="ws-1"
+      onSelectWorkspace={NOOP}
+      containers={[]}
+      selectedVenueId={null}
+      onSelectVenue={NOOP}
+      {...overrides}
+    />
+  );
+}
+
+it('운영처 0개에서도 onAddVenue 제공 시 추가 버튼 노출 + 콜백 호출', () => {
+  const onAddVenue = jest.fn();
+  const { getByLabelText } = renderSelector({ onAddVenue });
+  fireEvent.press(getByLabelText('운영처 추가'));
+  expect(onAddVenue).toHaveBeenCalledTimes(1);
+});
+
+it('onAddVenue 미제공 시 추가 버튼 미노출', () => {
+  const { queryByLabelText } = renderSelector();
+  expect(queryByLabelText('운영처 추가')).toBeNull();
+});

--- a/uniqn-mobile/src/components/weeklyGrid/index.ts
+++ b/uniqn-mobile/src/components/weeklyGrid/index.ts
@@ -10,4 +10,4 @@ export { buildVenueDayGroup, mapVenueDaySlotToConfirmedStaff } from './venueDayD
 export { AddSlotSheet, type AddSlotSheetProps } from './AddSlotSheet';
 export { buildAddSlotPayload, type BuildAddSlotPayloadParams } from './addSlotPayload';
 export { EditSlotSheet, type EditSlotSheetProps } from './EditSlotSheet';
-export { VenueCreateSheet } from './VenueCreateSheet';
+export { VenueCreateSheet, type VenueCreateSheetProps } from './VenueCreateSheet';

--- a/uniqn-mobile/src/components/weeklyGrid/index.ts
+++ b/uniqn-mobile/src/components/weeklyGrid/index.ts
@@ -10,3 +10,4 @@ export { buildVenueDayGroup, mapVenueDaySlotToConfirmedStaff } from './venueDayD
 export { AddSlotSheet, type AddSlotSheetProps } from './AddSlotSheet';
 export { buildAddSlotPayload, type BuildAddSlotPayloadParams } from './addSlotPayload';
 export { EditSlotSheet, type EditSlotSheetProps } from './EditSlotSheet';
+export { VenueCreateSheet } from './VenueCreateSheet';

--- a/uniqn-mobile/src/hooks/weeklyGrid/__tests__/useCreateVenueContainer.test.tsx
+++ b/uniqn-mobile/src/hooks/weeklyGrid/__tests__/useCreateVenueContainer.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * useCreateVenueContainer — 운영처 컨테이너 생성 변이 훅 테스트
+ *
+ * (1) 이름을 kind='dated' 로 레포 getOrCreateVenueContainer 에 위임,
+ * (2) 성공 시 weeklyGrid 쿼리 일괄 invalidate, (3) workspaceId 부재 시 레포 미호출+에러.
+ * 토스트는 호출부 책임이라 훅에서 검증하지 않는다(mutation only).
+ */
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/queryClient';
+import { jobPostingRepository } from '@/repositories';
+import { useCreateVenueContainer } from '../useCreateVenueContainer';
+
+jest.mock('@tanstack/react-query', () => jest.requireActual('@tanstack/react-query'));
+
+jest.mock('@/repositories', () => ({
+  jobPostingRepository: { getOrCreateVenueContainer: jest.fn() },
+}));
+
+// gridWriteService 가 모듈 로드 시 import 하는 sibling 레포 — 실제 supabase 체인 로드 회피용 스텁.
+jest.mock('@/repositories/weeklyGrid', () => ({ weeklyGridRepository: {} }));
+
+const mockCreate = jobPostingRepository.getOrCreateVenueContainer as jest.Mock;
+
+const FAKE_VENUE = {
+  id: 'venue-1',
+  name: '강남 홀덤펍',
+  workspaceId: 'ws-1',
+  ownerId: 'owner-1',
+  venueId: 'venue-1',
+  kind: 'dated',
+  softTargets: {},
+};
+
+function createClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function createWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useCreateVenueContainer', () => {
+  beforeEach(() => mockCreate.mockReset());
+
+  it('이름을 kind=dated 로 레포에 위임', async () => {
+    mockCreate.mockResolvedValueOnce(FAKE_VENUE);
+    const client = createClient();
+    const { result } = renderHook(() => useCreateVenueContainer('ws-1'), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync('강남 홀덤펍');
+    });
+
+    expect(mockCreate).toHaveBeenCalledWith('ws-1', { name: '강남 홀덤펍', kind: 'dated' });
+  });
+
+  it('성공 시 weeklyGrid 관련 쿼리를 일괄 invalidate', async () => {
+    mockCreate.mockResolvedValueOnce(FAKE_VENUE);
+    const client = createClient();
+    const invalidateSpy = jest.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useCreateVenueContainer('ws-1'), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync('강남 홀덤펍');
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.weeklyGrid.all });
+  });
+
+  it('workspaceId 부재 시 레포 미호출 + 에러', async () => {
+    const client = createClient();
+    const { result } = renderHook(() => useCreateVenueContainer(undefined), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync('강남 홀덤펍').catch(() => {});
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});

--- a/uniqn-mobile/src/hooks/weeklyGrid/__tests__/useCreateVenueContainer.test.tsx
+++ b/uniqn-mobile/src/hooks/weeklyGrid/__tests__/useCreateVenueContainer.test.tsx
@@ -18,6 +18,8 @@ jest.mock('@tanstack/react-query', () => jest.requireActual('@tanstack/react-que
 
 jest.mock('@/repositories', () => ({
   jobPostingRepository: { getOrCreateVenueContainer: jest.fn() },
+  // gridWriteService 가 같은 배럴에서 import 하는 workLogRepository 스텁(updateSlot 미사용이나 방어).
+  workLogRepository: {},
 }));
 
 // gridWriteService 가 모듈 로드 시 import 하는 sibling 레포 — 실제 supabase 체인 로드 회피용 스텁.

--- a/uniqn-mobile/src/hooks/weeklyGrid/__tests__/useCreateVenueContainer.test.tsx
+++ b/uniqn-mobile/src/hooks/weeklyGrid/__tests__/useCreateVenueContainer.test.tsx
@@ -3,6 +3,7 @@
  *
  * (1) 이름을 kind='dated' 로 레포 getOrCreateVenueContainer 에 위임,
  * (2) 성공 시 weeklyGrid 쿼리 일괄 invalidate, (3) workspaceId 부재 시 레포 미호출+에러.
+ * (4) 성공 시 컨테이너 목록 캐시에 낙관적 시드(N→N+1 자동선택 바운스 방지).
  * 토스트는 호출부 책임이라 훅에서 검증하지 않는다(mutation only).
  */
 import { renderHook, waitFor, act } from '@testing-library/react-native';
@@ -10,6 +11,7 @@ import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/queryClient';
 import { jobPostingRepository } from '@/repositories';
+import type { VenueContainer } from '@/domains/weeklyGrid';
 import { useCreateVenueContainer } from '../useCreateVenueContainer';
 
 jest.mock('@tanstack/react-query', () => jest.requireActual('@tanstack/react-query'));
@@ -23,12 +25,34 @@ jest.mock('@/repositories/weeklyGrid', () => ({ weeklyGridRepository: {} }));
 
 const mockCreate = jobPostingRepository.getOrCreateVenueContainer as jest.Mock;
 
-const FAKE_VENUE = {
+const FAKE_VENUE: VenueContainer = {
   id: 'venue-1',
   name: '강남 홀덤펍',
   workspaceId: 'ws-1',
   ownerId: 'owner-1',
   venueId: 'venue-1',
+  kind: 'dated',
+  softTargets: {},
+};
+
+/** 낙관적 시드 시나리오: 이미 캐시에 있는 기존 컨테이너 */
+const EXISTING_VENUE: VenueContainer = {
+  id: 'venue-existing',
+  name: '기존 홀덤펍',
+  workspaceId: 'ws-1',
+  ownerId: null,
+  venueId: 'venue-existing',
+  kind: 'dated',
+  softTargets: {},
+};
+
+/** 낙관적 시드 시나리오: 신규 생성되는 컨테이너 */
+const NEW_VENUE: VenueContainer = {
+  id: 'venue-new',
+  name: '신규 홀덤펍',
+  workspaceId: 'ws-1',
+  ownerId: null,
+  venueId: 'venue-new',
   kind: 'dated',
   softTargets: {},
 };
@@ -90,5 +114,51 @@ describe('useCreateVenueContainer', () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('성공 시 기존 컨테이너 목록에 새 컨테이너를 낙관적으로 시드 (N→N+1 자동선택 유지)', async () => {
+    // RED 전제: 훅 onSuccess 가 setQueryData 낙관적 시드를 하지 않으면
+    // invalidate 는 비동기라 동기 시점엔 NEW_VENUE 가 캐시에 없어 이 테스트가 실패한다.
+    mockCreate.mockResolvedValueOnce(NEW_VENUE);
+    const client = createClient();
+    // 기존 컨테이너 1개 사전 시드 (N≥1 시나리오)
+    client.setQueryData(queryKeys.weeklyGrid.containers('ws-1'), [EXISTING_VENUE]);
+
+    const { result } = renderHook(() => useCreateVenueContainer('ws-1'), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync('신규 홀덤펍');
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cached = client.getQueryData<VenueContainer[]>(queryKeys.weeklyGrid.containers('ws-1'));
+    // 기존 + 신규 둘 다 존재해야 화면의 자기-치유 effect 가 신규 선택을 유지할 수 있다.
+    expect(cached?.some((c) => c.id === NEW_VENUE.id)).toBe(true);
+    expect(cached?.some((c) => c.id === EXISTING_VENUE.id)).toBe(true);
+    expect(cached?.length).toBe(2);
+  });
+
+  it('낙관적 시드 멱등: 새 컨테이너가 이미 캐시에 있으면 중복 추가 안함', async () => {
+    mockCreate.mockResolvedValueOnce(NEW_VENUE);
+    const client = createClient();
+    // 이미 NEW_VENUE 가 캐시에 있는 상태(예: 다른 경로로 미리 채워진 경우)
+    client.setQueryData(queryKeys.weeklyGrid.containers('ws-1'), [EXISTING_VENUE, NEW_VENUE]);
+
+    const { result } = renderHook(() => useCreateVenueContainer('ws-1'), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync('신규 홀덤펍');
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cached = client.getQueryData<VenueContainer[]>(queryKeys.weeklyGrid.containers('ws-1'));
+    // 중복 추가 없이 길이 유지
+    expect(cached?.length).toBe(2);
   });
 });

--- a/uniqn-mobile/src/hooks/weeklyGrid/index.ts
+++ b/uniqn-mobile/src/hooks/weeklyGrid/index.ts
@@ -11,3 +11,4 @@ export {
   useNotifyWeeklyBatchConfirm,
   type NotifyWeeklyBatchConfirmVars,
 } from './useNotifyWeeklyBatchConfirm';
+export { useCreateVenueContainer } from './useCreateVenueContainer';

--- a/uniqn-mobile/src/hooks/weeklyGrid/useCreateVenueContainer.ts
+++ b/uniqn-mobile/src/hooks/weeklyGrid/useCreateVenueContainer.ts
@@ -1,0 +1,29 @@
+/**
+ * useCreateVenueContainer — 운영처 컨테이너 생성 변이 훅(TanStack useMutation).
+ *
+ * mutationFn 은 Service(gridWriteService.createVenueContainer) 경유(아키텍처 Hook→Service→Repository).
+ * 이름 XSS 검증(S1)·워크스페이스 권한 게이트·get-or-create 멱등은 레포/RPC 경계가 담당.
+ * onSuccess: weeklyGrid prefix 일괄 invalidate → useVenueContainers(목록) 재조회.
+ * 토스트/낙관 UI 는 호출부 책임(훅은 변이만). workspaceId 부재 시 변이는 거부(레포 미호출).
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/queryClient';
+import { createVenueContainer } from '@/services/weeklyGrid/gridWriteService';
+
+export function useCreateVenueContainer(workspaceId: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (name: string) => {
+      if (!workspaceId) {
+        return Promise.reject(new Error('WORKSPACE_REQUIRED'));
+      }
+      return createVenueContainer(workspaceId, name);
+    },
+    onSuccess: () => {
+      // summary/containers/daySlots 공통 prefix 무효화(queryKey 일관) → 컨테이너 목록 재조회.
+      qc.invalidateQueries({ queryKey: queryKeys.weeklyGrid.all });
+    },
+  });
+}
+
+export default useCreateVenueContainer;

--- a/uniqn-mobile/src/hooks/weeklyGrid/useCreateVenueContainer.ts
+++ b/uniqn-mobile/src/hooks/weeklyGrid/useCreateVenueContainer.ts
@@ -3,12 +3,16 @@
  *
  * mutationFn 은 Service(gridWriteService.createVenueContainer) 경유(아키텍처 Hook→Service→Repository).
  * 이름 XSS 검증(S1)·워크스페이스 권한 게이트·get-or-create 멱등은 레포/RPC 경계가 담당.
- * onSuccess: weeklyGrid prefix 일괄 invalidate → useVenueContainers(목록) 재조회.
+ * onSuccess: 컨테이너 목록 캐시에 낙관적 시드 → weeklyGrid prefix 일괄 invalidate.
+ *   낙관적 시드 이유: invalidate 는 비동기 리페치라 동기 렌더 시점엔 새 컨테이너가 목록에 없다.
+ *   화면의 자기-치유 useEffect(deps [containers, selectedVenueId]) 가 새 id 를 "유효한 항목"으로
+ *   인식해 선택을 유지하려면, setQueryData 로 즉시 반영해야 N→N+1 자동선택 바운스가 사라진다.
  * 토스트/낙관 UI 는 호출부 책임(훅은 변이만). workspaceId 부재 시 변이는 거부(레포 미호출).
  */
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/queryClient';
 import { createVenueContainer } from '@/services/weeklyGrid/gridWriteService';
+import type { VenueContainer } from '@/domains/weeklyGrid';
 
 export function useCreateVenueContainer(workspaceId: string | undefined) {
   const qc = useQueryClient();
@@ -19,7 +23,15 @@ export function useCreateVenueContainer(workspaceId: string | undefined) {
       }
       return createVenueContainer(workspaceId, name);
     },
-    onSuccess: () => {
+    onSuccess: (container) => {
+      // 낙관적 캐시 시드: 비동기 refetch 전에 새 컨테이너를 목록에 즉시 반영해,
+      // 화면의 selectedVenueId 자기-치유 effect 가 새 운영처를 유효하게 보고 선택을 유지하도록 한다.
+      // 멱등: 이미 목록에 있으면 추가하지 않는다(get-or-create 재호출 대비).
+      if (workspaceId) {
+        qc.setQueryData<VenueContainer[]>(queryKeys.weeklyGrid.containers(workspaceId), (old) =>
+          old?.some((c) => c.id === container.id) ? old : [...(old ?? []), container]
+        );
+      }
       // summary/containers/daySlots 공통 prefix 무효화(queryKey 일관) → 컨테이너 목록 재조회.
       qc.invalidateQueries({ queryKey: queryKeys.weeklyGrid.all });
     },

--- a/uniqn-mobile/src/services/weeklyGrid/gridWriteService.ts
+++ b/uniqn-mobile/src/services/weeklyGrid/gridWriteService.ts
@@ -7,7 +7,8 @@
  * 날짜 정규화(E5)·색상 화이트리스트·메모 XSS 검증은 RPC/레포 경계가 담당(여기서 중복하지 않는다).
  */
 import { weeklyGridRepository } from '@/repositories/weeklyGrid';
-import { workLogRepository, type UpdateSlotInput } from '@/repositories';
+import { workLogRepository, jobPostingRepository, type UpdateSlotInput } from '@/repositories';
+import type { VenueContainer } from '@/domains/weeklyGrid';
 
 /** 운영처 날짜별 목표인원(soft-target) 저장. 날짜 정규화(E5)·권한은 RPC(레포 경계)가 담당. */
 export function setVenueSoftTarget(venueId: string, date: string, count: number): Promise<void> {
@@ -17,4 +18,12 @@ export function setVenueSoftTarget(venueId: string, date: string, count: number)
 /** 배치 슬롯 편집(시간·역할·색상·메모). 색상 화이트리스트·메모 XSS 검증은 레포 경계가 담당. */
 export function updateSlot(workLogId: string, input: UpdateSlotInput): Promise<void> {
   return workLogRepository.updateSlot(workLogId, input);
+}
+
+/**
+ * 운영처 컨테이너 생성(get-or-create, 멱등). 이름 XSS 검증(S1)·워크스페이스 권한 게이트는
+ * 레포/RPC 경계가 담당. v1 은 kind='dated' 고정(날짜 기반 그리드 전제).
+ */
+export function createVenueContainer(workspaceId: string, name: string): Promise<VenueContainer> {
+  return jobPostingRepository.getOrCreateVenueContainer(workspaceId, { name, kind: 'dated' });
 }


### PR DESCRIPTION
## 배경 — QA가 적발한 출하 차단 결함

주간 배치 그리드(#219, 플래그 `weekly_grid_enabled` OFF) QA 중 **운영처(venue) 생성 UI가 앱에 없음**을 발견했습니다. 운영처가 0개인 새 워크스페이스(=실제 운영자 첫 상태)에서 그리드 빈 상태는 "운영처를 먼저 만들어주세요"라고 안내하지만, **만들 수 있는 버튼·입력·경로가 어디에도 없어** 기능 전체가 막다른 길이었습니다.

백엔드는 완성돼 있었습니다 — 생성 RPC `get_or_create_venue_container`(SECDEF + 워크스페이스 게이트 + ON CONFLICT 멱등)와 repository `getOrCreateVenueContainer`(이름 XSS 검증 포함)는 이미 있었으나 **이를 호출하는 UI 배선만 누락**됐습니다.

## 변경 — UI 배선만 추가 (v1: 생성만, 이름만, kind='dated')

| 파일 | 역할 |
|------|------|
| `hooks/weeklyGrid/useCreateVenueContainer.ts` | 생성 변이 훅(mutation-only). onSuccess: 컨테이너 목록 캐시 낙관적 시드 → `weeklyGrid.all` invalidate |
| `services/weeklyGrid/gridWriteService.ts` | `createVenueContainer` — Hook→Service→Repository 경계 |
| `components/weeklyGrid/VenueCreateSheet.tsx` | 이름 입력 `SheetModal`. 성공 시 `onCreated` + 토스트 |
| `components/weeklyGrid/VenueSelector.tsx` | "+ 운영처 추가" 진입점(`onAddVenue`, 항상 노출) |
| `app/(employer)/weekly-grid.tsx` | 빈 상태 버튼 / 선택기 "+ 추가" 두 진입점 → 동일 시트, 생성 후 새 운영처 자동 선택 |

아키텍처 준수: 쓰기 변이는 `gridWriteService`(Service) 경유(Repository 직접호출 금지). 이름 XSS 검증·권한 게이트·멱등은 레포/RPC 경계가 담당(클라 중복 없음).

## 개발 방식 — SDD(Subagent-Driven) + 다중 리뷰

- 설계(brainstorming) → 스펙 → 계획(writing-plans) → TDD 4태스크(태스크별 신규 구현 subagent + 태스크 리뷰 게이트).
- **전체 브랜치 적대 리뷰(opus)** 가 태스크별 게이트가 볼 수 없던 교차 결함 1건 적발·수정: **N→N+1 자동선택 바운스** — 운영처가 이미 있는 워크스페이스에서 새 운영처 생성 시, 비동기 refetch 전 화면의 self-heal effect가 새 id를 무효로 보고 첫 기존 운영처로 선택이 튕기던 버그. 훅 `onSuccess`에서 `setQueryData`로 컨테이너 목록을 동기 시드해 해소(회귀 테스트 추가).
- `/review` 구조적 critical pass(SQL/레이스/enum 완전성) 통과 — 신규 Critical/Important 없음.

## 테스트 플랜

- [x] `npm run quality` EXIT 0 (tsc strict · eslint 0 errors · prettier clean)
- [x] `jest weeklyGrid` 18 스위트 / 133 통과 (신규: 훅 3+회귀+시드, 시트 4 콜백경로, 선택기 3)
- [ ] **수동 QA(플래그 ON 후, BLOCKING)**: 0-venue 워크스페이스 → 빈 상태 "운영처 만들기" / 선택기 "+ 운영처 추가" → 이름 입력 → 만들기 → 새 운영처 자동 선택 + 그리드 진입. 다수 운영처(N→N+1)에서 새 운영처 선택 유지. 같은 이름 재생성 시 중복 없음(멱등). 빈 이름 제출 비활성. 다크모드 색상 정상.

## 배포 노트

- **JS만 변경**(네이티브 무변경) → 신규 RPC·마이그 **없음**(이미 적용됨). 추가 PROD 마이그 불필요.
- 이 UI가 머지된 뒤에야 `weekly_grid_enabled` ON 검토 가능(이 결함이 ON 차단 사유였음).

## 범위 밖 (후속)

운영처 이름변경/삭제, kind 토글(상시/대회), 대회 기간(period) 입력.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
